### PR TITLE
Match error on filtering string indexed columns

### DIFF
--- a/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
@@ -119,7 +119,6 @@ trait QbeastIntegrationTestSpec extends AnyFlatSpec with Matchers with DatasetCo
    * instance is used to customize the QbeastContext.
    *
    * @param keeper the keeper
-   * @param config the configuration
    * @param testCode the test code
    * @tparam T the test result type
    * @return the test result
@@ -143,7 +142,7 @@ trait QbeastIntegrationTestSpec extends AnyFlatSpec with Matchers with DatasetCo
   }
 
   def withQbeastContextSparkAndTmpDir[T](testCode: (SparkSession, String) => T): T =
-    withTmpDir(tmpDir => withSpark(spark => withQbeastContext()(testCode(spark, tmpDir))))
+    withQbeastContext()(withTmpDir(tmpDir => withSpark(spark => testCode(spark, tmpDir))))
 
   def withOTreeAlgorithm[T](code: IndexManager[DataFrame] => T): T = {
     code(SparkOTreeManager)

--- a/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
@@ -119,6 +119,7 @@ trait QbeastIntegrationTestSpec extends AnyFlatSpec with Matchers with DatasetCo
    * instance is used to customize the QbeastContext.
    *
    * @param keeper the keeper
+   * @param config the configuration
    * @param testCode the test code
    * @tparam T the test result type
    * @return the test result
@@ -142,7 +143,7 @@ trait QbeastIntegrationTestSpec extends AnyFlatSpec with Matchers with DatasetCo
   }
 
   def withQbeastContextSparkAndTmpDir[T](testCode: (SparkSession, String) => T): T =
-    withQbeastContext()(withTmpDir(tmpDir => withSpark(spark => testCode(spark, tmpDir))))
+    withTmpDir(tmpDir => withSpark(spark => withQbeastContext()(testCode(spark, tmpDir))))
 
   def withOTreeAlgorithm[T](code: IndexManager[DataFrame] => T): T = {
     code(SparkOTreeManager)

--- a/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
@@ -52,7 +52,7 @@ class QbeastFilterPushdownTest extends QbeastIntegrationTestSpec {
 
   "Qbeast" should
     "return a valid filtering of the original dataset " +
-    "for one column" in withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+    "for one column" in withSparkAndTmpDir { (spark, tmpDir) =>
       {
         val data = loadTestData(spark)
 
@@ -74,7 +74,7 @@ class QbeastFilterPushdownTest extends QbeastIntegrationTestSpec {
 
   it should
     "return a valid filtering of the original dataset " +
-    "for all columns indexed" in withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+    "for all columns indexed" in withSparkAndTmpDir { (spark, tmpDir) =>
       {
         val data = loadTestData(spark)
 
@@ -87,6 +87,34 @@ class QbeastFilterPushdownTest extends QbeastIntegrationTestSpec {
           filter_user_greaterThanOrEq,
           filter_product_lessThan,
           filter_product_greaterThanOrEq)
+        val filter = filters.mkString(" and ")
+        val qbeastQuery = df.filter(filter)
+        val normalQuery = data.filter(filter)
+
+        checkFileFiltering(qbeastQuery)
+        qbeastQuery.count() shouldBe normalQuery.count()
+        assertLargeDatasetEquality(qbeastQuery, normalQuery, orderedComparison = false)
+
+      }
+    }
+
+  it should
+    "return a valid filtering of the original dataset " +
+    "for all string columns" in withSparkAndTmpDir { (spark, tmpDir) =>
+      {
+        val data = loadTestData(spark)
+
+        writeTestData(data, Seq("user_id", "product_id"), 10000, tmpDir)
+
+        val df = spark.read.format("qbeast").load(tmpDir)
+        val filter_brand_greaterThanOrEq = "(`brand` >= 'a')"
+        val filter_brand_lessThan = "(`brand` < 'c')"
+
+        val filters = Seq(
+          filter_user_lessThan,
+          filter_user_greaterThanOrEq,
+          filter_brand_lessThan,
+          filter_brand_greaterThanOrEq)
         val filter = filters.mkString(" and ")
         val qbeastQuery = df.filter(filter)
         val normalQuery = data.filter(filter)

--- a/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
@@ -102,19 +102,14 @@ class QbeastFilterPushdownTest extends QbeastIntegrationTestSpec {
     "return a valid filtering of the original dataset " +
     "for all string columns" in withSparkAndTmpDir { (spark, tmpDir) =>
       {
-        val data = loadTestData(spark)
+        val data = loadTestData(spark).na.drop()
 
-        writeTestData(data, Seq("user_id", "product_id"), 10000, tmpDir)
+        writeTestData(data, Seq("brand", "product_id"), 10000, tmpDir)
 
         val df = spark.read.format("qbeast").load(tmpDir)
-        val filter_brand_greaterThanOrEq = "(`brand` >= 'a')"
-        val filter_brand_lessThan = "(`brand` < 'c')"
+        val filter_brand = "(`brand` == 'versace')"
 
-        val filters = Seq(
-          filter_user_lessThan,
-          filter_user_greaterThanOrEq,
-          filter_brand_lessThan,
-          filter_brand_greaterThanOrEq)
+        val filters = Seq(filter_user_lessThan, filter_user_greaterThanOrEq, filter_brand)
         val filter = filters.mkString(" and ")
         val qbeastQuery = df.filter(filter)
         val normalQuery = data.filter(filter)


### PR DESCRIPTION
In #58 we found a match error between spark `UTF8String` type and **core** types for transforming the column values. This affects only the query part, because is the only one that uses the spark unsafe types for parsing information. 

This PR solves the issue and adds tests that should fail on the `main` branch.  