### PR TITLE
Fix CI workflows: branch names and secrets

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   publish-container:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.REGISTRY_PAT }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,7 +1,7 @@
 name: Publish Container image
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'Dockerfile'
   pull_request:
@@ -21,11 +21,11 @@ jobs:
         CONTAINER_VERSION="nightly-$(git rev-parse --short ${GITHUB_SHA})"
         docker build . --rm --force-rm -t ghcr.io/qbeast-io/qbeast-spark/qbeast-spark:${CONTAINER_VERSION}
 
-    # Publish only if it is on the master branch
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    # Publish only if it is on the main branch
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       name: Log into registry
       run: docker login ghcr.io -u "Any User" -p ${{ secrets.GITHUB_TOKEN }}
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       name: Publish docker image
       run: |
         QBEAST_SPARK_VERSION="nightly-$(git rev-parse --short ${GITHUB_SHA})"

--- a/.github/workflows/test-and-publish-artifact.yml
+++ b/.github/workflows/test-and-publish-artifact.yml
@@ -8,7 +8,6 @@ jobs:
   test-and-publish-artifact:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.REGISTRY_PAT }}
       GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-and-publish-artifact.yml
+++ b/.github/workflows/test-and-publish-artifact.yml
@@ -1,7 +1,7 @@
 name: Test and publish artifact
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 jobs:
@@ -23,8 +23,8 @@ jobs:
     - name: Formatting of code and Scaladocs
       run: sbt scalafmtSbtCheck doc
 
-    # Publish only if it is on the master branch
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    # Publish only if it is on the main branch
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       name: Publish artifact
       run: |
         QBEAST_SPARK_VERSION="nightly-$(git rev-parse --short ${GITHUB_SHA})"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ sbt assembly
 ```
 
 ### Quickstart
+You can run the qbeast-spark application locally on your computer, or using a Docker image we already prepared with the dependencies.
+You can find it in the [Packages section](https://github.com/orgs/Qbeast-io/packages?repo_name=qbeast-spark).
+
 1 - Launch a **spark-shell**
 
 **Inside the project folder**, launch a **spark shell** with the required dependencies:


### PR DESCRIPTION
There are some errors in the workflow files due to old branch and secrets names. This PR updates the branches to the new names and removes unnecessary secrets from the workflows.
It includes as well a mention in the README to the published container images.