### PR TITLE
Infer parameters when appending

### DIFF
--- a/src/main/scala/io/qbeast/spark/internal/sources/QbeastDataSource.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/QbeastDataSource.scala
@@ -65,9 +65,11 @@ class QbeastDataSource private[sources] (private val tableFactory: IndexedTableF
       mode: SaveMode,
       parameters: Map[String, String],
       data: DataFrame): BaseRelation = {
-    require(
-      parameters.contains("columnsToIndex"),
-      throw AnalysisExceptionFactory.create("'columnsToIndex is not specified"))
+    if (mode != SaveMode.Append) {
+      require(
+        parameters.contains("columnsToIndex"),
+        throw AnalysisExceptionFactory.create("'columnsToIndex' is not specified"))
+    }
     val tableId = SparkToQTypesUtils.loadFromParameters(parameters)
     val table = tableFactory.getIndexedTable(tableId)
     mode match {

--- a/src/main/scala/io/qbeast/spark/internal/sources/QbeastDataSource.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/QbeastDataSource.scala
@@ -65,11 +65,11 @@ class QbeastDataSource private[sources] (private val tableFactory: IndexedTableF
       mode: SaveMode,
       parameters: Map[String, String],
       data: DataFrame): BaseRelation = {
-    if (mode != SaveMode.Append) {
-      require(
-        parameters.contains("columnsToIndex"),
-        throw AnalysisExceptionFactory.create("'columnsToIndex' is not specified"))
-    }
+
+    require(
+      parameters.contains("columnsToIndex") || mode == SaveMode.Append,
+      throw AnalysisExceptionFactory.create("'columnsToIndex' is not specified"))
+
     val tableId = SparkToQTypesUtils.loadFromParameters(parameters)
     val table = tableFactory.getIndexedTable(tableId)
     mode match {

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -8,6 +8,7 @@ import io.qbeast.core.model._
 import io.qbeast.spark.delta.CubeDataLoader
 import io.qbeast.spark.index.QbeastColumns
 import io.qbeast.spark.internal.QbeastOptions
+import io.qbeast.spark.internal.QbeastOptions.{COLUMNS_TO_INDEX, CUBE_SIZE}
 import io.qbeast.spark.internal.sources.QbeastBaseRelation
 import org.apache.spark.qbeast.config.DEFAULT_NUMBER_OF_RETRIES
 import org.apache.spark.sql.delta.actions.FileAction
@@ -143,6 +144,26 @@ private[table] class IndexedTableImpl(
 
   }
 
+  /**
+   * Add the required indexing parameters when the SaveMode is Append.
+   * The user-provided parameters are respected.
+   * @param latestRevision the latest revision
+   * @param params the parameters required for indexing
+   */
+  private def addRequiredParams(
+      latestRevision: Revision,
+      parameters: Map[String, String]): Map[String, String] = {
+    val columnsToIndex = latestRevision.columnTransformers.map(_.columnName).mkString(",")
+    val desiredCubeSize = latestRevision.desiredCubeSize.toString
+    (parameters.contains(COLUMNS_TO_INDEX), parameters.contains(CUBE_SIZE)) match {
+      case (true, true) => parameters
+      case (false, false) =>
+        parameters + (COLUMNS_TO_INDEX -> columnsToIndex, CUBE_SIZE -> desiredCubeSize)
+      case (true, false) => parameters + (CUBE_SIZE -> desiredCubeSize)
+      case (false, true) => parameters + (COLUMNS_TO_INDEX -> columnsToIndex)
+    }
+  }
+
   override def save(
       data: DataFrame,
       parameters: Map[String, String],
@@ -150,12 +171,13 @@ private[table] class IndexedTableImpl(
     val indexStatus =
       if (exists && append) {
         val latestIndexStatus = snapshot.loadLatestIndexStatus
-        if (checkRevisionParameters(QbeastOptions(parameters), latestIndexStatus)) {
+        val updatedParameters = addRequiredParams(latestIndexStatus.revision, parameters)
+        if (checkRevisionParameters(QbeastOptions(updatedParameters), latestIndexStatus)) {
           latestIndexStatus
         } else {
           val oldRevisionID = latestIndexStatus.revision.revisionID
           val newRevision = revisionBuilder
-            .createNextRevision(tableID, data.schema, parameters, oldRevisionID)
+            .createNextRevision(tableID, data.schema, updatedParameters, oldRevisionID)
           IndexStatus(newRevision)
         }
       } else {

--- a/src/test/scala/io/qbeast/spark/internal/sources/QbeastDataSourceTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/QbeastDataSourceTest.scala
@@ -157,7 +157,7 @@ class QbeastDataSourceTest extends FixtureAnyFlatSpec with MockitoSugar with Mat
     val parameters = Map("path" -> path)
     val data = mock[DataFrame]
     a[AnalysisException] shouldBe thrownBy {
-      f.dataSource.createRelation(f.sqlContext, SaveMode.Append, parameters, data)
+      f.dataSource.createRelation(f.sqlContext, SaveMode.Overwrite, parameters, data)
     }
   }
 

--- a/src/test/scala/io/qbeast/spark/utils/QbeastDataSourceIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastDataSourceIntegrationTest.scala
@@ -168,4 +168,88 @@ class QbeastDataSourceIntegrationTest extends QbeastIntegrationTestSpec {
       }
     }
 
+  "Appending to an existing qbeast table" should
+    "work without specifying cubeSize or columnsToIndex" in withQbeastContextSparkAndTmpDir {
+      (spark, tmpDir) =>
+        {
+          val original = loadTestData(spark)
+          original.write
+            .format("qbeast")
+            .option("cubeSize", 10000)
+            .option("columnsToIndex", "user_id,product_id")
+            .save(tmpDir)
+
+          original.write
+            .mode("append")
+            .format("qbeast")
+            .save(tmpDir)
+          val qDf = spark.read.format("qbeast").load(tmpDir)
+
+          qDf.count shouldBe original.count * 2
+        }
+    }
+
+  it should "work without specifying columnsToIndex" in
+    withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+      {
+        val original = loadTestData(spark)
+        original.write
+          .format("qbeast")
+          .option("cubeSize", 10000)
+          .option("columnsToIndex", "user_id,product_id")
+          .save(tmpDir)
+
+        original.write
+          .mode("append")
+          .format("qbeast")
+          .option("cubeSize", 10000)
+          .save(tmpDir)
+        val qDf = spark.read.format("qbeast").load(tmpDir)
+
+        qDf.count shouldBe original.count * 2
+      }
+    }
+
+  it should "work without specifying columnsToIndex" +
+    "while cause revision change by using a different cubeSize" in
+    withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+      {
+        val original = loadTestData(spark)
+        original.write
+          .format("qbeast")
+          .option("cubeSize", 10000)
+          .option("columnsToIndex", "user_id,product_id")
+          .save(tmpDir)
+
+        original.write
+          .mode("append")
+          .format("qbeast")
+          .option("cubeSize", 5000)
+          .save(tmpDir)
+        val qDf = spark.read.format("qbeast").load(tmpDir)
+
+        qDf.count shouldBe original.count * 2
+      }
+    }
+
+  it should "append to an existing qbeast table without specifying cubeSize" in
+    withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+      {
+        val original = loadTestData(spark)
+        original.write
+          .format("qbeast")
+          .option("cubeSize", 10000)
+          .option("columnsToIndex", "user_id,product_id")
+          .save(tmpDir)
+
+        original.write
+          .mode("append")
+          .format("qbeast")
+          .option("columnsToIndex", "user_id,product_id")
+          .save(tmpDir)
+        val qDf = spark.read.format("qbeast").load(tmpDir)
+
+        qDf.count shouldBe original.count * 2
+      }
+    }
 }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastDataSourceIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastDataSourceIntegrationTest.scala
@@ -5,6 +5,7 @@ package io.qbeast.spark.utils
 
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.delta.DeltaQbeastSnapshot
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.functions._
 
@@ -252,4 +253,19 @@ class QbeastDataSourceIntegrationTest extends QbeastIntegrationTestSpec {
         qDf.count shouldBe original.count * 2
       }
     }
+
+  "Appending to an non-existing table" should
+    "throw an exception if 'columnsToIndex' is not provided" in withQbeastContextSparkAndTmpDir {
+      (spark, tmpDir) =>
+        {
+          val original = loadTestData(spark)
+          a[AnalysisException] shouldBe thrownBy {
+            original.write
+              .format("qbeast")
+              .option("cubeSize", 10000)
+              .save(tmpDir)
+          }
+        }
+    }
+
 }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastDataSourceIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastDataSourceIntegrationTest.scala
@@ -210,7 +210,7 @@ class QbeastDataSourceIntegrationTest extends QbeastIntegrationTestSpec {
       }
     }
 
-  it should "work without specifying columnsToIndex" +
+  it should "work without specifying columnsToIndex " +
     "while cause revision change by using a different cubeSize" in
     withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
       {


### PR DESCRIPTION
## Description
Fixes #81.

As described in #81, we want the `Append` operations to existing qbeast tables to be able to omit providing values for `desiredCubeSize` and `columnsToIndex`, if there's no desire to create a new revision.

Instead of
```
df.write
  .mode("append")
  .format("qbeast")
  .option("cubeSize", cs)
  .option("columnsToIndex", cti)
  .save("path-to-existing-qtable")
```
we want to be able to just do the following instead:
```
df.write
  .mode("append")
  .format("qbeast")
  .save("path-to-existing-qtable")
```

If the user was to provide any value for `cubeSize` and/or `columnsToIndex` when appending, then they will be respected. If the values provided are different than that from the last revision, a new revision should be created for the Append operation.

My assumption for this PR is that , at the moment, we are only aware of revision changes when `desiredCubeSize` changes, not when `columnsToIndex` is changed. The changes made has considerations when the 'desiredCubeSize' is modified.

## Type of change

This change is an `enhancement`.

- Fixes #81 

- Adds a new feature - Appending to existing table without providing indexing params when no revision change is wanted.

- No **Breaking change** introduced

- No documentation change required


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## Tests

When appending, tests for the following scenarios are added:
- User provide no value for neither `cubeSize` or `columnsToIndex`:
```
df.write
  .mode("append")
  .format("qbeast")
  .save("path-to-existing-qtable")
```
- Only `cubeSize` is provided, regardless of the last `cubeSize` value:
```
df.write
  .mode("append")
  .format("qbeast")
  .option("cubeSize", cs)
  .save("path-to-existing-qtable")
```
- Only `columnsToIndex` is provided. It has **NOT** been tested when the values are different than that from the last revision:
```
df.write
  .mode("append")
  .format("qbeast")
  .option("columnsToIndex", cti)
  .save("path-to-existing-qtable")
```

**Test Configuration**:
* Spark Version: `3.1.3`
* Hadoop Version: `3.2`
* Cluster or local? `Local`