### PR TITLE
19 delta log should use relative paths instead of absolute

### DIFF
--- a/src/main/scala/io/qbeast/spark/sql/qbeast/BlockWriter.scala
+++ b/src/main/scala/io/qbeast/spark/sql/qbeast/BlockWriter.scala
@@ -5,15 +5,7 @@ package io.qbeast.spark.sql.qbeast
 
 import io.qbeast.spark.index.{ColumnsToIndex, CubeId, QbeastColumns, Weight}
 import io.qbeast.spark.model.SpaceRevision
-import io.qbeast.spark.sql.utils.TagUtils.{
-  cubeTag,
-  elementCountTag,
-  indexedColsTag,
-  spaceTag,
-  stateTag,
-  weightMaxTag,
-  weightMinTag
-}
+import io.qbeast.spark.sql.utils.TagUtils._
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.{JobConf, TaskAttemptContextImpl, TaskAttemptID}
 import org.apache.hadoop.mapreduce.TaskType
@@ -28,17 +20,18 @@ import java.util.UUID
 
 /**
  * BlockWriter is in charge of writing the qbeast data into files
- * @param dataPath path of the table
- * @param schema schema of the original data
- * @param schemaIndex schema with qbeast metadata columns
- * @param factory output writer factory
- * @param serConf configuration to serialize the data
- * @param qbeastColumns qbeast metadata columns
+ *
+ * @param dataPath       path of the table
+ * @param schema         schema of the original data
+ * @param schemaIndex    schema with qbeast metadata columns
+ * @param factory        output writer factory
+ * @param serConf        configuration to serialize the data
+ * @param qbeastColumns  qbeast metadata columns
  * @param columnsToIndex columns of the original data that are used for indexing
- * @param spaceRevision space revision of the data to write
+ * @param spaceRevision  space revision of the data to write
  */
 case class BlockWriter(
-    dataPath: Path,
+    dataPath: String,
     schema: StructType,
     schemaIndex: StructType,
     factory: OutputWriterFactory,
@@ -52,6 +45,7 @@ case class BlockWriter(
 
   /**
    * Writes rows in corresponding files
+   *
    * @param iter iterator of rows
    * @return the sequence of files added
    */

--- a/src/main/scala/io/qbeast/spark/sql/qbeast/BlockWriter.scala
+++ b/src/main/scala/io/qbeast/spark/sql/qbeast/BlockWriter.scala
@@ -38,7 +38,7 @@ import java.util.UUID
  * @param spaceRevision space revision of the data to write
  */
 case class BlockWriter(
-    dataPath: String,
+    dataPath: Path,
     schema: StructType,
     schemaIndex: StructType,
     factory: OutputWriterFactory,
@@ -108,7 +108,7 @@ case class BlockWriter(
 
           Iterator(
             AddFile(
-              path = path.toString,
+              path = path.getName(),
               partitionValues = Map(),
               size = fileStatus.getLen,
               modificationTime = fileStatus.getModificationTime,

--- a/src/main/scala/io/qbeast/spark/sql/qbeast/QbeastOptimizer.scala
+++ b/src/main/scala/io/qbeast/spark/sql/qbeast/QbeastOptimizer.scala
@@ -12,6 +12,7 @@ import io.qbeast.spark.index.{CubeId, OTreeAlgorithm}
 import io.qbeast.spark.model.SpaceRevision
 import io.qbeast.spark.sql.utils.State.REPLICATED
 import io.qbeast.spark.sql.utils.TagUtils.{cubeTag, stateTag}
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction}
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.functions.lit
@@ -23,10 +24,10 @@ import scala.collection.JavaConverters._
 /**
  * QbeastOptimizer is in charge of optimizing the index
  *
- * @param deltaLog deltaLog of the index
- * @param deltaOptions deltaOptions for writing on the index
+ * @param deltaLog       deltaLog of the index
+ * @param deltaOptions   deltaOptions for writing on the index
  * @param qbeastSnapshot current snapshot of the OTree
- * @param spaceRevision index revision to optimize
+ * @param spaceRevision  index revision to optimize
  * @param oTreeAlgorithm algorithm to replicate data
  */
 class QbeastOptimizer(
@@ -39,8 +40,8 @@ class QbeastOptimizer(
   /**
    * Updates the current set of replicated cubes
    *
-   * @param sparkSession SparkSession for reading/writing
-   * @param transaction number of trasaction to save
+   * @param sparkSession       SparkSession for reading/writing
+   * @param transaction        number of trasaction to save
    * @param newReplicatedCubes set of replicated cubes to add
    */
   def updateReplicatedSet(
@@ -72,7 +73,7 @@ class QbeastOptimizer(
   /**
    * Performs the optimization
    *
-   * @param sparkSession SparkSession
+   * @param sparkSession   SparkSession
    * @param announcedCubes Set of cube paths announced
    * @return the set of cubes that completed the operation along with the file actions to commit
    */
@@ -92,6 +93,7 @@ class QbeastOptimizer(
     val cubesToReplicate =
       cubesToOptimize.diff(replicatedSet)
 
+    val dataPath = qbeastSnapshot.snapshot.path.getParent
     val (dataToReplicate, updatedActions) = qbeastSnapshot
       .getCubeBlocks(cubesToReplicate, spaceRevision)
       .groupBy(_.tags(cubeTag))
@@ -99,7 +101,7 @@ class QbeastOptimizer(
         val cubeId = CubeId(dimensionCount, cube)
         val data = sparkSession.read
           .format("parquet")
-          .load(blocks.map(_.path): _*)
+          .load(blocks.map(f => new Path(dataPath, f.path).toString): _*)
           .withColumn(cubeToReplicateColumnName, lit(cubeId.bytes))
 
         val newAddFiles = blocks

--- a/src/main/scala/io/qbeast/spark/sql/qbeast/QbeastWriter.scala
+++ b/src/main/scala/io/qbeast/spark/sql/qbeast/QbeastWriter.scala
@@ -155,7 +155,7 @@ case class QbeastWriter(
 
     val blockWriter =
       BlockWriter(
-        dataPath = deltaLog.dataPath.toString,
+        dataPath = deltaLog.dataPath,
         schema = data.schema,
         schemaIndex = qbeastData.schema,
         factory = factory,

--- a/src/main/scala/io/qbeast/spark/sql/qbeast/QbeastWriter.scala
+++ b/src/main/scala/io/qbeast/spark/sql/qbeast/QbeastWriter.scala
@@ -155,7 +155,7 @@ case class QbeastWriter(
 
     val blockWriter =
       BlockWriter(
-        dataPath = deltaLog.dataPath,
+        dataPath = deltaLog.dataPath.toString,
         schema = data.schema,
         schemaIndex = qbeastData.schema,
         factory = factory,

--- a/src/test/scala/io/qbeast/spark/utils/BlockWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/BlockWriterTest.scala
@@ -4,13 +4,12 @@
 package io.qbeast.spark.utils
 
 import io.qbeast.spark.QbeastIntegrationTestSpec
+import io.qbeast.spark.index.QbeastColumns._
 import io.qbeast.spark.index.{CubeId, QbeastColumns, Weight}
 import io.qbeast.spark.model.{LinearTransformation, Point, SpaceRevision}
 import io.qbeast.spark.sql.qbeast.BlockWriter
-import io.qbeast.spark.index.QbeastColumns._
 import io.qbeast.spark.sql.utils.TagUtils.cubeTag
 import io.qbeast.spark.utils.BlockWriterTest.IndexData
-import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory
@@ -56,7 +55,7 @@ class BlockWriterTest extends AnyFlatSpec with Matchers with QbeastIntegrationTe
     val qbeastColumns = QbeastColumns(indexed)
     val (factory, serConf) = loadConf(data)
     val writer = BlockWriter(
-      dataPath = new Path(tmpDir),
+      dataPath = tmpDir,
       schema = data.schema,
       schemaIndex = indexed.schema,
       factory = factory,
@@ -98,7 +97,7 @@ class BlockWriterTest extends AnyFlatSpec with Matchers with QbeastIntegrationTe
     val qbeastColumns = QbeastColumns(indexed)
     val (factory, serConf) = loadConf(data)
     val writer = BlockWriter(
-      dataPath = new Path(tmpDir),
+      dataPath = tmpDir,
       schema = data.schema,
       schemaIndex = indexed.schema,
       factory = factory,

--- a/src/test/scala/io/qbeast/spark/utils/BlockWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/BlockWriterTest.scala
@@ -10,6 +10,7 @@ import io.qbeast.spark.sql.qbeast.BlockWriter
 import io.qbeast.spark.index.QbeastColumns._
 import io.qbeast.spark.sql.utils.TagUtils.cubeTag
 import io.qbeast.spark.utils.BlockWriterTest.IndexData
+import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory
@@ -55,7 +56,7 @@ class BlockWriterTest extends AnyFlatSpec with Matchers with QbeastIntegrationTe
     val qbeastColumns = QbeastColumns(indexed)
     val (factory, serConf) = loadConf(data)
     val writer = BlockWriter(
-      dataPath = tmpDir,
+      dataPath = new Path(tmpDir),
       schema = data.schema,
       schemaIndex = indexed.schema,
       factory = factory,
@@ -97,7 +98,7 @@ class BlockWriterTest extends AnyFlatSpec with Matchers with QbeastIntegrationTe
     val qbeastColumns = QbeastColumns(indexed)
     val (factory, serConf) = loadConf(data)
     val writer = BlockWriter(
-      dataPath = tmpDir,
+      dataPath = new Path(tmpDir),
       schema = data.schema,
       schemaIndex = indexed.schema,
       factory = factory,

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSnapshotTest.scala
@@ -25,9 +25,9 @@ class QbeastSnapshotTest
 
     val rdd =
       spark.sparkContext.parallelize(
-        Seq(Client3(size * size, s"student-$size", 20 + 1, 1000 + 123 + 1, 2567.3432143 + 1)) ++
+        Seq(Client3(size * size, s"student-$size", 20, 1000 + 123, 2567.3432143)) ++
           1.until(size)
-            .map(i => Client3(i * i, s"student-$i", 20, 1000 + 123, 2567.3432143)))
+            .map(i => Client3(i * i, s"student-$i", 20 + i, 1000 + 123 + i, 2567.3432143 + i)))
 
     assert(rdd.count() == size)
     spark.createDataFrame(rdd)


### PR DESCRIPTION
This PR makes the BlockWriter to use relative names for the data files.

In addition it also changes QbeastSnapshotTest, because it was failing on my machine due to rounding errors while merging the weight estimations of the partitions.