### PR TITLE
Modify index metrics

### DIFF
--- a/docs/QbeastTable.md
+++ b/docs/QbeastTable.md
@@ -39,7 +39,7 @@ qbeastTable.optimize() // optimizes the cubes
 
 You can use it to **compare the index** build **with different indexing parameters** such as the `desiredCubeSize` and `columnsToIndex`.
 
-If you're experimenting with new ways of implementing the OTree algorithm, you can also use this API to analyze the resulting index!
+This is meant to be used as an easy access point to analyze the resulting index, which should come handy for comparing different index parameters or even implementations.
 
 ```scala
 val metrics = qbeastTable.getIndexMetrics()
@@ -48,45 +48,49 @@ println(metrics)
 
 // EXAMPLE OUTPUT
 
-OTree Index Metrics:
-dimensionCount: 2
-elementCount: 1001
-depth: 2
-cubeCounts: 7
-desiredCubeSize: 100
-avgFanOut: 2.0
-depthOverLogNumNodes: 0.7124143742160444
-depthOnBalance: 0.6020599913279624
-Non-lead Cube Size Stats:
-(All values are 0 if there's no non-leaf cubes):
-- min: 3729
-- firstQuartile: 3729
-- secondQuartile: 4832
-- thirdQuartile: 5084
-- max: 5084
-- dev: 2.0133907E7
+Tree Index Metrics:
+dimensionCount: 3
+elementCount: 2879966589
+depth: 7
+cubeCount: 22217
+desiredCubeSize: 500000
+avgFan0ut: 8.0
+depthOnBalance: 1.4740213633300192
+
+Non-Leaf Cube Size Stats
+Quantiles:
+- min: 482642
+- 1stQ: 542859
+- 2ndQ: 557161
+- 3rdQ: 576939
+- max: 633266
+- dev(l1, l2): (0.11743615196254953, 0.0023669553335121983)
+
+(level, average weight, average cube size):
+(0, (1.6781478192839184E-4,482642))
+(1, (0.001726577786432248,550513))
+(2, (0.014704148241220776,566831))
+(3, (0.1260420146029599,570841))
+(4, (0.7243052757165773, 557425))
+(5, (0.4040913470739245,527043))
+(6, (0.8873759316622165, 513460))
 ```
 
 ## Metrics
 ### 1. General index metadata:
 
-- **Desired cube size**: the desired cube size choosed by the user, or the one that was automatically calculated.
-- **Number of cubes**: the number of cubes in the index.
-- **Tree depth**: the number of levels of the tree.
-- **Average fan out of the cubes**: the average number of children per non-leaf cube. For this metric, it is better to get closer to `2^(numberOfDimensions)`.
-- **Dimension count**: the number of dimensions (indexed columns) in the index.
-- **Number of rows**: the total number of elements.
+- **dimensionCount**: the number of dimensions (indexed columns) in the index.
+- **elementCount**: the number of rows in the table.
+- **desiredCubeSize**: the desired cube size chosen at the moment of indexing.
+- **Number of cubes**: the number of nodes in the index tree.
+- **depth**: the number of levels in the tree.
+- **avgFanOut**: the average number of children per non-leaf cube. The max value for this metrics is `2 ^ dimensionCount`.
+- **depthOnBalance**: how far the depth of the tree is to the theoretical value if we were to have the same number of cubes and max fan out.
 
-### 2. Some more specific details such as:
-- **depthOverLogNumNodes = depth / log(cubeCounts)**
-- **depthOnBalance = depth / log(rowCount/desiredCubeSize)**
+### 2. Cube sizes for non-leaf cubes:
+`Non-leaf cube size stats` is meant to describe the distribution of inner cube sizes:
+- **min**, **max**, **quartiles**, and how far the cube sizes are from the `desiredCubeSize`(**l1 and l2 error**).
+- The average normalizedWeight and cube size per level.
 
-  both logs use **base = dimensionCount**
-
-### 3. Cube sizes for non-leaf cubes:
-- `NonLeafCubeSizeDetails` contains their **min**, **max**, **quantiles**, and how far each of the cube sizes are from the `desiredCubeSize`(**dev**).
-
-### 4. `Map[CubeId, CubeStatus]`
-- Some information from the map can be interesting to analyze - for example, the **distribution of cube weights**.
-
-  You can access this information through `metrics.cubeStatuses`.
+### 3. `Map[CubeId, CubeStatus]`
+- More information can be extracted from the index tree through `metrics.cubeStatuses`.

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -215,11 +215,11 @@ case class NonLeafCubeSizeDetails(
 
   override def toString: String = {
     s"""Non-leaf Cube Size Stats
-       |(All values are 0 if there's no non-leaf cubes):
+       |Quartiles:
        |- min: $min
-       |- firstQuartile: $firstQuartile
-       |- secondQuartile: $secondQuartile
-       |- thirdQuartile: $thirdQuartile
+       |- 1stQ: $firstQuartile
+       |- 2ndQ: $secondQuartile
+       |- 3rdQ: $thirdQuartile
        |- max: $max
        |- dev(l1, l2): ($l1_dev, $l2_dev)
        |""".stripMargin
@@ -247,7 +247,7 @@ case class IndexMetrics(
        |desiredCubeSize: $desiredCubeSize
        |avgFanOut: $avgFanOut
        |depthOnBalance: $depthOnBalance
-       |$nonLeafCubeSizeDetails
+       |\n$nonLeafCubeSizeDetails
        |${levelStats()}""".stripMargin
   }
 

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -104,18 +104,21 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       val cubeSize = 100
       writeTestData(data, columnsToIndex, cubeSize, tmpDir)
 
-      val qbeastTable = QbeastTable.forPath(spark, tmpDir)
-      val metrics = qbeastTable.getIndexMetrics()
+      val metrics = QbeastTable.forPath(spark, tmpDir).getIndexMetrics()
+      val details = metrics.nonLeafCubeSizeDetails
+
+      // scalastyle:off println
+      println(metrics)
+      // scalastyle:on
 
       metrics.elementCount shouldBe data.count()
       metrics.dimensionCount shouldBe columnsToIndex.size
-      metrics.nonLeafCubeSizeDetails.min shouldBe <=(metrics.nonLeafCubeSizeDetails.firstQuartile)
-      metrics.nonLeafCubeSizeDetails.firstQuartile shouldBe <=(
-        metrics.nonLeafCubeSizeDetails.secondQuartile)
-      metrics.nonLeafCubeSizeDetails.secondQuartile shouldBe <=(
-        metrics.nonLeafCubeSizeDetails.thirdQuartile)
-      metrics.nonLeafCubeSizeDetails.thirdQuartile shouldBe <=(metrics.nonLeafCubeSizeDetails.max)
       metrics.desiredCubeSize shouldBe cubeSize
+
+      details.min shouldBe <=(details.firstQuartile)
+      details.firstQuartile shouldBe <=(details.secondQuartile)
+      details.secondQuartile shouldBe <=(details.thirdQuartile)
+      details.thirdQuartile shouldBe <=(details.max)
 
     }
   }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -132,7 +132,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         val metrics = qbeastTable.getIndexMetrics()
 
         metrics.depth shouldBe 0
-        metrics.avgFanOut shouldBe Double.NaN
+        metrics.avgFanOut.isNaN shouldBe true
       }
     }
 }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -119,4 +119,20 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
 
     }
   }
+
+  it should "single cube tree correctly" in
+    withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+      {
+        val data = createDF(spark)
+        val columnsToIndex = Seq("age", "val2")
+        val cubeSize = 5000
+        writeTestData(data, columnsToIndex, cubeSize, tmpDir)
+
+        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+        val metrics = qbeastTable.getIndexMetrics()
+
+        metrics.depth shouldBe 0
+        metrics.avgFanOut shouldBe Double.NaN
+      }
+    }
 }


### PR DESCRIPTION
Modify index metrics computation. Some others statistics are added since during many experiments they are found useful.

Changes made:
- Add `L1`, `L2` errors to measure how inner cube sizes deviate from the `desiredCubeSize`, values are between 0 and 1.
- For inner cubes, add a method to display average normalizedWeight and cube size per level
- Compute `depthOnBalance` using geometrics sum since many indexes don't have a high number of levels
- Add test for single cube tree

How to use:
```scala
import io.qbeast.spark.QbeastTable

val path = "yourTablePath"
val metrics = QbeastTable.forPath(spark, path).getIndexMetrics()

println(metrics)
```

* Spark Version: 3.1.3
* Hadoop Version: 3.2
* Cluster or local? Local