### PR TITLE
Feat: Throw Exception when reading not qbeast formatted data.

### DIFF
--- a/src/main/scala/io/qbeast/spark/sql/sources/QbeastDataSource.scala
+++ b/src/main/scala/io/qbeast/spark/sql/sources/QbeastDataSource.scala
@@ -91,7 +91,11 @@ class QbeastDataSource private[sources] (private val tableFactory: IndexedTableF
       parameters: Map[String, String]): BaseRelation = {
     val path = getPath(parameters)
     val table = tableFactory.getIndexedTable(sqlContext, path)
-    table.load()
+    if (table.exists) {
+      table.load()
+    } else {
+      throw AnalysisExceptionFactory.create(s"'$path' is not a Qbeast formatted data directory.")
+    }
   }
 
   private def getPath(parameters: Map[String, String]): String = {


### PR DESCRIPTION
This PR resolves #13.
After calling `tableFactory.getIndexedTable()` we must check if the table really exists:
https://github.com/Qbeast-io/qbeast-spark/blob/4f37b584065f99b48e848eeaaa6304bc92223feb/src/main/scala/io/qbeast/spark/table/IndexedTable.scala#L85-L86