### PR TITLE
Fix fanout

### DIFF
--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -119,10 +119,9 @@ class QbeastTable private (
       innerCubeStatuses.values.map(_.files.map(_.elementCount).sum).toSeq.sorted
     val innerCubeCount = innerCubeSizes.size.toDouble
 
-    val avgFanOut = innerCubeStatuses.keys
+    val avgFanOut = innerCubeStatuses.keys.toSeq
       .map(_.children.count(cubeStatuses.contains))
-      .sum
-      .toDouble / innerCubeCount
+      .sum / innerCubeCount
 
     val details =
       if (innerCubeCount == 0) {

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -86,7 +86,7 @@ class QbeastTable private (
     val dimensionCount = indexedColumns().size
     val desiredCubeSize = cubeSize()
 
-    val (avgFanOut, details) = getInnerCubeSizeDetails(allCubeStatuses, desiredCubeSize)
+    val (avgFanout, details) = getInnerCubeSizeDetails(allCubeStatuses, desiredCubeSize)
 
     IndexMetrics(
       allCubeStatuses,
@@ -95,7 +95,7 @@ class QbeastTable private (
       depth,
       cubeCount,
       desiredCubeSize,
-      avgFanOut,
+      avgFanout,
       depthOnBalance(depth, cubeCount, dimensionCount),
       details)
   }
@@ -119,7 +119,7 @@ class QbeastTable private (
       innerCubeStatuses.values.map(_.files.map(_.elementCount).sum).toSeq.sorted
     val innerCubeCount = innerCubeSizes.size.toDouble
 
-    val avgFanOut = innerCubeStatuses.keys.toSeq
+    val avgFanout = innerCubeStatuses.keys.toSeq
       .map(_.children.count(cubeStatuses.contains))
       .sum / innerCubeCount
 
@@ -158,7 +158,7 @@ class QbeastTable private (
           l2_dev,
           levelStats)
       }
-    (avgFanOut, details)
+    (avgFanout, details)
   }
 
   /**
@@ -250,7 +250,7 @@ case class IndexMetrics(
     depth: Int,
     cubeCount: Int,
     desiredCubeSize: Int,
-    avgFanOut: Double,
+    avgFanout: Double,
     depthOnBalance: Double,
     nonLeafCubeSizeDetails: NonLeafCubeSizeDetails) {
 
@@ -261,7 +261,7 @@ case class IndexMetrics(
        |depth: $depth
        |cubeCount: $cubeCount
        |desiredCubeSize: $desiredCubeSize
-       |avgFanOut: $avgFanOut
+       |avgFanout: $avgFanout
        |depthOnBalance: $depthOnBalance
        |\n$nonLeafCubeSizeDetails
        |""".stripMargin

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -114,6 +114,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       metrics.elementCount shouldBe data.count()
       metrics.dimensionCount shouldBe columnsToIndex.size
       metrics.desiredCubeSize shouldBe cubeSize
+      // If the tree has any inner node, avgFanout cannot be < 1.0
       metrics.avgFanout shouldBe >=(1.0)
 
       details.min shouldBe <=(details.firstQuartile)
@@ -129,14 +130,14 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       {
         val data = createDF(spark)
         val columnsToIndex = Seq("age", "val2")
-        val cubeSize = 5000
+        val cubeSize = 5000 // large cube size to make sure all elements are stored in the root
         writeTestData(data, columnsToIndex, cubeSize, tmpDir)
 
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
         val metrics = qbeastTable.getIndexMetrics()
 
         metrics.depth shouldBe 0
-        metrics.avgFanOut.isNaN shouldBe true
+        metrics.avgFanout.isNaN shouldBe true
       }
     }
 }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -114,6 +114,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       metrics.elementCount shouldBe data.count()
       metrics.dimensionCount shouldBe columnsToIndex.size
       metrics.desiredCubeSize shouldBe cubeSize
+      metrics.avgFanout shouldBe >=(1.0)
 
       details.min shouldBe <=(details.firstQuartile)
       details.firstQuartile shouldBe <=(details.secondQuartile)


### PR DESCRIPTION
## Description

Fix #122, convert map.key from set to seq before mapping.

## Type of change

Bug Fix

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Please describe the tests that you ran to verify your changes.

Test added to QbeastTableTest to account for scenarios where we have inner nodes but avgFanout is smaller than 1.0.

**Test Configuration**:
* Spark Version: 3.1.3
* Hadoop Version: 3.2
* Cluster or local? Local