### PR TITLE
126 enrich filtering support

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
@@ -45,9 +45,11 @@ class QuerySpaceFromTo(private val from: Seq[Option[Double]], private val to: Se
   }
 
   override def intersectsWith(cube: CubeId): Boolean = {
+    val epsilon = 1.1103e-16
+
     from.zip(to).zipWithIndex.forall {
-      case ((Some(f), Some(t)), i) => intersects(f, t, cube, i)
-      case ((None, Some(t)), i) => intersects(0.0, t, cube, i)
+      case ((Some(f), Some(t)), i) => intersects(f, t + epsilon, cube, i)
+      case ((None, Some(t)), i) => intersects(0.0, t + epsilon, cube, i)
       case ((Some(f), None), i) => intersects(f, 1.0, cube, i)
       case ((None, None), _) => true
     }

--- a/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
@@ -45,6 +45,7 @@ class QuerySpaceFromTo(private val from: Seq[Option[Double]], private val to: Se
   }
 
   override def intersectsWith(cube: CubeId): Boolean = {
+    // Use epsilon to support LessThanOrEqual: x <= t is approximated by x < t + epsilon
     val epsilon = 1.1103e-16
 
     from.zip(to).zipWithIndex.forall {

--- a/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
@@ -70,7 +70,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
     querySpaceFromTo.intersectsWith(cube) shouldBe true
   }
 
-  it should "include cube when ct < t + epsilon, though not really desired" in {
+  it should "include query range to, though not really desired" in {
     val from = Seq(Some(-1))
     val to = Seq(Some(1))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))

--- a/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
@@ -70,9 +70,19 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
     querySpaceFromTo.intersectsWith(cube) shouldBe true
   }
 
-  it should "exclude the left limit and beyond" in {
+  it should "include cube when ct < t + epsilon, though not really desired" in {
     val from = Seq(Some(-1))
     val to = Seq(Some(1))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
+
+    val cube = CubeId.root(3)
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "exclude beyond left limit" in {
+    val from = Seq(Some(-1))
+    val to = Seq(Some(0))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
     val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
 

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -12,9 +12,11 @@ import org.apache.spark.sql.catalyst.expressions.{
   BinaryComparison,
   EqualTo,
   Expression,
+  GreaterThan,
   GreaterThanOrEqual,
   IsNull,
   LessThan,
+  LessThanOrEqual,
   Literal,
   SubqueryExpression
 }
@@ -101,6 +103,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
         // if not found, use the overall coordinates
         val from = columnFilters
           .collectFirst {
+            case GreaterThan(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case GreaterThanOrEqual(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case EqualTo(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case IsNull(_) => null
@@ -109,6 +112,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
         val to = columnFilters
           .collectFirst {
             case LessThan(_, Literal(value, _)) => sparkTypeToCoreType(value)
+            case LessThanOrEqual(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case EqualTo(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case IsNull(_) => null
           }

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -220,4 +220,20 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
     indexed.where("c == 50000.0").count shouldBe 1
   })
 
+  it should "filter correctly using GreaterThan and LessThanOrEqual" in withSparkAndTmpDir(
+    (spark, tmpdir) => {
+      val source = createDF(50000, spark).toDF().coalesce(4)
+
+      writeTestData(source, Seq("a", "c"), 4000, tmpdir)
+
+      val indexed = spark.read.format("qbeast").load(tmpdir)
+
+      indexed.where("a > 1").count shouldBe 49999
+      indexed.where("a > 49999").count shouldBe 1
+
+      indexed.where("a <= 1").count shouldBe 2
+      indexed.where("a <= 49999").count shouldBe 50000
+
+    })
+
 }

--- a/src/test/scala/io/qbeast/spark/index/query/QuerySpecBuilderTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QuerySpecBuilderTest.scala
@@ -144,6 +144,19 @@ class QuerySpecBuilderTest
 
   })
 
+  it should "leverage otree index when filtering with GreaterThan and LessThanOrEqual" in withSpark(
+    spark => {
+      val (f, t) = (3, 8)
+
+      val expressions = Seq(expr(s"id > $f AND id <= $t").expr)
+      val revision = createRevision()
+      val querySpace = new QuerySpecBuilder(expressions).build(revision).querySpace
+      val idTransformation = LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType)
+
+      querySpace invokePrivate privateFrom() shouldBe Seq(Some(idTransformation.transform(f)))
+      querySpace invokePrivate privateTo() shouldBe Seq(Some(idTransformation.transform(t)))
+    })
+
   "extractDataFilters" should "extract qbeast filters correctly" in withSpark(spark => {
     val revision = createRevision()
     val rangeExpression = expr(s"id >= 3 OR id < 8").expr


### PR DESCRIPTION
## Description
Close #126

New feature - adding filtering support for `GreaterThan` and `LessThanOrEqual`.

`GreaterThan` is achieved by its simple addition to `from` filter selection, while the addition of `LessThanOrEqual` requires extending `to` by `epsilon`.

The value of `epsilon` is set to `1.1103e-16` for it's about to be the smallest number that satisfies `t < t + epsilon`(with `t = 1.0` or any one decimal point).

The drawback of this approach is that we might occasionally read more cubes than we should, though the probability is low: when using `LessThanOrEqual` and `t <= ct < t + epsilon`, we include the sibling cube (one that has `cf <= t + epsilon`) when we shouldn't. It takes about `log2(1 / epsilon) ~= 53` levels for the cubes to start having dimensions smaller than epsilon; in that case, extending `t` by `epsilon` can cause adding several extra cubes.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).
- [ ] Change the documentation.

## How Has This Been Tested? (Optional)

Please describe the tests that you ran to verify your changes.

Test added to `QuerySpecBuilderTest` makes sure that `GreaterThan` and `LessThanOrEqual` are taken into account.
Test added to `QueryExecutorTest` ensures that queries involving `GreaterThan` and `LessThanOrEqual` are executed correctly.

**Test Configuration**:
* Spark Version: `3.1.2`
* Hadoop Version: `3.2.0`
* Cluster or local? `Local`