### PR TITLE
Implement data format versioning

### DIFF
--- a/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -49,17 +49,14 @@ private[delta] case class DeltaMetadataWriter(
    * TODO: create QbeastProtocol, which stores information about the versions for QbeastReaderVersion and
    * QbeastWriterVersion. This information will help to control data versioning.
    */
-  class QbeastProtocol(
-      minQbeastReaderVersion: Int = Action.readerVersion,
-      minQbeastWriterVersion: Int = Action.writerVersion)
+  private[delta] class QbeastProtocol(minQbReaderVersion: Int, minQbWriterVersion: Int)
       extends Protocol {
+    val minQbeastReaderVersion: Int = minQbReaderVersion
+    val minQbeastWriterVersion: Int = minQbWriterVersion
 
-    // Mock method
-    def show(): Unit = {
-      printf(
-        s"minQbeastReaderVersion: ${minQbeastReaderVersion}, " +
-          s"minQbeastWriterVersion: ${minQbeastWriterVersion}\n")
-    }
+    override def simpleString: String =
+      s"($minReaderVersion, $minWriterVersion, " +
+        s"$minQbeastReaderVersion, $minQbeastWriterVersion)"
 
   }
 

--- a/src/main/scala/io/qbeast/spark/index/writer/BlockWriter.scala
+++ b/src/main/scala/io/qbeast/spark/index/writer/BlockWriter.scala
@@ -5,7 +5,7 @@ package io.qbeast.spark.index.writer
 
 import io.qbeast.core.model.{CubeId, TableChanges, Weight}
 import io.qbeast.spark.index.QbeastColumns
-import io.qbeast.spark.utils.TagUtils
+import io.qbeast.spark.utils.{QbeastProtocol, TagUtils}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.{JobConf, TaskAttemptContextImpl, TaskAttemptID}
 import org.apache.hadoop.mapreduce.TaskType
@@ -91,7 +91,8 @@ case class BlockWriter(
             TagUtils.maxWeight -> maxWeight.value.toString,
             TagUtils.state -> state,
             TagUtils.revision -> revision.revisionID.toString,
-            TagUtils.elementCount -> rowCount.toString)
+            TagUtils.elementCount -> rowCount.toString,
+            TagUtils.protocolVersion -> QbeastProtocol.protocolVersion)
 
           writer.close()
 

--- a/src/main/scala/io/qbeast/spark/utils/Params.scala
+++ b/src/main/scala/io/qbeast/spark/utils/Params.scala
@@ -22,10 +22,21 @@ object TagUtils {
   final val state = "state"
   final val revision = "revision"
   final val elementCount = "elementCount"
+  final val protocolVersion = "protocolVersion"
 }
 
 object MetadataConfig {
   final val revision = "qbeast.revision"
   final val replicatedSet = "qbeast.replicatedSet"
   final val lastRevisionID = "qbeast.lastRevisionID"
+}
+
+/**
+ * Qbeast-spark metadata protocol versioning.
+ * This value is used to identify the version of the data format.
+ * Read more in https://github.com/Qbeast-io/qbeast-spark/issues/44
+ * TODO: Add reference to protocol versioning documentation
+ */
+object QbeastProtocol {
+  final val protocolVersion = "2"
 }

--- a/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
@@ -141,8 +141,9 @@ trait QbeastIntegrationTestSpec extends AnyFlatSpec with Matchers with DatasetCo
     }
   }
 
-  def withQbeastContextSparkAndTmpDir[T](testCode: (SparkSession, String) => T): T =
-    withQbeastContext()(withTmpDir(tmpDir => withSpark(spark => testCode(spark, tmpDir))))
+  def withQbeastContextSparkAndTmpDir[T](testCode: (SparkSession, String) => T): T = {
+    withSpark(spark => withQbeastContext()(withTmpDir(tmpDir => testCode(spark, tmpDir))))
+  }
 
   def withOTreeAlgorithm[T](code: IndexManager[DataFrame] => T): T = {
     code(SparkOTreeManager)


### PR DESCRIPTION
As noted in #44, we need to implement a data format versioning system. We can do this by specifying a Protocol Version, which will be an increasing number starting from 1, which will uniquely identify the file's metadata version.

To achieve this, I approached two different alternatives:
-  **Use DeltaLog's `protocol` tag** to store information about our protocol versioning. (**it did not work**, but I left the commits in this PR so you can get an idea of what I tried, in case you want to keep trying🙂).
> You can find information at [Action Reconciliation](https://github.com/delta-io/delta/blob/a5cbeb16e7cc1bef5d7371c88e391a681b313bfd/PROTOCOL.md#action-reconciliation) and [Protocol Evolution](https://github.com/delta-io/delta/blob/a5cbeb16e7cc1bef5d7371c88e391a681b313bfd/PROTOCOL.md#protocol-evolution) from Delta can help to understand the solution.
As mentioned in [this comment](https://github.com/Qbeast-io/qbeast-spark/issues/44#issuecomment-1005898584) I tried to modify their `protocol` tag, with no luck due to "Action Reconciliation" reading only the latest protocol tag.

- **Use AddFile metadata** to include a `protocolVersion` tag which specifies the protocol version for each file. This is the result for this PR, which includes the following tasks to be completed:
  - [x] Add the File Format Version in the Delta Log. Version should be an increasing number starting from 1, which will be the old protocol, being 2 the current protocol version.
  - [ ] Check if we are reading the right version when loading a new DataFrame. Throw an exception otherwise.
  - [ ] Update the docs, listing the versions and tagging the latest version of the code that can read it.

Related issues: 
- Fixes #44 
- Solves #53 