### PR TITLE
Fixed indexing columns with unique values

### DIFF
--- a/core/src/main/scala/io/qbeast/core/transform/LinearTransformation.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/LinearTransformation.scala
@@ -77,7 +77,7 @@ case class LinearTransformation(
           otherNullValue,
           orderedDataType)
           .asInstanceOf[Transformation]
-      case IdentityTransformation(newVal) =>
+      case IdentityToZeroTransformation(newVal) =>
         val otherNullValue =
           LinearTransformationUtils.generateRandomNumber(
             min(minNumber, newVal),
@@ -104,7 +104,7 @@ case class LinearTransformation(
       case LinearTransformation(newMin, newMax, _, otherOrdering)
           if orderedDataType == otherOrdering =>
         gt(minNumber, newMin) || lt(maxNumber, newMax)
-      case IdentityTransformation(newVal) =>
+      case IdentityToZeroTransformation(newVal) =>
         gt(minNumber, newVal) || lt(maxNumber, newVal)
     }
 

--- a/core/src/main/scala/io/qbeast/core/transform/LinearTransformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/LinearTransformer.scala
@@ -40,7 +40,7 @@ case class LinearTransformer(columnName: String, dataType: QDataType) extends Tr
       NullToZeroTransformation
     } else if (minAux == maxAux) {
       // If both values are equal we return an IdentityTransformation
-      IdentityTransformation(minAux)
+      IdentityToZeroTransformation(minAux)
     } else { // otherwhise we pick the min and max
       val min = getValue(minAux)
       val max = getValue(maxAux)

--- a/core/src/main/scala/io/qbeast/core/transform/Transformation.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/Transformation.scala
@@ -47,12 +47,11 @@ trait OrdinalTransformation extends Transformation {
 /**
  * Identity transformation.
  */
-case class IdentityTransformation(newVal: Any) extends Transformation {
+case class IdentityToZeroTransformation(identityValue: Any) extends Transformation {
 
   @inline
   override def transform(value: Any): Double = value match {
-    case v: Number =>
-      v.byteValue()
+    case v: Number if v == identityValue => 0.0
   }
 
   override def isSupersededBy(newTransformation: Transformation): Boolean = false

--- a/core/src/test/scala/io/qbeast/core/transform/LinearTransformationTest.scala
+++ b/core/src/test/scala/io/qbeast/core/transform/LinearTransformationTest.scala
@@ -82,7 +82,7 @@ class LinearTransformationTest extends AnyFlatSpec with Matchers {
 
     var otherNullValue =
       LinearTransformationUtils.generateRandomNumber(0, 90000, Option(42.toLong))
-    linearT.merge(IdentityTransformation(90000)) shouldBe LinearTransformation(
+    linearT.merge(IdentityToZeroTransformation(90000)) shouldBe LinearTransformation(
       0,
       90000,
       otherNullValue,
@@ -90,14 +90,14 @@ class LinearTransformationTest extends AnyFlatSpec with Matchers {
 
     otherNullValue =
       LinearTransformationUtils.generateRandomNumber(-100, 10000, Option(42.toLong))
-    linearT.merge(IdentityTransformation(-100)) shouldBe LinearTransformation(
+    linearT.merge(IdentityToZeroTransformation(-100)) shouldBe LinearTransformation(
       -100,
       10000,
       otherNullValue,
       IntegerDataType)
 
     otherNullValue = LinearTransformationUtils.generateRandomNumber(0, 10000, Option(42.toLong))
-    linearT.merge(IdentityTransformation(10)) shouldBe LinearTransformation(
+    linearT.merge(IdentityToZeroTransformation(10)) shouldBe LinearTransformation(
       0,
       10000,
       otherNullValue,
@@ -108,11 +108,11 @@ class LinearTransformationTest extends AnyFlatSpec with Matchers {
     val nullValue = 5000
     val linearT = LinearTransformation(0, 10000, nullValue, IntegerDataType)
 
-    linearT.isSupersededBy(IdentityTransformation(90000)) shouldBe true
+    linearT.isSupersededBy(IdentityToZeroTransformation(90000)) shouldBe true
 
-    linearT.isSupersededBy(IdentityTransformation(-100)) shouldBe true
+    linearT.isSupersededBy(IdentityToZeroTransformation(-100)) shouldBe true
 
-    linearT.isSupersededBy(IdentityTransformation(10)) shouldBe false
+    linearT.isSupersededBy(IdentityToZeroTransformation(10)) shouldBe false
 
   }
 }

--- a/src/test/scala/io/qbeast/spark/index/TransformerIndexingTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/TransformerIndexingTest.scala
@@ -234,7 +234,7 @@ class TransformerIndexingTest extends AnyFlatSpec with Matchers with QbeastInteg
       import spark.implicits._
       val source = 0
         .to(100000)
-        .map(i => TestNull(Some(s"student$i"), Some(1), Some(i * 2)))
+        .map(i => TestNull(Some(s"student$i"), Some(10), Some(i)))
         .toDF()
         .as[TestNull]
 


### PR DESCRIPTION
## Description


Fixes #128. 

## Type of change

When indexing a column with the same value, an IdentityTransformation is instantiated. A Transformation is in charge of mapping the original values of the column to a [0.0, 1.0] space. In the case of IdentityTransformation, the method was returning the `value.byteValue()`, which can give you a `Double` up to 2^8. 

We solved this by changing `IdentityTransformation` to `IdentityToZeroTransformation` and returning 0.0 if the number corresponds to the transformation value.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

- I changed one line of an existing test because this was badly designed. It checked if qbeast could index a column with the same value, but that value was 1. So, when transforming the value, it was in the [0.0, 1.0] range and no requirement failed. I change this value to 10.