### PR TITLE
User a smaller lower-bound for groupCubeSize

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/CubeWeights.scala
+++ b/core/src/main/scala/io/qbeast/core/model/CubeWeights.scala
@@ -6,7 +6,7 @@ import io.qbeast.core.model.Weight.MaxValue
 import scala.collection.mutable
 
 object CubeWeightsBuilder {
-  val minGroupCubeSize = 1000
+  val minGroupCubeSize = 30
 
   /**
    * Estimates the groupCubeSize depending on the input parameters.
@@ -115,8 +115,8 @@ class CubeWeightsBuilder protected (
     }
     weights.map {
       case (cubeId, weightAndCount) if weightAndCount.count == groupCubeSize =>
-        val numGroups = desiredCubeSize / groupCubeSize
-        CubeNormalizedWeight(cubeId.bytes, NormalizedWeight(weightAndCount.weight) * numGroups)
+        val scale = desiredCubeSize / groupCubeSize
+        CubeNormalizedWeight(cubeId.bytes, NormalizedWeight(weightAndCount.weight) * scale)
       case (cubeId, weightAndCount) =>
         CubeNormalizedWeight(
           cubeId.bytes,

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
@@ -95,7 +95,7 @@ class QbeastSamplingTest extends QbeastIntegrationTestSpec {
         val df = spark.read.format("qbeast").load(tmpDir)
 
         // analyze and optimize the index 3 times
-        optimize(spark, tmpDir, 3)
+        optimize(spark, tmpDir, 1)
         val dataSize = data.count()
 
         df.count() shouldBe dataSize


### PR DESCRIPTION
Using 1000 as the lower-bound value for `groupCubeSize` is performing poorly for the `DoublePass` analyzer when it comes to respecting the `desiredCubeSize` of the index.

We propose to use a smaller value, 30, for the lower-bound. The change is tested against the TPC-DS 1tb store_sales dataset. The average cube size per level is improved in comparison to using gcs=1000.

* Spark Version: 3.1.3
* Hadoop Version: 3.2
* Cluster or local: Tested in both scenarios