### PR TITLE
Space limit

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
@@ -41,7 +41,7 @@ class QuerySpaceFromTo(private val from: Seq[Option[Double]], private val to: Se
   private def intersects(f: Double, t: Double, cube: CubeId, coordinate: Int): Boolean = {
     val cf = cube.from.coordinates(coordinate)
     val ct = cube.to.coordinates(coordinate)
-    (f <= cf && cf < t) || (cf <= f && f < ct)
+    (f <= cf && cf < t) || (cf <= f && f < ct) || (f == 1.0 && ct == 1.0)
   }
 
   override def intersectsWith(cube: CubeId): Boolean = {

--- a/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
@@ -20,9 +20,59 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
     querySpaceFromTo.intersectsWith(cube) shouldBe true
   }
 
-  it should "detect a wrong intersection" in {
-    val from = Seq(Some(2))
+  it should "not intersect with query space larger than the max value" in {
+    val from = Seq(Some(3))
     val to = Seq(Some(4))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
+
+    val cube = CubeId.root(3)
+    querySpaceFromTo.intersectsWith(cube) shouldBe false
+  }
+
+  it should "not intersect with query space smaller than the min value" in {
+    val from = Seq(Some(-1))
+    val to = Seq(Some(0))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
+
+    val cube = CubeId.root(3)
+    querySpaceFromTo.intersectsWith(cube) shouldBe false
+  }
+
+  it should "include the right limit" in {
+    val from = Seq(Some(2))
+    val to = Seq(Some(2))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
+
+    val cube = CubeId.root(3)
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "include the right limit and beyond" in {
+    val from = Seq(Some(2))
+    val to = Seq(Some(3))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
+
+    val cube = CubeId.root(3)
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "include the left limit" in {
+    val from = Seq(Some(1))
+    val to = Seq(Some(1))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
+
+    val cube = CubeId.root(3)
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "exclude the left limit and beyond" in {
+    val from = Seq(Some(-1))
+    val to = Seq(Some(1))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
     val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
 

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -208,4 +208,16 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
     val diff = allFiles.toSet -- matchFiles.toSet
     diff.size shouldBe 1
   })
+
+  it should "find the max value when filtering" in withSparkAndTmpDir((spark, tmpdir) => {
+    val source = createDF(50000, spark).toDF().coalesce(4)
+
+    writeTestData(source, Seq("a", "c"), 4000, tmpdir)
+
+    val indexed = spark.read.format("qbeast").load(tmpdir)
+
+    indexed.where("a == 50000").count shouldBe 1
+    indexed.where("c == 50000.0").count shouldBe 1
+  })
+
 }


### PR DESCRIPTION
When filtering with the max value from an indexed column, the QuerySpace filtering doesn't address the case because the right limit of a cube is always excluded.

The issue is addressed now by adding an additional condition where if the range left limit and the cube right limit are both 1.0, then we take the cube.

Fixes #111 

Test added to `QueryExecutorTest.scala`

* Spark Version: 3.1.1.
* Hadoop Version: 3.2.0
* Local test