### PR TITLE
Avoid repeated reading of the DeltaLog

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
@@ -4,7 +4,6 @@ package io.qbeast.core.model
  * Container class for Qbeast file's metadata
  * @param path
  * @param revision
- * @param cube
  * @param minWeight
  * @param maxWeight
  * @param state
@@ -12,10 +11,10 @@ package io.qbeast.core.model
  * @param size
  * @param modificationTime
  */
+
 case class QbeastBlock(
     path: String,
     revision: Long,
-    cube: String,
     minWeight: Weight,
     maxWeight: Weight,
     state: String,
@@ -29,7 +28,7 @@ case class QbeastBlock(
 object QbeastBlock {
 
   private val metadataKeys =
-    Set("cube", "minWeight", "maxWeight", "state", "revision", "elementCount")
+    Set("minWeight", "maxWeight", "state", "revision", "elementCount")
 
   private def checkBlockMetadata(blockMetadata: Map[String, String]): Unit = {
     metadataKeys.foreach(key =>
@@ -56,7 +55,6 @@ object QbeastBlock {
     QbeastBlock(
       path,
       blockMetadata("revision").toLong,
-      blockMetadata("cube"),
       Weight(blockMetadata("minWeight").toInt),
       Weight(blockMetadata("maxWeight").toInt),
       blockMetadata("state"),

--- a/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
@@ -12,7 +12,7 @@ package io.qbeast.core.model
  * @param size
  * @param modificationTime
  */
-case class QbeastFile(
+case class QbeastBlock(
     path: String,
     revision: Long,
     cube: String,
@@ -24,43 +24,43 @@ case class QbeastFile(
     modificationTime: Long)
 
 /**
- * Companion object for QbeastFile
+ * Companion object for QbeastBlock
  */
-object QbeastFile {
+object QbeastBlock {
 
   private val metadataKeys =
     Set("cube", "minWeight", "maxWeight", "state", "revision", "elementCount")
 
-  private def checkFileMetadata(fileMetadata: Map[String, String]): Unit = {
+  private def checkBlockMetadata(blockMetadata: Map[String, String]): Unit = {
     metadataKeys.foreach(key =>
-      if (!fileMetadata.contains(key)) {
+      if (!blockMetadata.contains(key)) {
         throw new IllegalArgumentException(s"Missing metadata key $key")
       })
   }
 
   /**
-   * Creates a QbeastFile from a file path and metadata map
+   * Creates a QbeastBlock from a file path and metadata map
    * @param path
-   * @param fileMetadata
+   * @param blockMetadata
    * @param size
    * @param modificationTime
    * @return
    */
   def apply(
       path: String,
-      fileMetadata: Map[String, String],
+      blockMetadata: Map[String, String],
       size: Long,
-      modificationTime: Long): QbeastFile = {
-    checkFileMetadata(fileMetadata)
+      modificationTime: Long): QbeastBlock = {
+    checkBlockMetadata(blockMetadata)
 
-    QbeastFile(
+    QbeastBlock(
       path,
-      fileMetadata("revision").toLong,
-      fileMetadata("cube"),
-      Weight(fileMetadata("minWeight").toInt),
-      Weight(fileMetadata("maxWeight").toInt),
-      fileMetadata("state"),
-      fileMetadata("elementCount").toLong,
+      blockMetadata("revision").toLong,
+      blockMetadata("cube"),
+      Weight(blockMetadata("minWeight").toInt),
+      Weight(blockMetadata("maxWeight").toInt),
+      blockMetadata("state"),
+      blockMetadata("elementCount").toLong,
       size,
       modificationTime)
   }

--- a/core/src/main/scala/io/qbeast/core/model/QbeastFile.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastFile.scala
@@ -9,6 +9,8 @@ package io.qbeast.core.model
  * @param maxWeight
  * @param state
  * @param elementCount
+ * @param size
+ * @param modificationTime
  */
 case class QbeastFile(
     path: String,
@@ -17,7 +19,9 @@ case class QbeastFile(
     minWeight: Weight,
     maxWeight: Weight,
     state: String,
-    elementCount: Long)
+    elementCount: Long,
+    size: Long,
+    modificationTime: Long)
 
 /**
  * Companion object for QbeastFile
@@ -38,9 +42,15 @@ object QbeastFile {
    * Creates a QbeastFile from a file path and metadata map
    * @param path
    * @param fileMetadata
+   * @param size
+   * @param modificationTime
    * @return
    */
-  def apply(path: String, fileMetadata: Map[String, String]): QbeastFile = {
+  def apply(
+      path: String,
+      fileMetadata: Map[String, String],
+      size: Long,
+      modificationTime: Long): QbeastFile = {
     checkFileMetadata(fileMetadata)
 
     QbeastFile(
@@ -50,7 +60,9 @@ object QbeastFile {
       Weight(fileMetadata("minWeight").toInt),
       Weight(fileMetadata("maxWeight").toInt),
       fileMetadata("state"),
-      fileMetadata("elementCount").toLong)
+      fileMetadata("elementCount").toLong,
+      size,
+      modificationTime)
   }
 
 }

--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -218,7 +218,10 @@ case class IndexStatus(
  * @param normalizedWeight the normalized weight of the cube
  * @param files the name of the files belonging to the cube
  */
-case class CubeStatus(maxWeight: Weight, normalizedWeight: NormalizedWeight, files: IISeq[String])
+case class CubeStatus(
+    maxWeight: Weight,
+    normalizedWeight: NormalizedWeight,
+    files: IISeq[QbeastFile])
     extends Serializable
 
 /**

--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -216,7 +216,7 @@ case class IndexStatus(
  * Container for the status information of a cube
  * @param maxWeight the max weight of the cube
  * @param normalizedWeight the normalized weight of the cube
- * @param files the name of the files belonging to the cube
+ * @param files the files belonging to the cube
  */
 case class CubeStatus(
     maxWeight: Weight,

--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -221,7 +221,7 @@ case class IndexStatus(
 case class CubeStatus(
     maxWeight: Weight,
     normalizedWeight: NormalizedWeight,
-    files: IISeq[QbeastFile])
+    files: IISeq[QbeastBlock])
     extends Serializable
 
 /**

--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -219,6 +219,7 @@ case class IndexStatus(
  * @param files the files belonging to the cube
  */
 case class CubeStatus(
+    cubeId: CubeId,
     maxWeight: Weight,
     normalizedWeight: NormalizedWeight,
     files: IISeq[QbeastBlock])

--- a/core/src/main/scala/io/qbeast/core/model/Weight.scala
+++ b/core/src/main/scala/io/qbeast/core/model/Weight.scala
@@ -20,8 +20,8 @@ object Weight {
    */
   val MinValue: Weight = Weight(Int.MinValue)
 
-  private val offset: Double = MinValue.value.toDouble
-  private val range: Double = MaxValue.value.toDouble - offset
+  private[qbeast] val offset: Double = MinValue.value.toDouble
+  private[qbeast] val range: Double = MaxValue.value.toDouble - offset
 
   /**
    * Creates a weight from a given fraction. The fraction must

--- a/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
@@ -5,37 +5,34 @@ import org.scalatest.matchers.should.Matchers
 
 class QbeastBlockTest extends AnyFlatSpec with Matchers {
   "QbeastBlock" should "find all the keys in the map" in {
-    val fileMetadata: Map[String, String] = Map(
-      "cube" -> CubeId.root(1).string,
+    val blockMetadata: Map[String, String] = Map(
       "minWeight" -> "19217",
       "maxWeight" -> "11111111",
       "state" -> "FlOODED",
       "revision" -> "1",
       "elementCount" -> "777")
 
-    val qbeastFile = QbeastBlock("path", fileMetadata, 0L, 0L)
-    qbeastFile.cube shouldBe CubeId.root(1).string
-    qbeastFile.minWeight shouldBe Weight(19217)
-    qbeastFile.maxWeight shouldBe Weight(11111111)
-    qbeastFile.state shouldBe "FlOODED"
-    qbeastFile.revision shouldBe 1
-    qbeastFile.elementCount shouldBe 777
+    val qbeastBlock = QbeastBlock("path", blockMetadata, 0L, 0L)
+    qbeastBlock.minWeight shouldBe Weight(19217)
+    qbeastBlock.maxWeight shouldBe Weight(11111111)
+    qbeastBlock.state shouldBe "FlOODED"
+    qbeastBlock.revision shouldBe 1
+    qbeastBlock.elementCount shouldBe 777
   }
 
   it should "throw exception if key not found" in {
-    val fileMetadata = Map.empty[String, String]
-    a[IllegalArgumentException] shouldBe thrownBy(QbeastBlock("path", fileMetadata, 0L, 0L))
+    val blockMetadata = Map.empty[String, String]
+    a[IllegalArgumentException] shouldBe thrownBy(QbeastBlock("path", blockMetadata, 0L, 0L))
   }
 
   it should "throw error if the types are different" in {
-    val fileMetadata: Map[String, String] = Map(
-      "cube" -> CubeId.root(1).string,
+    val blockMetadata: Map[String, String] = Map(
       "minWeight" -> "19217",
       "maxWeight" -> "11111111",
       "state" -> "FlOODED",
       "revision" -> "bad_type",
       "elementCount" -> "777")
 
-    a[IllegalArgumentException] shouldBe thrownBy(QbeastBlock("path", fileMetadata, 0L, 0L))
+    a[IllegalArgumentException] shouldBe thrownBy(QbeastBlock("path", blockMetadata, 0L, 0L))
   }
 }

--- a/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
@@ -3,8 +3,8 @@ package io.qbeast.core.model
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class QbeastFileTest extends AnyFlatSpec with Matchers {
-  "QbeastFile" should "find all the keys in the map" in {
+class QbeastBlockTest extends AnyFlatSpec with Matchers {
+  "QbeastBlock" should "find all the keys in the map" in {
     val fileMetadata: Map[String, String] = Map(
       "cube" -> CubeId.root(1).string,
       "minWeight" -> "19217",
@@ -13,7 +13,7 @@ class QbeastFileTest extends AnyFlatSpec with Matchers {
       "revision" -> "1",
       "elementCount" -> "777")
 
-    val qbeastFile = QbeastFile("path", fileMetadata, 0L, 0L)
+    val qbeastFile = QbeastBlock("path", fileMetadata, 0L, 0L)
     qbeastFile.cube shouldBe CubeId.root(1).string
     qbeastFile.minWeight shouldBe Weight(19217)
     qbeastFile.maxWeight shouldBe Weight(11111111)
@@ -24,7 +24,7 @@ class QbeastFileTest extends AnyFlatSpec with Matchers {
 
   it should "throw exception if key not found" in {
     val fileMetadata = Map.empty[String, String]
-    a[IllegalArgumentException] shouldBe thrownBy(QbeastFile("path", fileMetadata, 0L, 0L))
+    a[IllegalArgumentException] shouldBe thrownBy(QbeastBlock("path", fileMetadata, 0L, 0L))
   }
 
   it should "throw error if the types are different" in {
@@ -36,6 +36,6 @@ class QbeastFileTest extends AnyFlatSpec with Matchers {
       "revision" -> "bad_type",
       "elementCount" -> "777")
 
-    a[IllegalArgumentException] shouldBe thrownBy(QbeastFile("path", fileMetadata, 0L, 0L))
+    a[IllegalArgumentException] shouldBe thrownBy(QbeastBlock("path", fileMetadata, 0L, 0L))
   }
 }

--- a/core/src/test/scala/io/qbeast/core/model/QbeastFileTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QbeastFileTest.scala
@@ -13,7 +13,7 @@ class QbeastFileTest extends AnyFlatSpec with Matchers {
       "revision" -> "1",
       "elementCount" -> "777")
 
-    val qbeastFile = QbeastFile("path", fileMetadata)
+    val qbeastFile = QbeastFile("path", fileMetadata, 0L, 0L)
     qbeastFile.cube shouldBe CubeId.root(1).string
     qbeastFile.minWeight shouldBe Weight(19217)
     qbeastFile.maxWeight shouldBe Weight(11111111)
@@ -24,7 +24,7 @@ class QbeastFileTest extends AnyFlatSpec with Matchers {
 
   it should "throw exception if key not found" in {
     val fileMetadata = Map.empty[String, String]
-    a[IllegalArgumentException] shouldBe thrownBy(QbeastFile("path", fileMetadata))
+    a[IllegalArgumentException] shouldBe thrownBy(QbeastFile("path", fileMetadata, 0L, 0L))
   }
 
   it should "throw error if the types are different" in {
@@ -36,6 +36,6 @@ class QbeastFileTest extends AnyFlatSpec with Matchers {
       "revision" -> "bad_type",
       "elementCount" -> "777")
 
-    a[IllegalArgumentException] shouldBe thrownBy(QbeastFile("path", fileMetadata))
+    a[IllegalArgumentException] shouldBe thrownBy(QbeastFile("path", fileMetadata, 0L, 0L))
   }
 }

--- a/src/main/scala/io/qbeast/spark/delta/CubeDataLoader.scala
+++ b/src/main/scala/io/qbeast/spark/delta/CubeDataLoader.scala
@@ -4,7 +4,7 @@
 package io.qbeast.spark.delta
 
 import io.qbeast.core.model.{CubeId, QTableID, Revision}
-import io.qbeast.spark.utils.{State, TagUtils}
+import io.qbeast.spark.utils.{State, TagColumns}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -61,10 +61,10 @@ case class CubeDataLoader(tableID: QTableID) {
   def loadCubeData(cube: CubeId, revision: Revision): DataFrame = {
 
     val cubeBlocks = snapshot.allFiles
-      .filter(file =>
-        file.tags(TagUtils.revision) == revision.revisionID.toString &&
-          cube.string == file.tags(TagUtils.cube) &&
-          file.tags(TagUtils.state) != State.ANNOUNCED)
+      .where(
+        TagColumns.revision === lit(revision.revisionID.toString) &&
+          TagColumns.cube === lit(cube.string) &&
+          TagColumns.state != lit(State.ANNOUNCED))
       .collect()
 
     val fileNames = cubeBlocks.map(f => new Path(tableID.id, f.path).toString)

--- a/src/main/scala/io/qbeast/spark/delta/DeltaQbeastSnapshot.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaQbeastSnapshot.scala
@@ -4,20 +4,12 @@
 package io.qbeast.spark.delta
 
 import io.qbeast.IISeq
-import io.qbeast.core.model.{
-  IndexStatus,
-  QbeastBlock,
-  QbeastSnapshot,
-  ReplicatedSet,
-  Revision,
-  RevisionID,
-  mapper
-}
+import io.qbeast.core.model._
 import io.qbeast.spark.utils.{MetadataConfig, TagColumns}
-import org.apache.spark.sql.{AnalysisExceptionFactory, Dataset, SparkSession}
 import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.{AnalysisExceptionFactory, Dataset}
 
 /**
  * Qbeast Snapshot that provides information about the current index state.

--- a/src/main/scala/io/qbeast/spark/delta/DeltaQbeastSnapshot.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaQbeastSnapshot.scala
@@ -13,9 +13,11 @@ import io.qbeast.core.model.{
   RevisionID,
   mapper
 }
-import io.qbeast.spark.utils.{MetadataConfig, TagUtils}
+import io.qbeast.spark.utils.{MetadataConfig, TagColumns}
 import org.apache.spark.sql.{AnalysisExceptionFactory, Dataset, SparkSession}
 import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.functions.lit
 
 /**
  * Qbeast Snapshot that provides information about the current index state.
@@ -166,13 +168,9 @@ case class DeltaQbeastSnapshot(private val snapshot: Snapshot) extends QbeastSna
    * @param revisionID the revision identifier
    * @return the Dataset of QbeastBlocks
    */
-  def loadRevisionBlocks(revisionID: RevisionID): Dataset[QbeastBlock] = {
-    val spark = SparkSession.active
-    import spark.implicits._
+  def loadRevisionBlocks(revisionID: RevisionID): Dataset[AddFile] = {
     snapshot.allFiles
-      .filter(_.tags(TagUtils.revision) == revisionID.toString)
-      .map(addFile =>
-        QbeastBlock(addFile.path, addFile.tags, addFile.size, addFile.modificationTime))
+      .where(TagColumns.revision === lit(revisionID.toString))
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
@@ -17,24 +17,24 @@ class QueryExecutor(querySpecBuilder: QuerySpecBuilder, qbeastSnapshot: QbeastSn
 
   /**
    * Executes the query
-   * @return the final sequence of files that match the query
+   * @return the final sequence of blocks that match the query
    */
-  def execute(): Seq[QbeastFile] = {
+  def execute(): Seq[QbeastBlock] = {
 
     qbeastSnapshot.loadAllRevisions.flatMap { revision =>
       val querySpec = querySpecBuilder.build(revision)
       val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
 
-      val matchingFiles = executeRevision(querySpec, indexStatus)
-      matchingFiles
+      val matchingBlocks = executeRevision(querySpec, indexStatus)
+      matchingBlocks
     }
   }
 
   private[query] def executeRevision(
       querySpec: QuerySpec,
-      indexStatus: IndexStatus): IISeq[QbeastFile] = {
+      indexStatus: IndexStatus): IISeq[QbeastBlock] = {
 
-    val outputFiles = Vector.newBuilder[QbeastFile]
+    val outputFiles = Vector.newBuilder[QbeastBlock]
     val stack = mutable.Stack(indexStatus.revision.createCubeIdRoot())
     while (stack.nonEmpty) {
       val currentCube = stack.pop()

--- a/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
@@ -47,7 +47,7 @@ class QueryExecutor(querySpecBuilder: QuerySpecBuilder, qbeastSnapshot: QbeastSn
       // 4. empty, the currentCube is the right-most cube in the tree and it is not in cubesStatuses
       if (cubeIter.hasNext) { // cases 1 to 3
         cubeIter.next() match {
-          case (cube, CubeStatus(maxWeight, _, files)) if cube == currentCube => // Case 1
+          case (cube, CubeStatus(_, maxWeight, _, files)) if cube == currentCube => // Case 1
             val unfilteredFiles = if (querySpec.weightRange.to < maxWeight) {
               // cube maxWeight is larger than the sample fraction, weightRange.to,
               // it means that currentCube is the last cube to visit from the current branch.

--- a/src/main/scala/io/qbeast/spark/index/writer/BlockWriter.scala
+++ b/src/main/scala/io/qbeast/spark/index/writer/BlockWriter.scala
@@ -99,7 +99,7 @@ case class BlockWriter(
             .getFileSystem(serConf.value)
             .getFileStatus(path)
 
-          // TODO create a QbeastFile to not use anything from Delta to write
+          // TODO create a QbeastBlock to not use anything from Delta to write
           Iterator(
             AddFile(
               path = path.getName(),

--- a/src/main/scala/io/qbeast/spark/utils/Params.scala
+++ b/src/main/scala/io/qbeast/spark/utils/Params.scala
@@ -3,6 +3,8 @@
  */
 package io.qbeast.spark.utils
 
+import org.apache.spark.sql.functions.col
+
 /**
  * Names of possible states of the cube
  */
@@ -15,6 +17,15 @@ object State {
 /**
  * Tag keys for saving qbeast index metadata into the delta commit log
  */
+object TagColumns {
+  final val cube = col("tags.cube")
+  final val minWeight = col("tags.minWeight")
+  final val maxWeight = col("tags.maxWeight")
+  final val state = col("tags.state")
+  final val revision = col("tags.revision")
+  final val elementCount = col("tags.elementCount")
+}
+
 object TagUtils {
   final val cube = "cube"
   final val minWeight = "minWeight"

--- a/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/QbeastIntegrationTestSpec.scala
@@ -123,26 +123,27 @@ trait QbeastIntegrationTestSpec extends AnyFlatSpec with Matchers with DatasetCo
    * @tparam T the test result type
    * @return the test result
    */
-  def withQbeastContext[T](
-      keeper: Keeper = LocalKeeper,
-      config: SparkConf = SparkSession.active.sparkContext.getConf)(testCode: => T): T = {
-    val indexedTableFactory = new IndexedTableFactoryImpl(
-      keeper,
-      SparkOTreeManager,
-      SparkDeltaMetadataManager,
-      SparkDataWriter,
-      SparkRevisionFactory)
-    val context = new QbeastContextImpl(config, keeper, indexedTableFactory)
-    try {
-      QbeastContext.setUnmanaged(context)
-      testCode
-    } finally {
-      QbeastContext.unsetUnmanaged()
+  def withQbeastAndSparkContext[T](keeper: Keeper = LocalKeeper)(
+      testCode: SparkSession => T): T = {
+    withSpark { spark =>
+      val indexedTableFactory = new IndexedTableFactoryImpl(
+        keeper,
+        SparkOTreeManager,
+        SparkDeltaMetadataManager,
+        SparkDataWriter,
+        SparkRevisionFactory)
+      val context = new QbeastContextImpl(spark.sparkContext.getConf, keeper, indexedTableFactory)
+      try {
+        QbeastContext.setUnmanaged(context)
+        testCode(spark)
+      } finally {
+        QbeastContext.unsetUnmanaged()
+      }
     }
   }
 
   def withQbeastContextSparkAndTmpDir[T](testCode: (SparkSession, String) => T): T =
-    withQbeastContext()(withTmpDir(tmpDir => withSpark(spark => testCode(spark, tmpDir))))
+    withTmpDir(tmpDir => withQbeastAndSparkContext()(spark => testCode(spark, tmpDir)))
 
   def withOTreeAlgorithm[T](code: IndexManager[DataFrame] => T): T = {
     code(SparkOTreeManager)

--- a/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
@@ -1,13 +1,25 @@
 package io.qbeast.spark.delta
 
 import io.qbeast.TestClasses.T2
+import io.qbeast.core.model.QbeastBlock
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 
 class OTreeIndexTest extends QbeastIntegrationTestSpec {
+
+  class OTreeIndexTest(tahoe: TahoeLogFileIndex) extends OTreeIndex(index = tahoe) {
+
+    // Testing protected method
+    override def matchingBlocks(
+        partitionFilters: Seq[Expression],
+        dataFilters: Seq[Expression]): Seq[QbeastBlock] =
+      super.matchingBlocks(partitionFilters, dataFilters)
+
+  }
 
   private def createDF(size: Int, spark: SparkSession) = {
     import spark.implicits._
@@ -35,11 +47,11 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
     val tahoeFileIndex = {
       TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
     }
-    val oTreeIndex = OTreeIndex(tahoeFileIndex)
+    val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
     val allFiles = deltaLog.snapshot.allFiles.collect().map(_.path)
 
-    val matchFiles = oTreeIndex.matchingFiles(Seq.empty, Seq.empty).map(_.path)
+    val matchFiles = oTreeIndex.matchingBlocks(Seq.empty, Seq.empty).map(_.path)
 
     val diff = (allFiles.toSet -- matchFiles.toSet)
 
@@ -63,7 +75,7 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
     val tahoeFileIndex = {
       TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
     }
-    val oTreeIndex = OTreeIndex(tahoeFileIndex)
+    val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
     oTreeIndex.inputFiles shouldBe deltaLog.snapshot.allFiles
       .collect()
@@ -85,10 +97,10 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
       val tahoeFileIndex = {
         TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
       }
-      val oTreeIndex = OTreeIndex(tahoeFileIndex)
+      val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
       val allFiles = deltaLog.snapshot.allFiles.collect().map(_.path)
 
-      oTreeIndex.matchingFiles(Seq.empty, Seq.empty).map(_.path).toSet shouldBe allFiles.toSet
+      oTreeIndex.matchingBlocks(Seq.empty, Seq.empty).map(_.path).toSet shouldBe allFiles.toSet
     })
 
   it should "sizeInBytes" in withSparkAndTmpDir((spark, tmpdir) => {
@@ -105,7 +117,7 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
     val tahoeFileIndex = {
       TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
     }
-    val oTreeIndex = OTreeIndex(tahoeFileIndex)
+    val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
     val sizeInBytes = deltaLog.snapshot.allFiles.collect().map(_.size).sum
     oTreeIndex.sizeInBytes shouldBe sizeInBytes

--- a/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
@@ -37,9 +37,9 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
     }
     val oTreeIndex = OTreeIndex(tahoeFileIndex)
 
-    val allFiles = deltaLog.snapshot.allFiles.collect()
+    val allFiles = deltaLog.snapshot.allFiles.collect().map(_.path)
 
-    val matchFiles = oTreeIndex.matchingFiles(Seq.empty, Seq.empty)
+    val matchFiles = oTreeIndex.matchingFiles(Seq.empty, Seq.empty).map(_.path)
 
     val diff = (allFiles.toSet -- matchFiles.toSet)
 
@@ -86,9 +86,9 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
         TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
       }
       val oTreeIndex = OTreeIndex(tahoeFileIndex)
-      val allFiles = deltaLog.snapshot.allFiles.collect()
+      val allFiles = deltaLog.snapshot.allFiles.collect().map(_.path)
 
-      oTreeIndex.matchingFiles(Seq.empty, Seq.empty).toSet shouldBe allFiles.toSet
+      oTreeIndex.matchingFiles(Seq.empty, Seq.empty).map(_.path).toSet shouldBe allFiles.toSet
     })
 
   it should "sizeInBytes" in withSparkAndTmpDir((spark, tmpdir) => {

--- a/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
@@ -6,7 +6,6 @@ package io.qbeast.spark.delta
 import io.qbeast.TestClasses.Client3
 import io.qbeast.core.model.{CubeStatus, QTableID}
 import io.qbeast.spark.index.SparkRevisionFactory
-import io.qbeast.spark.utils.TagUtils
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.{Dataset, SparkSession}
@@ -125,14 +124,12 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           val revisionState = builder.buildCubesStatuses
 
           val overflowed = qbeastSnapshot.loadLatestIndexStatus.overflowedSet
-          val fileInfo = qbeastSnapshot.snapshot.allFiles.collect().map(a => (a.path, a)).toMap
 
           revisionState
             .filter { case (cube, _) => overflowed.contains(cube) }
             .foreach { case (cube, CubeStatus(weight, _, files)) =>
               val size = files
-                .map(fileInfo)
-                .map(a => a.tags(TagUtils.elementCount).toLong)
+                .map(a => a.elementCount)
                 .sum
 
               size should be > (cubeSize * 0.9).toLong withClue

--- a/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
@@ -127,7 +127,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
 
           revisionState
             .filter { case (cube, _) => overflowed.contains(cube) }
-            .foreach { case (cube, CubeStatus(weight, _, files)) =>
+            .foreach { case (cube, CubeStatus(_, weight, _, files)) =>
               val size = files
                 .map(a => a.elementCount)
                 .sum

--- a/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
@@ -64,7 +64,7 @@ class CubeWeightsIntegrationTest extends QbeastIntegrationTestSpec {
     val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
     val cubeWeights = qbeastSnapshot.loadLatestIndexStatus.cubesStatuses
 
-    cubeWeights.values.foreach { case CubeStatus(weight, _, _) =>
+    cubeWeights.values.foreach { case CubeStatus(_, weight, _, _) =>
       weight shouldBe >(Weight.MinValue)
       weight shouldBe <=(Weight.MaxValue)
     }

--- a/src/test/scala/io/qbeast/spark/index/OTreeAlgorithmTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/OTreeAlgorithmTest.scala
@@ -13,28 +13,26 @@ import org.apache.spark.sql.functions._
 class OTreeAlgorithmTest extends QbeastIntegrationTestSpec {
 
   "addRandomWeight" should
-    "be deterministic when a row have only nullable columns" in withQbeastContext() {
-      withSpark { spark =>
+    "be deterministic when a row have only nullable columns" in withQbeastAndSparkContext() {
+      spark =>
         val rdd = spark.sparkContext.parallelize(
           0.to(1000).map(i => Client1(Some(i * i), Some(s"student-$i"), Some(i))))
         val df = spark.createDataFrame(rdd)
         checkRDD(df)
-      }
+
     }
 
-  it should "be deterministic when a row have only strings" in withQbeastContext(
-  ) {
-    withSpark { spark =>
+  it should "be deterministic when a row have only strings" in
+    withQbeastAndSparkContext() { spark =>
       val rdd = spark.sparkContext.parallelize(
         0.to(1000).map(i => ClientString((i * i).toString, s"student-$i", i.toString)))
       val df = spark.createDataFrame(rdd)
       checkRDD(df)
-    }
-  }
 
-  it should "be deterministic when a row have only optional strings" in withQbeastContext(
-  ) {
-    withSpark { spark =>
+    }
+
+  it should "be deterministic when a row have only optional strings" in
+    withQbeastAndSparkContext() { spark =>
       val rdd = spark.sparkContext.parallelize(
         0.to(1000)
           .map(i =>
@@ -42,50 +40,44 @@ class OTreeAlgorithmTest extends QbeastIntegrationTestSpec {
       val df = spark.createDataFrame(rdd)
       checkRDD(df)
     }
-  }
 
-  it should "be deterministic with real data" in withQbeastContext() {
-    withSpark { spark =>
-      val inputPath = "src/test/resources/"
-      val file1 = "ecommerce300k_2019_Nov.csv"
-      val df = spark.read
-        .format("csv")
-        .option("header", "true")
-        .option("inferSchema", "true")
-        .load(inputPath + file1)
-        .distinct()
-      checkRDD(df)
-    }
+  it should "be deterministic with real data" in withQbeastAndSparkContext() { spark =>
+    val inputPath = "src/test/resources/"
+    val file1 = "ecommerce300k_2019_Nov.csv"
+    val df = spark.read
+      .format("csv")
+      .option("header", "true")
+      .option("inferSchema", "true")
+      .load(inputPath + file1)
+      .distinct()
+    checkRDD(df)
   }
 
   it should "be deterministic when a row has only nullable columns" +
-    " and null values" in withQbeastContext() {
-      withSpark { spark =>
-        val rdd = spark.sparkContext.parallelize(0.to(1000).map {
-          case i if i % 3 == 0 => Client1(Some(i * i), None, Some(i))
-          case i if i % 5 == 0 => Client1(Some(i * i), Some(s"student-$i"), None)
-          case i if i % 7 == 0 => Client1(None, Some(s"student-$i"), Some(i))
-          case i if i % 11 == 0 => Client1(None, None, None)
-          case i => Client1(Some(i * i), Some(s"student-$i"), Some(i))
-        })
-        val df = spark.createDataFrame(rdd)
-        checkRDD(df)
-      }
+    " and null values" in withQbeastAndSparkContext() { spark =>
+      val rdd = spark.sparkContext.parallelize(0.to(1000).map {
+        case i if i % 3 == 0 => Client1(Some(i * i), None, Some(i))
+        case i if i % 5 == 0 => Client1(Some(i * i), Some(s"student-$i"), None)
+        case i if i % 7 == 0 => Client1(None, Some(s"student-$i"), Some(i))
+        case i if i % 11 == 0 => Client1(None, None, None)
+        case i => Client1(Some(i * i), Some(s"student-$i"), Some(i))
+      })
+      val df = spark.createDataFrame(rdd)
+      checkRDD(df)
+
     }
 
-  it should "be deterministic when a row have only NOT nullable columns" in withQbeastContext(
-  ) {
-    withSpark { spark =>
+  it should "be deterministic when a row have only NOT nullable columns" in
+    withQbeastAndSparkContext() { spark =>
       val rdd =
         spark.sparkContext.parallelize(0.to(1000).map(i => Client2(i * i, s"student-$i", i)))
       val df = spark.createDataFrame(rdd)
       checkRDD(df)
 
     }
-  }
 
   def checkRDD(df: DataFrame): Unit =
-    withQbeastContext() {
+    withQbeastAndSparkContext() { _ =>
       val rev = SparkRevisionFactory.createNewRevision(
         QTableID("test"),
         df.schema,

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -1,7 +1,7 @@
 package io.qbeast.spark.index.query
 
 import io.qbeast.TestClasses.T2
-import io.qbeast.core.model.{QbeastFile, Weight, WeightRange}
+import io.qbeast.core.model.{QbeastBlock, Weight, WeightRange}
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.delta.DeltaQbeastSnapshot
 import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash
@@ -167,7 +167,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
           s"Skipped files: ${diff.size}")
 
       val allQbeastFiles = allDeltaFiles.map(addFile =>
-        QbeastFile(addFile.path, addFile.tags, addFile.size, addFile.modificationTime))
+        QbeastBlock(addFile.path, addFile.tags, addFile.size, addFile.modificationTime))
 
       for (f <- allQbeastFiles) {
         if (f.maxWeight < weightRange.from) {

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -50,9 +50,9 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
     val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
-    val allFiles = allDeltaFiles.map(a => QbeastFile(a.path, a.tags))
+    val allFiles = allDeltaFiles.map(_.path)
 
-    val matchFiles = queryExecutor.execute(allFiles)
+    val matchFiles = queryExecutor.execute().map(_.path)
 
     val diff = allFiles.toSet -- matchFiles.toSet
 
@@ -75,9 +75,9 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
     val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
-    val allFiles = allDeltaFiles.map(a => QbeastFile(a.path, a.tags))
+    val allFiles = allDeltaFiles.map(_.path)
 
-    val matchFiles = queryExecutor.execute(allFiles)
+    val matchFiles = queryExecutor.execute().map(_.path)
 
     matchFiles.size shouldBe <(allFiles.length)
     matchFiles.foreach(file => allFiles should contain(file))
@@ -97,9 +97,9 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
     val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
-    val allFiles = allDeltaFiles.map(a => QbeastFile(a.path, a.tags))
+    val allFiles = allDeltaFiles.map(_.path)
 
-    val matchFiles = queryExecutor.execute(allFiles)
+    val matchFiles = queryExecutor.execute().map(_.path)
 
     matchFiles.size shouldBe <(allFiles.length)
     matchFiles.foreach(file => allFiles should contain(file))
@@ -129,9 +129,9 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
     val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
-    val allFiles = allDeltaFiles.map(a => QbeastFile(a.path, a.tags))
+    val allFiles = allDeltaFiles.map(_.path)
 
-    val matchFiles = queryExecutor.execute(allFiles)
+    val matchFiles = queryExecutor.execute().map(_.path)
 
     val diff = allFiles.toSet -- matchFiles.toSet
     diff.size shouldBe 0
@@ -156,9 +156,9 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
       val queryExecutor = new QueryExecutor(querySpecBuilder, qbeastSnapshot)
 
       val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
-      val allFiles = allDeltaFiles.map(a => QbeastFile(a.path, a.tags))
+      val allFiles = allDeltaFiles.map(_.path)
 
-      val matchFiles = queryExecutor.execute(allFiles)
+      val matchFiles = queryExecutor.execute().map(_.path)
       val diff = allFiles.toSet -- matchFiles.toSet
 
       // scalastyle:off println
@@ -166,10 +166,13 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
         s"Number of files: ${allFiles.length}, Matching files: ${matchFiles.length}, " +
           s"Skipped files: ${diff.size}")
 
-      for (f <- allFiles) {
+      val allQbeastFiles = allDeltaFiles.map(addFile =>
+        QbeastFile(addFile.path, addFile.tags, addFile.size, addFile.modificationTime))
+
+      for (f <- allQbeastFiles) {
         if (f.maxWeight < weightRange.from) {
-          diff should contain(f)
-          matchFiles should not contain (f)
+          diff should contain(f.path)
+          matchFiles should not contain (f.path)
         }
       }
     })


### PR DESCRIPTION
This PR fixes #61 

The changes made are:
- `OTreeIndex` now extends `FileIndex` instead of `TahoeLogFileIndex`
- QueryExecutor doesn't need `previouslyMatchedFiles` anymore
- `QbeastFile` now it's named `QbeastBlock`
- Add more metadata to the `QbeastBlock`: **size** and **modificationTime**
- `CubeStatus` now contains `QbeastBlock` objects instead of the path
