### PR TITLE
Easier information API

### DIFF
--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -6,11 +6,10 @@ package io.qbeast.spark
 import io.qbeast.context.QbeastContext
 import io.qbeast.core.model.{QTableID, RevisionID}
 import io.qbeast.spark.delta.DeltaQbeastSnapshot
+import io.qbeast.spark.internal.commands.{AnalyzeTableCommand, OptimizeTableCommand}
 import io.qbeast.spark.table._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.DeltaLog
-import io.qbeast.spark.internal.commands.AnalyzeTableCommand
-import io.qbeast.spark.internal.commands.OptimizeTableCommand
 
 /**
  * Class for interacting with QbeastTable at a user level
@@ -32,40 +31,13 @@ class QbeastTable private (
 
   private def indexedTable: IndexedTable = indexedTableFactory.getIndexedTable(tableID)
 
-  private def latestRevisionAvailable = qbeastSnapshot.loadLatestRevision.revisionID
+  private def latestRevisionAvailable = qbeastSnapshot.loadLatestRevision
 
-  private def getAvailableRevision(revisionID: Option[RevisionID]): RevisionID = {
-    revisionID match {
-      case Some(id) if qbeastSnapshot.existsRevision(id) => id
-      case None => latestRevisionAvailable
-    }
+  private def latestRevisionAvailableID = latestRevisionAvailable.revisionID
+
+  private def getAvailableRevision(revisionID: RevisionID): RevisionID = {
+    if (qbeastSnapshot.existsRevision(revisionID)) revisionID else latestRevisionAvailableID
   }
-
-  // ////// PRIVATE METHODS ///////
-
-  private def optimize(revisionID: Option[RevisionID]): Unit = {
-    OptimizeTableCommand(getAvailableRevision(revisionID), indexedTable)
-      .run(sparkSession)
-
-  }
-
-  private def analyze(revisionID: Option[RevisionID]): Seq[String] = {
-    AnalyzeTableCommand(getAvailableRevision(revisionID), indexedTable)
-      .run(sparkSession)
-      .map(_.getString(0))
-  }
-
-  private def indexedColumns(revisionID: Option[RevisionID]): Seq[String] = {
-    val revID = getAvailableRevision(revisionID)
-    qbeastSnapshot.loadRevision(revID).columnTransformers.map(_.columnName)
-  }
-
-  private def cubeSize(revisionID: Option[RevisionID]): Int = {
-    val revID = getAvailableRevision(revisionID)
-    qbeastSnapshot.loadRevision(revID).desiredCubeSize
-  }
-
-  // ////// PUBLIC METHODS ///////
 
   /**
    * The optimize operation should read the data of those cubes announced
@@ -73,18 +45,34 @@ class QbeastTable private (
    * @param revisionID the identifier of the revision to optimize.
    *                          If doesn't exist or none is specified, would be the last available
    */
-  def optimize(revisionID: RevisionID): Unit = optimize(Some(revisionID))
+  def optimize(revisionID: RevisionID): Unit = {
+    OptimizeTableCommand(getAvailableRevision(revisionID), indexedTable)
+      .run(sparkSession)
+  }
 
-  def optimize(): Unit = optimize(None)
+  def optimize(): Unit = {
+    OptimizeTableCommand(latestRevisionAvailableID, indexedTable)
+      .run(sparkSession)
+  }
 
   /**
    * The analyze operation should analyze the index structure
    * and find the cubes that need optimization
+   * @param revisionID the identifier of the revision to optimize.
+   *                        If doesn't exist or none is specified, would be the last available
    * @return the sequence of cubes to optimize in string representation
    */
-  def analyze(revisionID: RevisionID): Seq[String] = analyze(Some(revisionID))
+  def analyze(revisionID: RevisionID): Seq[String] = {
+    AnalyzeTableCommand(getAvailableRevision(revisionID), indexedTable)
+      .run(sparkSession)
+      .map(_.getString(0))
+  }
 
-  def analyze(): Seq[String] = analyze(None)
+  def analyze(): Seq[String] = {
+    AnalyzeTableCommand(latestRevisionAvailableID, indexedTable)
+      .run(sparkSession)
+      .map(_.getString(0))
+  }
 
   /**
    * Outputs the indexed columns of the table
@@ -93,9 +81,16 @@ class QbeastTable private (
    * @return
    */
 
-  def indexedColumns(revisionID: RevisionID): Seq[String] = indexedColumns(Some(revisionID))
+  def indexedColumns(revisionID: RevisionID): Seq[String] = {
+    qbeastSnapshot
+      .loadRevision(getAvailableRevision(revisionID))
+      .columnTransformers
+      .map(_.columnName)
+  }
 
-  def indexedColumns(): Seq[String] = indexedColumns(None)
+  def indexedColumns(): Seq[String] = {
+    latestRevisionAvailable.columnTransformers.map(_.columnName)
+  }
 
   /**
    * Outputs the cubeSize of the table
@@ -103,9 +98,11 @@ class QbeastTable private (
    *                          If doesn't exist or none is specified, would be the last available
    * @return
    */
-  def cubeSize(revisionID: RevisionID): Int = cubeSize(Some(revisionID))
+  def cubeSize(revisionID: RevisionID): Int =
+    qbeastSnapshot.loadRevision(getAvailableRevision(revisionID)).desiredCubeSize
 
-  def cubeSize(): Int = cubeSize(None)
+  def cubeSize(): Int =
+    latestRevisionAvailable.desiredCubeSize
 
   /**
    * Outputs all the revision identifiers available for the table
@@ -120,7 +117,7 @@ class QbeastTable private (
    * @return
    */
   def latestRevisionID(): RevisionID = {
-    latestRevisionAvailable
+    latestRevisionAvailableID
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -90,7 +90,6 @@ class QbeastTable private (
    * Outputs all the revision identifiers available for the table
    * @return
    */
-
   def revisionsID(): Seq[RevisionID] = {
     qbeastSnapshot.loadAllRevisions.map(_.revisionID)
   }
@@ -99,9 +98,8 @@ class QbeastTable private (
    * Outputs the identifier of the latest revision available
    * @return
    */
-
   def latestRevisionID(): RevisionID = {
-    qbeastSnapshot.loadLatestRevision.revisionID
+    latestRevisionAvailable
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -91,7 +91,7 @@ class QbeastTable private (
    * @return
    */
 
-  def revisions(): Seq[RevisionID] = {
+  def revisionsID(): Seq[RevisionID] = {
     qbeastSnapshot.loadAllRevisions.map(_.revisionID)
   }
 
@@ -100,7 +100,7 @@ class QbeastTable private (
    * @return
    */
 
-  def latestRevision(): RevisionID = {
+  def latestRevisionID(): RevisionID = {
     qbeastSnapshot.loadLatestRevision.revisionID
   }
 

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -1,0 +1,99 @@
+package io.qbeast.spark.utils
+
+import io.qbeast.TestClasses.Client3
+import io.qbeast.spark.{QbeastIntegrationTestSpec, QbeastTable}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.col
+
+class QbeastTableTest extends QbeastIntegrationTestSpec {
+
+  private def createDF(spark: SparkSession) = {
+    val rdd =
+      spark.sparkContext.parallelize(
+        0.to(1000)
+          .map(i => Client3(i * i, s"student-$i", i, (i * 1000 + 123), i * 2567.3432143)))
+    spark.createDataFrame(rdd)
+  }
+
+  "IndexedColumns" should "output the indexed columns" in withQbeastContextSparkAndTmpDir {
+    (spark, tmpDir) =>
+      {
+        val data = createDF(spark)
+        val columnsToIndex = Seq("age", "val2")
+        val cubeSize = 100
+        // WRITE SOME DATA
+        writeTestData(data, columnsToIndex, cubeSize, tmpDir)
+
+        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+        qbeastTable.indexedColumns() shouldBe columnsToIndex
+      }
+  }
+
+  "CubeSize" should "output the cube size" in withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+    {
+      val data = createDF(spark)
+      val columnsToIndex = Seq("age", "val2")
+      val cubeSize = 100
+      // WRITE SOME DATA
+      writeTestData(data, columnsToIndex, cubeSize, tmpDir)
+
+      val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+      qbeastTable.cubeSize() shouldBe cubeSize
+    }
+  }
+
+  "Latest revision" should "ouput the last revision available" in withQbeastContextSparkAndTmpDir {
+    (spark, tmpDir) =>
+      {
+        val data = createDF(spark)
+        val columnsToIndex = Seq("age", "val2")
+        val cubeSize = 100
+        // WRITE SOME DATA
+        writeTestData(data, columnsToIndex, cubeSize, tmpDir)
+
+        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+        qbeastTable.latestRevision() shouldBe 1L
+      }
+  }
+
+  it should "ouput the last revision available within different revisions" in
+    withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+      {
+        val revision1 = createDF(spark)
+        val columnsToIndex = Seq("age", "val2")
+        val cubeSize = 100
+        // WRITE SOME DATA
+        writeTestData(revision1, columnsToIndex, cubeSize, tmpDir)
+
+        val revision2 = revision1.withColumn("age", col("age") * 2)
+        writeTestData(revision2, columnsToIndex, cubeSize, tmpDir, "append")
+
+        val revision3 = revision1.withColumn("val2", col("val2") * 2)
+        writeTestData(revision3, columnsToIndex, cubeSize, tmpDir, "append")
+
+        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+        qbeastTable.latestRevision() shouldBe 3L
+      }
+    }
+
+  "Revisions" should "outputs all the revision available" in withQbeastContextSparkAndTmpDir {
+    (spark, tmpDir) =>
+      {
+        val revision1 = createDF(spark)
+        val columnsToIndex = Seq("age", "val2")
+        val cubeSize = 100
+        // WRITE SOME DATA
+        writeTestData(revision1, columnsToIndex, cubeSize, tmpDir)
+
+        val revision2 = revision1.withColumn("age", col("age") * 2)
+        writeTestData(revision2, columnsToIndex, cubeSize, tmpDir, "append")
+
+        val revision3 = revision1.withColumn("val2", col("val2") * 2)
+        writeTestData(revision3, columnsToIndex, cubeSize, tmpDir, "append")
+
+        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+        qbeastTable.revisions().size shouldBe 3
+        qbeastTable.revisions() shouldBe Seq(1L, 2L, 3L)
+      }
+  }
+}

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -52,7 +52,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         writeTestData(data, columnsToIndex, cubeSize, tmpDir)
 
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
-        qbeastTable.latestRevision() shouldBe 1L
+        qbeastTable.latestRevisionID() shouldBe 1L
       }
   }
 
@@ -72,7 +72,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         writeTestData(revision3, columnsToIndex, cubeSize, tmpDir, "append")
 
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
-        qbeastTable.latestRevision() shouldBe 3L
+        qbeastTable.latestRevisionID() shouldBe 3L
       }
     }
 
@@ -92,8 +92,8 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         writeTestData(revision3, columnsToIndex, cubeSize, tmpDir, "append")
 
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
-        qbeastTable.revisions().size shouldBe 3
-        qbeastTable.revisions() shouldBe Seq(1L, 2L, 3L)
+        qbeastTable.revisionsID().size shouldBe 3
+        qbeastTable.revisionsID() shouldBe Seq(1L, 2L, 3L)
       }
   }
 }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -92,8 +92,8 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         writeTestData(revision3, columnsToIndex, cubeSize, tmpDir, "append")
 
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
-        qbeastTable.revisionsID().size shouldBe 3
-        qbeastTable.revisionsID() shouldBe Seq(1L, 2L, 3L)
+        qbeastTable.revisionsIDs().size shouldBe 3
+        qbeastTable.revisionsIDs() shouldBe Seq(1L, 2L, 3L)
       }
   }
 }


### PR DESCRIPTION
Related to #43, this PR adds new methods to `QbeastTable` that allows both developers and users to understand the metadata of qbeast, such as:

```scala
val qbeastTable = QbeastTable.forPath(spark, path)
qbeastTable.indexedColumns() // Outputs the actual indexed columns
qbeastTable.cubeSize() // Outputs the actual cube size
qbeastTable.revisionsID() // Outputs the list of revision identifiers available for a table
qbeastTable.latestRevisionID() // Outputs the latest revision identifier available for a table
```

Any suggestion is welcome! Feel free to ask for metadata information that would be relevant to you :smile: 