### PR TITLE
Replace `result` with `resultInternal` for `CubeWeights`

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/CubeWeights.scala
+++ b/core/src/main/scala/io/qbeast/core/model/CubeWeights.scala
@@ -76,7 +76,7 @@ class CubeWeightsBuilder protected (
   def update(point: Point, weight: Weight, parent: Option[CubeId] = None): CubeWeightsBuilder = {
     queue.enqueue(PointWeightAndParent(point, weight, parent))
     if (queue.size >= bufferCapacity) {
-      resultBuffer ++= result()
+      resultBuffer ++= resultInternal()
       queue.clear()
     }
     this

--- a/core/src/test/scala/io/qbeast/core/model/CubeWeightsBuilderTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/CubeWeightsBuilderTest.scala
@@ -107,4 +107,11 @@ class CubeWeightsBuilderTest extends AnyFlatSpec with Matchers {
       CubeWeightTesting(id10, Weight(2).fraction))
   }
 
+  it should "not duplicate elements in result" in {
+    val builder =
+      new CubeWeightsBuilderTesting(1, 1, 1000, announcedOrReplicatedSet = Set(root))
+    0.to(10000).map { _ => builder.update(point, Weight(Random.nextInt())) }
+    val result = builder.result()
+    result.size shouldBe result.distinct.size
+  }
 }


### PR DESCRIPTION
The `CubeWeights.update` method flushes the `queue` into the `resultBuffer` when its size exceeds a predetermined `bufferSize`.

However, aside from adding the current elements to the `resultBuffer`, it also duplicates the current elements of the `buffer`. Which greatly increases the amount of memory required to do the operations.

```scala
resultBuffer ++= results()
// results() = resultInternal ++ resultBuffer
```

Instead of `resultBuffer ++= results()`, it should be `resultBuffer ++= resultInternal()`.

Solve Issue #84 