### PR TITLE
135 the same cubeid with different hashcodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ project/plugins/project/
 .worksheet
 .idea
 
+# VSCode specific
+.bloop/
+.metals/
+.vscode/
+metals.sbt
+
 # publication project
 nodep
 

--- a/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
@@ -23,6 +23,19 @@ class CubeIdTest extends AnyFlatSpec with Matchers {
     id1 == id2 shouldBe false
     id3 == id4 shouldBe false
     id1 == id5 shouldBe false
+    val id6 =
+      CubeId(2, "wQwwwQwwQwwQwwwwwQwQwwwQQwwwwQQwQwwwQwwQwwQwwwwwQwwQQQQQQQQQQQQQQ").parent.get
+    val id7 =
+      CubeId(2, "wQwwwQwwQwwQwwwwwQwQwwwQQwwwwQQwQwwwQwwQwwQwwwwwQwwQQQQQQQQQQQQQ")
+    id6 == id7 shouldBe true
+  }
+
+  it should "implement hashCode correctly" in {
+    val id1 =
+      CubeId(2, "wQwwwQwwQwwQwwwwwQwQwwwQQwwwwQQwQwwwQwwQwwQwwwwwQwwQQQQQQQQQQQQQQ").parent.get
+    val id2 =
+      CubeId(2, "wQwwwQwwQwwQwwwwwQwQwwwQQwwwwQQwQwwwQwwQwwQwwwwwQwwQQQQQQQQQQQQQ")
+    id1.hashCode() == id2.hashCode() shouldBe true
   }
 
   it should "implement conversion to byte array correctly" in {


### PR DESCRIPTION
## Description

Fixes [The same CubeId with different hashCodes](https://github.com/Qbeast-io/qbeast-spark/issues/135).
The PR proposes to change implementations of equals and `hashCode` of the `CubeId` class so the `bitMask` arrays are compared without possible trailing zeros. The same approach is implemented for `CubeId.isAncestor` method.

A note on performance: removing trailing zeros for every call to `equals`, `hashCode`, and `isAncestor` seems to be cheap enough, because for the majority of CubeId instances do not have trailing zeros in their `bitMask`, in such cases the new `trimBitMask` function returns the same array on discovering that the last element of the array is not 0.

@osopardo1 @Jiaweihu08 could you please review, thank you.

## Type of change

This is a bug fix. The existing API was not modified, no new API was added.

## How Has This Been Tested?

The examples to reproduce the bug were added to existing tests of the affected CubeId methods. 