### PR TITLE
Keeper Integration API

### DIFF
--- a/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
@@ -3,7 +3,8 @@
  */
 package io.qbeast.core.keeper
 
-import io.qbeast.{SerializedCubeID, SerializedTableID}
+import io.qbeast.SerializedCubeID
+import io.qbeast.core.model.QTableID
 
 import java.util.ServiceLoader
 
@@ -19,7 +20,7 @@ trait Keeper {
    * @param revision the domain revision
    * @return the write operation
    */
-  def beginWrite(tableID: SerializedTableID, revision: Long): Write
+  def beginWrite(tableID: QTableID, revision: Long): Write
 
   /**
    * Runs an action as part of write operation for the specified index revision.
@@ -29,7 +30,7 @@ trait Keeper {
    * @tparam T the result type
    * @return the result
    */
-  def withWrite[T](tableID: SerializedTableID, revision: Long)(action: Write => T): T = {
+  def withWrite[T](tableID: QTableID, revision: Long)(action: Write => T): T = {
     val write = beginWrite(tableID, revision)
     try {
       action(write)
@@ -44,7 +45,7 @@ trait Keeper {
    * @param revision the domain revision
    * @param cubes the announced cube identifiers
    */
-  def announce(tableID: SerializedTableID, revision: Long, cubes: Seq[SerializedCubeID]): Unit
+  def announce(tableID: QTableID, revision: Long, cubes: Seq[SerializedCubeID]): Unit
 
   /**
    * Begins an optimization for given index domain revision.
@@ -54,7 +55,7 @@ trait Keeper {
    * @return the optimization operation
    */
   def beginOptimization(
-      tableID: SerializedTableID,
+      tableID: QTableID,
       revision: Long,
       cubeLimit: Integer = Integer.MAX_VALUE): Optimization
 

--- a/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
@@ -3,6 +3,8 @@
  */
 package io.qbeast.core.keeper
 
+import io.qbeast.SerializedCubeID
+
 import java.util.ServiceLoader
 
 /**
@@ -42,7 +44,7 @@ trait Keeper {
    * @param revision the domain revision
    * @param cubes the announced cube identifiers
    */
-  def announce(tableID: String, revision: Long, cubes: Seq[String]): Unit
+  def announce(tableID: String, revision: Long, cubes: Seq[SerializedCubeID]): Unit
 
   /**
    * Begins an optimization for given index domain revision.
@@ -75,14 +77,14 @@ trait Optimization {
   /**
    * The cubes to optimize.
    */
-  val cubesToOptimize: Set[String]
+  val cubesToOptimize: Set[SerializedCubeID]
 
   /**
    * Ends the optimization.
    *
    * @param replicatedCubes the replicated cube identifiers
    */
-  def end(replicatedCubes: Set[String]): Unit
+  def end(replicatedCubes: Set[SerializedCubeID]): Unit
 }
 
 /**
@@ -98,7 +100,7 @@ trait Write {
   /**
    * The announced cube identifiers
    */
-  val announcedCubes: Set[String]
+  val announcedCubes: Set[SerializedCubeID]
 
   /**
    * Ends the write.

--- a/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
@@ -3,8 +3,6 @@
  */
 package io.qbeast.core.keeper
 
-import io.qbeast.core.model.{CubeId, QTableID}
-
 import java.util.ServiceLoader
 
 /**
@@ -19,7 +17,7 @@ trait Keeper {
    * @param revision the domain revision
    * @return the write operation
    */
-  def beginWrite(tableID: QTableID, revision: Long): Write
+  def beginWrite(tableID: String, revision: Long): Write
 
   /**
    * Runs an action as part of write operation for the specified index revision.
@@ -29,7 +27,7 @@ trait Keeper {
    * @tparam T the result type
    * @return the result
    */
-  def withWrite[T](tableID: QTableID, revision: Long)(action: Write => T): T = {
+  def withWrite[T](tableID: String, revision: Long)(action: Write => T): T = {
     val write = beginWrite(tableID, revision)
     try {
       action(write)
@@ -44,7 +42,7 @@ trait Keeper {
    * @param revision the domain revision
    * @param cubes the announced cube identifiers
    */
-  def announce(tableID: QTableID, revision: Long, cubes: Seq[CubeId]): Unit
+  def announce(tableID: String, revision: Long, cubes: Seq[String]): Unit
 
   /**
    * Begins an optimization for given index domain revision.
@@ -54,7 +52,7 @@ trait Keeper {
    * @return the optimization operation
    */
   def beginOptimization(
-      tableID: QTableID,
+      tableID: String,
       revision: Long,
       cubeLimit: Integer = Integer.MAX_VALUE): Optimization
 
@@ -77,14 +75,14 @@ trait Optimization {
   /**
    * The cubes to optimize.
    */
-  val cubesToOptimize: Set[CubeId]
+  val cubesToOptimize: Set[String]
 
   /**
    * Ends the optimization.
    *
    * @param replicatedCubes the replicated cube identifiers
    */
-  def end(replicatedCubes: Set[CubeId]): Unit
+  def end(replicatedCubes: Set[String]): Unit
 }
 
 /**
@@ -100,7 +98,7 @@ trait Write {
   /**
    * The announced cube identifiers
    */
-  val announcedCubes: Set[CubeId]
+  val announcedCubes: Set[String]
 
   /**
    * Ends the write.

--- a/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/Keeper.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.core.keeper
 
-import io.qbeast.SerializedCubeID
+import io.qbeast.{SerializedCubeID, SerializedTableID}
 
 import java.util.ServiceLoader
 
@@ -19,7 +19,7 @@ trait Keeper {
    * @param revision the domain revision
    * @return the write operation
    */
-  def beginWrite(tableID: String, revision: Long): Write
+  def beginWrite(tableID: SerializedTableID, revision: Long): Write
 
   /**
    * Runs an action as part of write operation for the specified index revision.
@@ -29,7 +29,7 @@ trait Keeper {
    * @tparam T the result type
    * @return the result
    */
-  def withWrite[T](tableID: String, revision: Long)(action: Write => T): T = {
+  def withWrite[T](tableID: SerializedTableID, revision: Long)(action: Write => T): T = {
     val write = beginWrite(tableID, revision)
     try {
       action(write)
@@ -44,7 +44,7 @@ trait Keeper {
    * @param revision the domain revision
    * @param cubes the announced cube identifiers
    */
-  def announce(tableID: String, revision: Long, cubes: Seq[SerializedCubeID]): Unit
+  def announce(tableID: SerializedTableID, revision: Long, cubes: Seq[SerializedCubeID]): Unit
 
   /**
    * Begins an optimization for given index domain revision.
@@ -54,7 +54,7 @@ trait Keeper {
    * @return the optimization operation
    */
   def beginOptimization(
-      tableID: String,
+      tableID: SerializedTableID,
       revision: Long,
       cubeLimit: Integer = Integer.MAX_VALUE): Optimization
 

--- a/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
@@ -3,7 +3,8 @@
  */
 package io.qbeast.core.keeper
 
-import io.qbeast.{SerializedCubeID, SerializedTableID}
+import io.qbeast.SerializedCubeID
+import io.qbeast.core.model.QTableID
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -15,22 +16,19 @@ object LocalKeeper extends Keeper {
   private val generator = new AtomicInteger()
 
   private val announcedMap =
-    scala.collection.mutable.Map.empty[(SerializedTableID, Long), Set[SerializedCubeID]]
+    scala.collection.mutable.Map.empty[(QTableID, Long), Set[SerializedCubeID]]
 
-  override def beginWrite(tableID: SerializedTableID, revision: Long): Write = new LocalWrite(
+  override def beginWrite(tableID: QTableID, revision: Long): Write = new LocalWrite(
     generator.getAndIncrement().toString,
     announcedMap.getOrElse((tableID, revision), Set.empty[SerializedCubeID]))
 
-  override def announce(
-      tableID: SerializedTableID,
-      revision: Long,
-      cubes: Seq[SerializedCubeID]): Unit = {
+  override def announce(tableID: QTableID, revision: Long, cubes: Seq[SerializedCubeID]): Unit = {
     val announcedCubes = announcedMap.getOrElse((tableID, revision), Set.empty[SerializedCubeID])
     announcedMap.update((tableID, revision), announcedCubes.union(cubes.toSet))
   }
 
   override def beginOptimization(
-      tableID: SerializedTableID,
+      tableID: QTableID,
       revision: Long,
       cubeLimit: Integer): Optimization =
     new LocalOptimization(

--- a/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
@@ -3,6 +3,7 @@
  */
 package io.qbeast.core.keeper
 
+import io.qbeast.SerializedCubeID
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -11,14 +12,16 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 object LocalKeeper extends Keeper {
   private val generator = new AtomicInteger()
-  private val announcedMap = scala.collection.mutable.Map.empty[(String, Long), Set[String]]
+
+  private val announcedMap =
+    scala.collection.mutable.Map.empty[(String, Long), Set[SerializedCubeID]]
 
   override def beginWrite(tableID: String, revision: Long): Write = new LocalWrite(
     generator.getAndIncrement().toString,
     announcedMap.getOrElse((tableID, revision), Set.empty[String]))
 
-  override def announce(tableID: String, revision: Long, cubes: Seq[String]): Unit = {
-    val announcedCubes = announcedMap.getOrElse((tableID, revision), Set.empty[String])
+  override def announce(tableID: String, revision: Long, cubes: Seq[SerializedCubeID]): Unit = {
+    val announcedCubes = announcedMap.getOrElse((tableID, revision), Set.empty[SerializedCubeID])
     announcedMap.update((tableID, revision), announcedCubes.union(cubes.toSet))
   }
 
@@ -28,18 +31,21 @@ object LocalKeeper extends Keeper {
       cubeLimit: Integer): Optimization =
     new LocalOptimization(
       generator.getAndIncrement().toString,
-      announcedMap.getOrElse((tableID, revision), Set.empty[String]))
+      announcedMap.getOrElse((tableID, revision), Set.empty[SerializedCubeID]))
 
   override def stop(): Unit = {}
 }
 
-private class LocalWrite(val id: String, override val announcedCubes: Set[String]) extends Write {
+private class LocalWrite(val id: String, override val announcedCubes: Set[SerializedCubeID])
+    extends Write {
 
   override def end(): Unit = {}
 }
 
-private class LocalOptimization(val id: String, override val cubesToOptimize: Set[String])
+private class LocalOptimization(
+    val id: String,
+    override val cubesToOptimize: Set[SerializedCubeID])
     extends Optimization {
 
-  override def end(replicatedCubes: Set[String]): Unit = {}
+  override def end(replicatedCubes: Set[SerializedCubeID]): Unit = {}
 }

--- a/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
@@ -3,8 +3,6 @@
  */
 package io.qbeast.core.keeper
 
-import io.qbeast.core.model.{CubeId, QTableID}
-
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -13,34 +11,35 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 object LocalKeeper extends Keeper {
   private val generator = new AtomicInteger()
-  private val announcedMap = scala.collection.mutable.Map.empty[(QTableID, Long), Set[CubeId]]
+  private val announcedMap = scala.collection.mutable.Map.empty[(String, Long), Set[String]]
 
-  override def beginWrite(tableID: QTableID, revision: Long): Write = new LocalWrite(
+  override def beginWrite(tableID: String, revision: Long): Write = new LocalWrite(
     generator.getAndIncrement().toString,
-    announcedMap.getOrElse((tableID, revision), Set.empty[CubeId]))
+    announcedMap.getOrElse((tableID, revision), Set.empty[String]))
 
-  override def announce(tableID: QTableID, revision: Long, cubes: Seq[CubeId]): Unit = {
-    val announcedCubes = announcedMap.getOrElse((tableID, revision), Set.empty[CubeId])
+  override def announce(tableID: String, revision: Long, cubes: Seq[String]): Unit = {
+    val announcedCubes = announcedMap.getOrElse((tableID, revision), Set.empty[String])
     announcedMap.update((tableID, revision), announcedCubes.union(cubes.toSet))
   }
 
   override def beginOptimization(
-      tableID: QTableID,
+      tableID: String,
       revision: Long,
-      cubeLimit: Integer): Optimization = new LocalOptimization(
-    generator.getAndIncrement().toString,
-    announcedMap.getOrElse((tableID, revision), Set.empty[CubeId]))
+      cubeLimit: Integer): Optimization =
+    new LocalOptimization(
+      generator.getAndIncrement().toString,
+      announcedMap.getOrElse((tableID, revision), Set.empty[String]))
 
   override def stop(): Unit = {}
 }
 
-private class LocalWrite(val id: String, override val announcedCubes: Set[CubeId]) extends Write {
+private class LocalWrite(val id: String, override val announcedCubes: Set[String]) extends Write {
 
   override def end(): Unit = {}
 }
 
-private class LocalOptimization(val id: String, override val cubesToOptimize: Set[CubeId])
+private class LocalOptimization(val id: String, override val cubesToOptimize: Set[String])
     extends Optimization {
 
-  override def end(replicatedCubes: Set[CubeId]): Unit = {}
+  override def end(replicatedCubes: Set[String]): Unit = {}
 }

--- a/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
+++ b/core/src/main/scala/io/qbeast/core/keeper/LocalKeeper.scala
@@ -3,7 +3,8 @@
  */
 package io.qbeast.core.keeper
 
-import io.qbeast.SerializedCubeID
+import io.qbeast.{SerializedCubeID, SerializedTableID}
+
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -14,19 +15,22 @@ object LocalKeeper extends Keeper {
   private val generator = new AtomicInteger()
 
   private val announcedMap =
-    scala.collection.mutable.Map.empty[(String, Long), Set[SerializedCubeID]]
+    scala.collection.mutable.Map.empty[(SerializedTableID, Long), Set[SerializedCubeID]]
 
-  override def beginWrite(tableID: String, revision: Long): Write = new LocalWrite(
+  override def beginWrite(tableID: SerializedTableID, revision: Long): Write = new LocalWrite(
     generator.getAndIncrement().toString,
-    announcedMap.getOrElse((tableID, revision), Set.empty[String]))
+    announcedMap.getOrElse((tableID, revision), Set.empty[SerializedCubeID]))
 
-  override def announce(tableID: String, revision: Long, cubes: Seq[SerializedCubeID]): Unit = {
+  override def announce(
+      tableID: SerializedTableID,
+      revision: Long,
+      cubes: Seq[SerializedCubeID]): Unit = {
     val announcedCubes = announcedMap.getOrElse((tableID, revision), Set.empty[SerializedCubeID])
     announcedMap.update((tableID, revision), announcedCubes.union(cubes.toSet))
   }
 
   override def beginOptimization(
-      tableID: String,
+      tableID: SerializedTableID,
       revision: Long,
       cubeLimit: Integer): Optimization =
     new LocalOptimization(

--- a/core/src/main/scala/io/qbeast/package.scala
+++ b/core/src/main/scala/io/qbeast/package.scala
@@ -2,5 +2,5 @@ package io
 
 package object qbeast {
   type IISeq[T] = scala.collection.immutable.Seq[T]
-
+  type SerializedCubeID = String
 }

--- a/core/src/main/scala/io/qbeast/package.scala
+++ b/core/src/main/scala/io/qbeast/package.scala
@@ -3,5 +3,4 @@ package io
 package object qbeast {
   type IISeq[T] = scala.collection.immutable.Seq[T]
   type SerializedCubeID = String
-  type SerializedTableID = String
 }

--- a/core/src/main/scala/io/qbeast/package.scala
+++ b/core/src/main/scala/io/qbeast/package.scala
@@ -3,4 +3,5 @@ package io
 package object qbeast {
   type IISeq[T] = scala.collection.immutable.Seq[T]
   type SerializedCubeID = String
+  type SerializedTableID = String
 }

--- a/src/main/scala/io/qbeast/context/QbeastContext.scala
+++ b/src/main/scala/io/qbeast/context/QbeastContext.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.context
 
-import io.qbeast.core.keeper.Keeper
+import io.qbeast.core.keeper.{Keeper, LocalKeeper}
 import io.qbeast.core.model._
 import io.qbeast.spark.delta.SparkDeltaMetadataManager
 import io.qbeast.spark.index.{SparkOTreeManager, SparkRevisionFactory}
@@ -126,8 +126,12 @@ object QbeastContext
     new QbeastContextImpl(config, keeper, indexedTableFactory)
   }
 
-  private def createKeeper(config: SparkConf): Keeper = Keeper(
-    config.getAll.filter(_._1.startsWith("spark.qbeast.keeper")).toMap)
+  private def createKeeper(config: SparkConf): Keeper = {
+    val configKeeper = config.getAll.filter(_._1.startsWith("spark.qbeast.keeper")).toMap
+    if (configKeeper.isEmpty) {
+      LocalKeeper
+    } else Keeper(configKeeper)
+  }
 
   private def createIndexedTableFactory(keeper: Keeper): IndexedTableFactory =
     new IndexedTableFactoryImpl(

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -204,7 +204,9 @@ private[table] class IndexedTableImpl(
         doWrite(data, updatedStatus, append)
       }
     } else {
-      doWrite(data, indexStatus, append)
+      keeper.withWrite(tableID.id, revision.revisionID) { write =>
+        doWrite(data, indexStatus, append)
+      }
     }
     clearCaches()
     createQbeastBaseRelation()

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -198,13 +198,13 @@ private[table] class IndexedTableImpl(
     val revision = indexStatus.revision
 
     if (exists) {
-      keeper.withWrite(tableID.id, revision.revisionID) { write =>
+      keeper.withWrite(tableID, revision.revisionID) { write =>
         val announcedSet = write.announcedCubes.map(revision.createCubeId)
         val updatedStatus = indexStatus.addAnnouncements(announcedSet)
         doWrite(data, updatedStatus, append)
       }
     } else {
-      keeper.withWrite(tableID.id, revision.revisionID) { write =>
+      keeper.withWrite(tableID, revision.revisionID) { write =>
         doWrite(data, indexStatus, append)
       }
     }
@@ -227,7 +227,7 @@ private[table] class IndexedTableImpl(
   override def analyze(revisionID: RevisionID): Seq[String] = {
     val indexStatus = snapshot.loadIndexStatus(revisionID)
     val cubesToAnnounce = indexManager.analyze(indexStatus).map(_.string)
-    keeper.announce(tableID.id, revisionID, cubesToAnnounce)
+    keeper.announce(tableID, revisionID, cubesToAnnounce)
     cubesToAnnounce
 
   }
@@ -235,7 +235,7 @@ private[table] class IndexedTableImpl(
   override def optimize(revisionID: RevisionID): Unit = {
 
     // begin keeper transaction
-    val bo = keeper.beginOptimization(tableID.id, revisionID)
+    val bo = keeper.beginOptimization(tableID, revisionID)
 
     val currentIndexStatus = snapshot.loadIndexStatus(revisionID)
     val cubesToOptimize = bo.cubesToOptimize.map(currentIndexStatus.revision.createCubeId)


### PR DESCRIPTION
This PR is changing **ONLY the API** to connect to the Keeper. It does not introduce any logic. 
PR #77 is the one solving #41. Here I only take care of **matching calls between the different libraries** we want to implement. 

In order to delegate the maintenance of the index to a **Keeper instance**, this is the **configuration** you need to use:

```bash

$SPARK_HOME/bin/spark-shell --master local[*]\
 --packages io.delta:delta-core_2.12:1.0.0,io.qbeast:qbeast-spark-keeper_2.12:0.1.0-a2\
 --jars ./target/scala-2.12/qbeast-spark-assembly-0.2.0.jar\
 --conf spark.sql.extensions=io.qbeast.spark.internal.QbeastSparkSessionExtension\
 --conf spark.qbeast.keeper.host=localhost\
 --conf spark.qbeast.keeper.port=50051

```

As you can see, there's **three new parameters:**

1.` --packages io.qbeast:qbeast-spark-keeper_2.12:0.1.0-a2` -> Package of the qbeast-spark-keeper driver. It maps calls between the qbeast-spark and qbeast-keeper. It also shades `grpc/netty` libraries to the Spark.
2.  `--conf spark.qbeast.keeper.host=localhost` -> The ip/host of the keeper
3.  ` --conf spark.qbeast.keeper.port=50051` -> The port of the keeper
 