### PR TITLE
Change random generation in Hash null values

### DIFF
--- a/core/src/main/scala/io/qbeast/core/transform/HashTransformation.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/HashTransformation.scala
@@ -7,7 +7,7 @@ import scala.util.hashing.MurmurHash3
  * A hash transformation of a coordinate
  * @param nullValue the value to use for null coordinates
  */
-case class HashTransformation(nullValue: Any = Random.nextString(10)) extends Transformation {
+case class HashTransformation(nullValue: Any = Random.nextInt()) extends Transformation {
 
   override def transform(value: Any): Double = {
     val v = if (value == null) nullValue else value

--- a/core/src/test/scala/io/qbeast/core/transform/HashTransformationTest.scala
+++ b/core/src/test/scala/io/qbeast/core/transform/HashTransformationTest.scala
@@ -20,9 +20,11 @@ class HashTransformationTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "create null value of length 10" in {
+  it should "create null value of random int" in {
     val ht = HashTransformation()
-    ht.nullValue.asInstanceOf[String].length should be(10)
+    val nullValue = ht.nullValue.asInstanceOf[Int]
+    nullValue should be >= Int.MinValue
+    nullValue should be < Int.MaxValue
   }
 
   "The murmur" should "uniformly distributed with Strings" in {


### PR DESCRIPTION
## Description

Fixed issue #112 

## Type of change

Describe the change you're making: how it affects the API, user experience...

It is a bug fix. We were using the method Random.nextString(10) to generate a random string for null values in hashed columns (such as `string` or specific `hash(x)`). Aside from the problems described in #112, according to the documentation this method is not recommended to be used in anything important.

Better to use the Random Int approach. 


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [ x ] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ x ] Add tests.
- [ x ] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Please describe the tests that you ran to verify your changes.

- Test: Created Test in `TransformerIndexingTest` where we generate a dataset with similar characteristics of Github Archive. 

**Test Configuration**:
* Spark Version: 3.1.2
* Hadoop Version: 3.2.0
* Cluster or local? Local