### PR TITLE
Remove "project packaging" from README, as it is now available in Maven

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,14 +105,13 @@ export SPARK_HOME=$PWD/spark-3.1.1-bin-hadoop3.2
  ```
 
 ### 3. Project packaging:
-Clone the repo, navigate to the repository folder, and package the project through **sbt**. [JDK 8](https://www.azul.com/downloads/?version=java-8-lts&package=jdk) is recommended.
+Navigate to the repository folder and package the project using **sbt**. [JDK 8](https://www.azul.com/downloads/?version=java-8-lts&package=jdk) is recommended.
 
-**Note**: You can specify **custom** Spark or Hadoop **versions** when packaging by using `-Dspark.version=3.2.0` or `-Dhadoop.version=2.7.4` when running `sbt assembly`.
+> ℹ️ **Note**: You can specify **custom** Spark or Hadoop **versions** when packaging by using  
+>`-Dspark.version=3.2.0` or `-Dhadoop.version=2.7.4` when running `sbt assembly`.
 If you have troubles with the versions you use, don't hesitate to **ask the community** in [GitHub discussions](https://github.com/Qbeast-io/qbeast-spark/discussions).
 
 ``` bash
-git clone https://github.com/Qbeast-io/qbeast-spark.git
-
 cd qbeast-spark
 
 sbt assembly

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can find it in the [Packages section](https://github.com/orgs/Qbeast-io/pack
 ### Pre: Install **Spark**
 Download **Spark 3.1.1 with Hadoop 3.2**, unzip it, and create the `SPARK_HOME` environment variable:<br />
 
->:information_source: **Note: You can use Hadoop 2.7 if desired, but you could have some troubles with different cloud providers' storage, read more about it [here](docs/CloudStorages.md).**
+>:information_source: **Note**: You can use Hadoop 2.7 if desired, but you could have some troubles with different cloud providers' storage, read more about it [here](docs/CloudStorages.md).
 
 ```bash
 wget https://archive.apache.org/dist/spark/spark-3.1.1/spark-3.1.1-bin-hadoop3.2.tgz
@@ -85,20 +85,6 @@ tar xzvf spark-3.1.1-bin-hadoop3.2.tgz
 
 export SPARK_HOME=$PWD/spark-3.1.1-bin-hadoop3.2
  ```
-### 0. Project packaging:
-
-Clone the repo, navigate to the repository folder, and package the project through **sbt**. [JDK 8](https://www.azul.com/downloads/?version=java-8-lts&package=jdk) is recommended.  
-> ℹ️ **Note**: You can specify **custom** Spark or Hadoop **versions** when packaging by using  
->`-Dspark.version=3.2.0` or `-Dhadoop.version=2.7.4` when running `sbt assembly`.
-If you have troubles with the versions you use, don't hesitate to **ask the community** in [GitHub discussions](https://github.com/Qbeast-io/qbeast-spark/discussions).
-``` bash
-git clone https://github.com/Qbeast-io/qbeast-spark.git
-
-cd qbeast-spark
-
-sbt assembly
-```
-
 ### 1. Launch a spark-shell
 
 **Inside the project folder**, launch a **spark shell** with the required dependencies:


### PR DESCRIPTION
## Description

After merging #96 I realized that there was still a reference to packaging in the README.md. Sorry about that!🙏🏼

I removed this reference, along with a redundant step in CONTRIBUTING.md, which was mentioning "git clone" when it was not required.

## Type of change

Documentation update.

Any suggestions or proposed changes are more than welcome!