### PR TITLE
Headers and footers for scaladoc generation, including version in HTML

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,7 @@ qbeastSpark / Compile / doc / scalacOptions ++= Seq(
   "-doc-version",
   qbeast_spark_version,
   "-doc-footer",
-  "Copyright 2022 Qbeast - Docs for version " + qbeast_spark_version +
-    " of qbeast-spark - https://github.com/Qbeast-io/qbeast-spark/")
+  "Copyright 2022 Qbeast - Docs for version " + qbeast_spark_version + " of qbeast-spark")
 
 lazy val qbeastSparkNodep = (project in file("nodep"))
   .settings(name := "qbeast-spark-nodep", Compile / packageBin := (qbeastSpark / assembly).value)

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,15 @@ lazy val qbeastSpark = (project in file("."))
     publish / skip := true)
   .settings(noWarningInConsole)
 
+qbeastSpark / Compile / doc / scalacOptions ++= Seq(
+  "-doc-title",
+  "qbeast-spark",
+  "-doc-version",
+  qbeast_spark_version,
+  "-doc-footer",
+  "Copyright 2022 Qbeast - Docs for version " + qbeast_spark_version +
+    " of qbeast-spark - https://github.com/Qbeast-io/qbeast-spark/")
+
 lazy val qbeastSparkNodep = (project in file("nodep"))
   .settings(name := "qbeast-spark-nodep", Compile / packageBin := (qbeastSpark / assembly).value)
 
@@ -33,7 +42,8 @@ lazy val qbeastSparkMaven = (project in file("maven"))
   .settings(name := "qbeast-spark", Compile / packageBin := (qbeastSpark / assembly).value)
 
 // Common metadata
-ThisBuild / version := "0.2.0"
+val qbeast_spark_version = "0.2.0"
+ThisBuild / version := qbeast_spark_version
 ThisBuild / organization := "io.qbeast"
 ThisBuild / organizationName := "Qbeast Analytics, S.L."
 ThisBuild / organizationHomepage := Some(url("https://qbeast.io/"))


### PR DESCRIPTION
The current version of scaladoc (`sbt unidoc`) generates HTML documents like the one in the screenshot below. My idea is to include in these some information about the **qbeast-spark version**, both in the **header** and the **footer** of the files:

<img width="400" alt="Screenshot 2022-03-24 at 19 19 24" src="https://user-images.githubusercontent.com/34559457/159984419-393180b7-ea1d-4d26-a093-fdddedd4d64e.png">

Any suggestions or modifications are more than welcome!☺️