### PR TITLE
Add lower bound for groupCubeSize

### DIFF
--- a/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
@@ -70,7 +70,7 @@ class QbeastSamplingTest extends QbeastIntegrationTestSpec {
         writeTestData(data, Seq("user_id", "product_id"), 1000, tmpDir)
 
         val df = spark.read.format("qbeast").load(tmpDir)
-        val precision = 0.1
+        val precision = 0.01
 
         val query = df.sample(withReplacement = false, precision)
         checkFileFiltering(query)


### PR DESCRIPTION
When the number of elements in a table is large, the `groupCubeSize` used by `CubeWeightsBuilder` tends to 1. This can leads to a large number of estimated Cube Weight pairs that can cause OOM errors.

For instance, using default values for `bufferCapacity` and `desiredCubeSize`, a table with 2600M records split between 1200 partitions, the `groupCubeSize` is 190. The algorithm estimates 37K cubes, among which only around 1K are used. The workaround is to set a minimum value for `groupCubeSize`, for instance 1000, so the number of estimated cubes won't be as large. Using this setting, the number of estimated cubes is reduced to about 5K.

Test added:
Using default `bufferCapacity` and `DesiredCubeSize`, make sure that the minimum value for `groupCubeSize` is respected for different `numElements`.
