### PR TITLE
Add check to publish only when repository is "Qbeast-io/qbeast-spark"

### DIFF
--- a/.github/workflows/test-and-publish-artifact.yml
+++ b/.github/workflows/test-and-publish-artifact.yml
@@ -25,7 +25,7 @@ jobs:
       run: sbt scalafmtSbtCheck doc
 
     # Publish only if it is on the main branch
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Qbeast-io/qbeast-spark' }}
       name: Publish artifact
       run: |
         QBEAST_SPARK_VERSION="nightly-$(git rev-parse --short ${GITHUB_SHA})"


### PR DESCRIPTION
Adding a simple check for the repository name to avoid running the `sbt publish` on the repository forks' CI. The syntax used is the one from [GitHub Actions Quickstart](https://docs.github.com/en/actions/quickstart).

Fixes #52