### PR TITLE
Improved double pass

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/CubeWeights.scala
+++ b/core/src/main/scala/io/qbeast/core/model/CubeWeights.scala
@@ -63,7 +63,7 @@ class CubeWeightsBuilder protected (
 
   private val byWeight = Ordering.by[PointWeightAndParent, Weight](_.weight).reverse
   protected val queue = new mutable.PriorityQueue[PointWeightAndParent]()(byWeight)
-  private var resultBuffer = Seq.empty[CubeNormalizedWeight]
+  private var resultBuffer = Seq.empty[LocalTree]
 
   /**
    * Updates the builder with given point with weight.
@@ -77,7 +77,8 @@ class CubeWeightsBuilder protected (
   def update(point: Point, weight: Weight, parent: Option[CubeId] = None): CubeWeightsBuilder = {
     queue.enqueue(PointWeightAndParent(point, weight, parent))
     if (queue.size >= bufferCapacity) {
-      resultBuffer ++= resultInternal()
+      val unpopulatedTree = resultInternal()
+      resultBuffer = resultBuffer :+ populateTreeSize(unpopulatedTree).toMap
       queue.clear()
     }
     this
@@ -88,11 +89,16 @@ class CubeWeightsBuilder protected (
    *
    * @return the resulting cube weights map
    */
-  def result(): Seq[CubeNormalizedWeight] = {
-    resultInternal() ++ resultBuffer
+  def result(): Seq[LocalTree] = {
+    val unpopulatedTree = resultInternal()
+    if (unpopulatedTree.nonEmpty) {
+      resultBuffer :+ populateTreeSize(unpopulatedTree).toMap
+    } else {
+      resultBuffer
+    }
   }
 
-  def resultInternal(): Seq[CubeNormalizedWeight] = {
+  def resultInternal(): mutable.Map[CubeId, CubeInfo] = {
     val weights = mutable.Map.empty[CubeId, WeightAndCount]
     while (queue.nonEmpty) {
       val PointWeightAndParent(point, weight, parent) = queue.dequeue()
@@ -113,15 +119,47 @@ class CubeWeightsBuilder protected (
         }
       }
     }
-    weights.map {
-      case (cubeId, weightAndCount) if weightAndCount.count == groupCubeSize =>
-        val scale = desiredCubeSize / groupCubeSize
-        CubeNormalizedWeight(cubeId.bytes, NormalizedWeight(weightAndCount.weight) * scale)
-      case (cubeId, weightAndCount) =>
-        CubeNormalizedWeight(
-          cubeId.bytes,
-          NormalizedWeight(desiredCubeSize, weightAndCount.count))
-    }.toSeq
+
+    weights
+      .map {
+        case (cubeId, weightAndCount) if weightAndCount.count == groupCubeSize =>
+          val nw = NormalizedWeight(weightAndCount.weight)
+          (cubeId, CubeInfo(nw, groupCubeSize))
+
+        case (cubeId, weightAndCount) =>
+          val nw = NormalizedWeight(desiredCubeSize, weightAndCount.count)
+          (cubeId, CubeInfo(nw, weightAndCount.count))
+      }
+  }
+
+  /**
+   * Populate cube tree sizes for all existing cubes in the tree
+   * @param cubeMap local tree
+   * @return
+   */
+  def populateTreeSize(cubeMap: mutable.Map[CubeId, CubeInfo]): mutable.Map[CubeId, CubeInfo] = {
+    // This could have been implemented in the DFS fashion if it wasn't for
+    // the optimization processes where we don't know the cubes the DFS traversal
+    // should begin with.
+    // Unlike the global index, the local trees are assumed to have no corrupt branches.
+
+    // TODO: Alternatively, we can usd DFS on cubes that don't have parent nodes
+    //  in the map as the starting cubes. This is to be discussed.
+    val levelCubes = cubeMap.keys.groupBy(_.depth)
+    val minLevel = levelCubes.keys.min
+    val maxLevel = levelCubes.keys.max
+    (maxLevel until minLevel by -1) foreach { level =>
+      // We group cubes by their parent cube to avoid copying CubeInfo too many times
+      // An alternative is to use a var for treeSize in CubeInfo, but we don't want
+      // this value to be modified once the values are populated.
+      levelCubes(level).groupBy(c => c.parent.get) foreach { case (parent, siblings) =>
+        val parentCubeInfo = cubeMap(parent)
+        var treeSize = parentCubeInfo.treeSize
+        siblings.foreach(c => treeSize += cubeMap(c).treeSize)
+        cubeMap(parent) = parentCubeInfo.copy(treeSize = treeSize)
+      }
+    }
+    cubeMap
   }
 
 }
@@ -143,10 +181,4 @@ private class WeightAndCount(var weight: Weight, var count: Int)
  */
 protected case class PointWeightAndParent(point: Point, weight: Weight, parent: Option[CubeId])
 
-/**
- * Cube and NormalizedWeight
- *
- * @param cubeBytes        the cube
- * @param normalizedWeight the weight
- */
-case class CubeNormalizedWeight(cubeBytes: Array[Byte], normalizedWeight: NormalizedWeight)
+case class CubeInfo(normalizedWeight: NormalizedWeight, treeSize: Double)

--- a/core/src/main/scala/io/qbeast/core/model/package.scala
+++ b/core/src/main/scala/io/qbeast/core/model/package.scala
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 package object model {
   type NormalizedWeight = Double
   type RevisionID = Long
+  type LocalTree = Map[CubeId, CubeInfo]
 
   /**
    * ReplicatedSet is used to represent a set of CubeId's that had been replicated

--- a/core/src/test/scala/io/qbeast/core/model/CubeWeightsBuilderTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/CubeWeightsBuilderTest.scala
@@ -4,21 +4,14 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.util.Random
+import scala.collection.mutable
 
 class CubeWeightsBuilderTest extends AnyFlatSpec with Matchers {
 
   private val point = Point(0.66, 0.28)
-  private val numDimensions = point.coordinates.length
   private val List(root, id10, id1001) = CubeId.containers(point).take(3).toList
 
-  case class CubeWeightTesting(cube: CubeId, normalizedWeight: NormalizedWeight)
-
-  object CubeWeightTesting {
-
-    def apply(cubeWeight: CubeNormalizedWeight): CubeWeightTesting =
-      CubeWeightTesting(CubeId(numDimensions, cubeWeight.cubeBytes), cubeWeight.normalizedWeight)
-
-  }
+  case class CubeAndInfoTesting(cube: CubeId, info: CubeInfo)
 
   class CubeWeightsBuilderTesting(
       desiredCubeSize: Int,
@@ -33,9 +26,13 @@ class CubeWeightsBuilderTest extends AnyFlatSpec with Matchers {
 
   "CubeWeightsBuilder" should "calculate maxWeight for the roots" in {
     val builder = new CubeWeightsBuilderTesting(10, 10, 100000)
+
     Random.shuffle(0.to(100).toList).foreach { value => builder.update(point, Weight(value)) }
-    val weights = builder.result().map(CubeWeightTesting.apply)
-    weights.find(_.cube.equals(root)).get.normalizedWeight shouldBe Weight(9).fraction
+
+    val localTree = builder.result().head
+
+    localTree(root).normalizedWeight shouldBe Weight(9).fraction
+    localTree(root).treeSize shouldBe 101d
   }
 
   it should "give the same results whether the data is sorted or not" in {
@@ -45,73 +42,148 @@ class CubeWeightsBuilderTest extends AnyFlatSpec with Matchers {
     Random.shuffle(0.to(1000).toList).foreach { value =>
       randomBuilder.update(point, Weight(value))
     }
+
     0.to(1000).foreach { value => sortedBuilder.update(point, Weight(value)) }
-    randomBuilder.result().map(CubeWeightTesting.apply) shouldBe sortedBuilder
-      .result()
-      .map(CubeWeightTesting.apply)
+
+    val randomTree = randomBuilder.result().head
+    val sortedTree = sortedBuilder.result().head
+
+    randomTree == sortedTree shouldBe true
   }
 
   it should "add weights to the cube until it is full" in {
     val builder = new CubeWeightsBuilderTesting(2, 2, 100000)
+
     builder.update(point, Weight(1))
     builder.update(point, Weight(2))
     builder.update(point, Weight(3))
     builder.update(point, Weight(4))
-    builder.result().map(CubeWeightTesting.apply) shouldBe Seq(
-      CubeWeightTesting(root, Weight(2).fraction),
-      CubeWeightTesting(id10, Weight(4).fraction))
+
+    builder
+      .result()
+      .head
+      .toSeq shouldBe Seq(
+      (root, CubeInfo(Weight(2).fraction, 4)),
+      (id10, CubeInfo(Weight(4).fraction, 2)))
   }
 
   it should "assign a the correct normalized maxWeight if the cube is not full" in {
     val builder = new CubeWeightsBuilderTesting(2, 2, 100000)
+
     builder.update(point, Weight(1))
     builder.update(point, Weight(2))
     builder.update(point, Weight(3))
     builder.update(point, Weight(4))
     builder.update(point, Weight(5))
-    builder.result().map(CubeWeightTesting.apply) shouldBe Seq(
-      CubeWeightTesting(root, Weight(2).fraction),
-      CubeWeightTesting(id10, Weight(4).fraction),
-      CubeWeightTesting(id1001, 2.0))
+
+    builder
+      .result()
+      .head
+      .toSeq shouldBe Seq(
+      (root, CubeInfo(Weight(2).fraction, 5)),
+      (id10, CubeInfo(Weight(4).fraction, 3)),
+      (id1001, CubeInfo(2.0, 1)))
   }
 
   it should "move the biggest maxWeight to a child cube if the cube is full" in {
     val builder = new CubeWeightsBuilderTesting(2, 2, 100000)
+
     builder.update(point, Weight(5))
     builder.update(point, Weight(6))
     builder.update(point, Weight(3))
     builder.update(point, Weight(4))
     builder.update(point, Weight(1))
     builder.update(point, Weight(2))
-    builder.result().map(CubeWeightTesting.apply) shouldBe Seq(
-      CubeWeightTesting(root, Weight(2).fraction),
-      CubeWeightTesting(id10, Weight(4).fraction),
-      CubeWeightTesting(id1001, Weight(6).fraction))
+
+    builder
+      .result()
+      .head
+      .toSeq shouldBe Seq(
+      (root, CubeInfo(Weight(2).fraction, 6)),
+      (id10, CubeInfo(Weight(4).fraction, 4)),
+      (id1001, CubeInfo(Weight(6).fraction, 2)))
   }
 
   it should "add maxWeight to the child of announced cube" in {
     val builder =
       new CubeWeightsBuilderTesting(1, 1, 100000, announcedOrReplicatedSet = Set(root))
+
     builder.update(point, Weight(2))
-    builder.result().map(CubeWeightTesting.apply) shouldBe Seq(
-      CubeWeightTesting(root, Weight(2).fraction),
-      CubeWeightTesting(id10, Weight(2).fraction))
+
+    builder
+      .result()
+      .head
+      .toSeq shouldBe Seq(
+      (root, CubeInfo(Weight(2).fraction, 2)),
+      (id10, CubeInfo(Weight(2).fraction, 1)))
   }
 
   it should "add maxWeight to the child of replicated cube" in {
     val builder =
       new CubeWeightsBuilderTesting(1, 1, 100000, announcedOrReplicatedSet = Set(root))
+
     builder.update(point, Weight(2))
-    builder.result().map(CubeWeightTesting.apply) shouldBe Seq(
-      CubeWeightTesting(root, Weight(2).fraction),
-      CubeWeightTesting(id10, Weight(2).fraction))
+
+    builder
+      .result()
+      .head
+      .toSeq shouldBe Seq(
+      (root, CubeInfo(Weight(2).fraction, 2)),
+      (id10, CubeInfo(Weight(2).fraction, 1)))
   }
 
   it should "not duplicate elements in result" in {
     val builder =
       new CubeWeightsBuilderTesting(1, 1, 1000, announcedOrReplicatedSet = Set(root))
+
     0.to(10000).map { _ => builder.update(point, Weight(Random.nextInt())) }
-    val result = builder.result()
-    result.size shouldBe result.distinct.size
+
+    builder
+      .result()
+      .foreach(tree => tree.toSeq.size shouldBe tree.toSeq.distinct.size)
   }
+
+  "populateTreeSize" should "create correct tree size results" in {
+    // Initial Tree:
+    //                                 root(_, 50)
+    //                                /            \
+    //                        c1(_, 50)             c6(_, 50)
+    //                       /        \            /         \
+    //               c2(_,15)      c3(_,50)    c7(_,30)      c8(_,30)
+    //                             /      \
+    //                        c4(_, 1)   c5(_,15)
+
+    val root = CubeId.root(3)
+    root.children.take(2)
+    val Seq(c1, c6) = root.children.take(2).toSeq
+    val Seq(c2, c3) = c1.children.take(2).toSeq
+    val Seq(c4, c5) = c3.children.take(2).toSeq
+    val Seq(c7, c8) = c6.children.take(2).toSeq
+
+    val initialTree =
+      mutable.Map[CubeId, CubeInfo](
+        root -> CubeInfo(-1d, 50d),
+        c1 -> CubeInfo(-1d, 50d),
+        c2 -> CubeInfo(-1d, 15d),
+        c3 -> CubeInfo(-1d, 50d),
+        c4 -> CubeInfo(-1d, 1d),
+        c5 -> CubeInfo(-1d, 15d),
+        c6 -> CubeInfo(-1d, 50d),
+        c7 -> CubeInfo(-1d, 30d),
+        c8 -> CubeInfo(-1d, 30d))
+
+    val builder = new CubeWeightsBuilderTesting(50, 50, 100000)
+    val populatedTree = builder.populateTreeSize(initialTree.clone())
+
+    populatedTree.foreach { case (cube, info) =>
+      val cubeSize = initialTree(cube).treeSize
+      val subtreeSize = cube.children
+        .filter(populatedTree.contains)
+        .map(populatedTree(_).treeSize)
+        .sum
+
+      info.treeSize shouldBe cubeSize + subtreeSize
+    }
+  }
+
 }

--- a/src/main/scala/io/qbeast/spark/index/MissingCubeDomainEstimation.scala
+++ b/src/main/scala/io/qbeast/spark/index/MissingCubeDomainEstimation.scala
@@ -11,7 +11,7 @@ object MissingCubeDomainEstimation {
    * Find the closest existing ancestor of a missing cube in the local tree,
    * starting from the immediate parent of the missing cube.
    */
-  private[index] def findClosestAncestorBottomUp(
+  private[index] def findClosestAncestor(
       localTree: LocalTree,
       missingCube: CubeId): Option[CubeId] = {
     // Find the first ancestor cube of the missingCube in a bottom-up fashion.
@@ -77,7 +77,7 @@ object MissingCubeDomainEstimation {
   private[index] def domainThroughPayloadFractions(
       missingCube: CubeId,
       localTree: LocalTree): Double = {
-    findClosestAncestorBottomUp(localTree, missingCube) match {
+    findClosestAncestor(localTree, missingCube) match {
       case None => 0d
       case Some(cube) =>
         var ancestor = cube

--- a/src/main/scala/io/qbeast/spark/index/MissingCubeDomainEstimation.scala
+++ b/src/main/scala/io/qbeast/spark/index/MissingCubeDomainEstimation.scala
@@ -23,4 +23,59 @@ object MissingCubeDomainEstimation {
     parentOption
   }
 
+  /**
+   * Given a CubeId C and its LocalTree, compute the size of its parent payload as well as its
+   * fraction that fall within the subspace of C. C and C.parent are assumed to be present in
+   * the given LocalTree.
+   */
+  private[index] def parentFractionAndPayload(
+      ancestor: CubeId,
+      localTree: LocalTree): (Double, Double) = {
+    // The fraction f from A's payload that belongs to C's branch is computed as:
+    // f = TreeSize(C) / (TreeSize(B) + TreeSize(C), TreeSize(D))
+    // LocalTree:
+    //                    A
+    //                  / | \
+    //                 B  C  D
+    val ancestorTreeSize = localTree(ancestor).treeSize
+
+    val parent = ancestor.parent.get
+    val parentTreeSize = localTree(parent).treeSize
+    val siblingTreeSize =
+      parent.children.filter(localTree.contains).map(localTree(_).treeSize).sum
+
+    val f = ancestorTreeSize / siblingTreeSize
+    val payload = parentTreeSize - siblingTreeSize
+
+    (f, payload)
+  }
+
+  /**
+   *  For each existing ancestor of the missing cube, compute the fraction of
+   *  their payload that belongs to our target domain. The payload distribution of a given cube
+   *  is assumed to be the same as that of its child cube tree sizes.
+   */
+  private[index] def domainThroughPayloadFractions(
+      missingCube: CubeId,
+      localTree: LocalTree): Double = {
+    findClosestAncestorBottomUp(localTree, missingCube) match {
+      case None => 0d
+      case Some(cube) =>
+        var ancestor = cube
+        var (payloadFraction, localDomain) = (1d, 0d)
+        // Stop the computation when the ancestor is root or,
+        // its parent is missing from the LocalTree, which happens during optimization.
+        while (!ancestor.isRoot && localTree.contains(ancestor.parent.get)) {
+          val (fraction, payload) = parentFractionAndPayload(ancestor, localTree)
+          // Update fraction using accumulative product, and update the domain.
+          payloadFraction *= fraction
+          localDomain += payload * payloadFraction
+
+          ancestor = ancestor.parent.get
+        }
+
+        localDomain
+    }
+  }
+
 }

--- a/src/main/scala/io/qbeast/spark/index/MissingCubeDomainEstimation.scala
+++ b/src/main/scala/io/qbeast/spark/index/MissingCubeDomainEstimation.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
+package io.qbeast.spark.index
+
+import io.qbeast.core.model.{CubeId, LocalTree}
+
+object MissingCubeDomainEstimation {
+
+  /**
+   * Find the closest existing ancestor of a missing cube in the local tree,
+   * starting from the immediate parent of the missing cube.
+   */
+  private[index] def findClosestAncestorBottomUp(
+      localTree: LocalTree,
+      missingCube: CubeId): Option[CubeId] = {
+    // Find the first ancestor cube of the missingCube in a bottom-up fashion.
+    var parentOption = missingCube.parent
+    // Loop ends when either parentOption is None, or when the parent is present in the tree.
+    while (parentOption.isDefined && !localTree.contains(parentOption.get)) {
+      parentOption = parentOption.get.parent
+    }
+    parentOption
+  }
+
+}

--- a/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
@@ -6,19 +6,15 @@ package io.qbeast.spark.index
 import io.qbeast.core.model.{CubeId, CubeInfo, LocalTree}
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.index.MissingCubeDomainEstimation._
-import scala.collection.mutable
 
 class MissingCubeDomainEstimationTest extends QbeastIntegrationTestSpec {
-  // groupCubeSize: 100
+  // groupCubeSize: 150
 
   //              root(0.2,300)
   //               /         \
   //        c1(0.4,150)    c2(2, 50)
   //             /
   //        c3(2,50)
-
-  val tree: mutable.Builder[(CubeId, CubeInfo), mutable.Map[CubeId, CubeInfo]] =
-    mutable.Map.newBuilder[CubeId, CubeInfo]
 
   val partitionSize = 300d
 
@@ -27,13 +23,13 @@ class MissingCubeDomainEstimationTest extends QbeastIntegrationTestSpec {
   val c2: CubeId = c1.nextSibling.get
   val c3: CubeId = c1.firstChild
 
-  tree += (root -> CubeInfo(0.2, partitionSize))
-  tree += (c1 -> CubeInfo(0.4, 150))
-  tree += (c2 -> CubeInfo(2d, 50))
-  tree += (c3 -> CubeInfo(2d, 50))
-
-  val localTree: LocalTree = tree.result().toMap
   val emptyTree: LocalTree = Map.empty[CubeId, CubeInfo]
+
+  val localTree: LocalTree = Map(
+    root -> CubeInfo(0.2, partitionSize),
+    c1 -> CubeInfo(0.4, 150),
+    c2 -> CubeInfo(2d, 50),
+    c3 -> CubeInfo(2d, 50))
 
   "findClosestAncestorBottomUp" should "return the correct ancestor cube" in {
     findClosestAncestor(emptyTree, root) shouldBe None

--- a/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
@@ -8,7 +8,7 @@ import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.index.MissingCubeDomainEstimation._
 
 class MissingCubeDomainEstimationTest extends QbeastIntegrationTestSpec {
-  // groupCubeSize: 150
+  // groupCubeSize: 100
 
   //              root(0.2,300)
   //               /         \

--- a/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
+package io.qbeast.spark.index
+
+import io.qbeast.core.model.{CubeId, CubeInfo, LocalTree}
+import io.qbeast.spark.QbeastIntegrationTestSpec
+import io.qbeast.spark.index.MissingCubeDomainEstimation._
+import scala.collection.mutable
+
+class MissingCubeDomainEstimationTest extends QbeastIntegrationTestSpec {
+  // groupCubeSize: 100
+
+  //              root(0.2,300)
+  //               /         \
+  //        c1(0.4,150)    c2(2, 50)
+  //             /
+  //        c3(2,50)
+
+  val tree: mutable.Builder[(CubeId, CubeInfo), mutable.Map[CubeId, CubeInfo]] =
+    mutable.Map.newBuilder[CubeId, CubeInfo]
+
+  val partitionSize = 300d
+
+  val root: CubeId = CubeId.root(2)
+  val c1: CubeId = root.firstChild
+  val c2: CubeId = c1.nextSibling.get
+  val c3: CubeId = c1.firstChild
+
+  tree += (root -> CubeInfo(0.2, partitionSize))
+  tree += (c1 -> CubeInfo(0.4, 150))
+  tree += (c2 -> CubeInfo(2d, 50))
+  tree += (c3 -> CubeInfo(2d, 50))
+
+  val localTree: LocalTree = tree.result().toMap
+  val emptyTree: LocalTree = Map.empty[CubeId, CubeInfo]
+
+  "findClosestAncestorBottomUp" should "return the correct ancestor cube" in {
+    findClosestAncestorBottomUp(emptyTree, root) shouldBe None
+    findClosestAncestorBottomUp(localTree, c3.firstChild) shouldBe Some(c3)
+    findClosestAncestorBottomUp(localTree, c3.firstChild.firstChild) shouldBe Some(c3)
+    findClosestAncestorBottomUp(localTree, c2.firstChild.firstChild) shouldBe Some(c2)
+
+    // During optimization, the LocalTree can miss some upper levels but this should
+    // not affect the correctness of the algorithm
+    findClosestAncestorBottomUp(localTree - root, c3.firstChild) shouldBe Some(c3)
+    findClosestAncestorBottomUp(localTree - root, c1) shouldBe None
+  }
+
+  "initialFractionAndDomain" should
+    "estimate fraction and domain from the closest ancestor correctly" in {
+      val c1TreeSize = localTree(c1).treeSize
+      val c2TreeSize = localTree(c2).treeSize
+      val c3TreeSize = localTree(c3).treeSize
+
+      val (f0, d0) = initialFractionAndDomain(root, localTree)
+      f0 shouldBe 1d / (c1TreeSize + c2TreeSize + 1d)
+      d0 shouldBe 0d
+
+      val (f1, d1) = initialFractionAndDomain(c1, localTree)
+      f1 shouldBe 1d / (c3TreeSize + 1d)
+      d1 shouldBe 0d
+
+      val (f2, d2) = initialFractionAndDomain(c2.firstChild, localTree)
+      f2 shouldBe 1d
+      d2 shouldBe 0d
+    }
+
+  "parentFractionAndPayload" should
+    "estimate fraction and payload from subsequent ancestors correctly" in {
+      val c1TreeSize = localTree(c1).treeSize
+      val c2TreeSize = localTree(c2).treeSize
+
+      val (f1, cs1) = parentFractionAndPayload(c1, localTree)
+      f1 shouldBe c1TreeSize / (c1TreeSize + c2TreeSize)
+      cs1 shouldBe 100d
+
+      val (f2, cs2) = parentFractionAndPayload(c2, localTree)
+      f2 shouldBe c2TreeSize / (c1TreeSize + c2TreeSize)
+      cs2 shouldBe 100d
+
+      // Method on root should throw an exception
+      an[NoSuchElementException] should be thrownBy parentFractionAndPayload(root, localTree)
+    }
+
+  "domainThroughPayloadFractions" should "estimate missing cube domain correctly" in {
+    val missingCube = c3.nextSibling.get
+    // c1
+    val ca = findClosestAncestorBottomUp(localTree, missingCube).get
+    // f and d from c1 should be 1d / 51d and 0d
+    val (f0, _) = initialFractionAndDomain(ca, localTree)
+    // f and d from root to c1 should be 150d / 200d and 100d
+    val (f1, d1) = parentFractionAndPayload(ca, localTree)
+
+    domainThroughPayloadFractions(missingCube, localTree) shouldBe f0 * f1 * d1
+
+    // it should return 0d when applied on root
+    domainThroughPayloadFractions(root, localTree) shouldBe 0d
+  }
+}

--- a/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/MissingCubeDomainEstimationTest.scala
@@ -36,15 +36,15 @@ class MissingCubeDomainEstimationTest extends QbeastIntegrationTestSpec {
   val emptyTree: LocalTree = Map.empty[CubeId, CubeInfo]
 
   "findClosestAncestorBottomUp" should "return the correct ancestor cube" in {
-    findClosestAncestorBottomUp(emptyTree, root) shouldBe None
-    findClosestAncestorBottomUp(localTree, c3.firstChild) shouldBe Some(c3)
-    findClosestAncestorBottomUp(localTree, c3.firstChild.firstChild) shouldBe Some(c3)
-    findClosestAncestorBottomUp(localTree, c2.firstChild.firstChild) shouldBe Some(c2)
+    findClosestAncestor(emptyTree, root) shouldBe None
+    findClosestAncestor(localTree, c3.firstChild) shouldBe Some(c3)
+    findClosestAncestor(localTree, c3.firstChild.firstChild) shouldBe Some(c3)
+    findClosestAncestor(localTree, c2.firstChild.firstChild) shouldBe Some(c2)
 
     // During optimization, the LocalTree can miss some upper levels but this should
     // not affect the correctness of the algorithm
-    findClosestAncestorBottomUp(localTree - root, c3.firstChild) shouldBe Some(c3)
-    findClosestAncestorBottomUp(localTree - root, c1) shouldBe None
+    findClosestAncestor(localTree - root, c3.firstChild) shouldBe Some(c3)
+    findClosestAncestor(localTree - root, c1) shouldBe None
   }
 
   "initialFractionAndDomain" should
@@ -86,7 +86,7 @@ class MissingCubeDomainEstimationTest extends QbeastIntegrationTestSpec {
   "domainThroughPayloadFractions" should "estimate missing cube domain correctly" in {
     val missingCube = c3.nextSibling.get
     // c1
-    val ca = findClosestAncestorBottomUp(localTree, missingCube).get
+    val ca = findClosestAncestor(localTree, missingCube).get
     // f and d from c1 should be 1d / 51d and 0d
     val (f0, _) = initialFractionAndDomain(ca, localTree)
     // f and d from root to c1 should be 150d / 200d and 100d


### PR DESCRIPTION
## Description

One of the main issues of the current OTree implementation is its failure to enforce desiredCubeSize on the tree nodes. As shown in the image below, the deeper we go down the tree, the larger the cube sizes increase.

This leads to an undesired outcome, namely, files that contain an unpredictable number of records with very large sizes. The aim of this PR is to address this issue.

A comparison with the existing DoublePass implementation is shown in the following image. As we can see, the average cube sizes are just as good as the sequential implementation. The dataset used is derived from the GitHub Archive project dataset; The index is built on two columns but all columns are used for weight computation:

![Average cube size per level  All columns used for weight computation](https://user-images.githubusercontent.com/47899566/204338244-7d1a958e-0628-445b-a229-66c6ef643827.png)

## How is this achieved?
Instead of merging partition-level `NormalizedWeight` via Harmonic Means to obtain cube weights, the improvements are achieved by estimating weights so that the expected value of the node size is that of the `desiredCubeSize`.

### Existing cubes
Given a cube `c` with domain `Nc`, knowing the weight of its parent node `Wpc`, find the weight of c, `Wc`, so the amount of `Nc` we leave in c has an expected value of `desiredCubeSize`, in other words `desiredCubeSize = (Wc - Wpc) • |Nc|`. Weights can now be computed using `Wc = Wpc + desiredCubeSize / |Nc|`.

The domain of a cube, `Nc`, is the dataset records that fall within the limits of c. Generally, `Nc` is distributed among the line of ancestors of c, and the subtree of c (including c). 

The subtree of c, `Dc`, is where the remaining of Nc is found, so `|Dc| = (1 - Wpc) • |Nc|`; The local domain of a cube can be found via `|Nc,i|  = |Dc,i| / (1 - Wpc,i)`. And the global domain is to be found via a simple sum: **|Nc| = $\sum_{} |Nc,i|$**.

This requires two changes:
1. The computation of `Dc` for the local trees, with is the sum of c's payload size and the tree size of its child cubes.
2. The computation of global weights `Wc` has to be done in a top-down fashion, for `Wpc` is needed in each step. Having, Wpc, find |Nc| for c in all local trees via `|Nc,i|  = |Dc,i| / (1 - Wpc,i)`.

####Missing cubes
What if c is not present in a given local tree? Since partition data are different, we can expect local trees to have different topologies. The domain of c has to be computed differently in this case because |Dci| = 0.

The idea is to find a good upper-bound of the missing cube domain in the local tree. Since c is not present, we know that all its payload is left in its chain of parent nodes. **The approach we've taken is to compute the fraction of each ancestor payload that belongs to the missing cube region**.

Given a cube A with child cubes A1, A2, and A3. The fraction of A's payload that belongs to the A3 domain can be estimated by `f = |A3| / (|A1| + |A2| + |A3|)`. In doing so, we are assuming the distribution of A's payload is the same as that of its child cube tree sizes.

Now, we can compute `f` for each existing ancestor and extract the correct fraction from their payload and add it to the domain. `f_acc` at each ancestor going upwards is updated by `f`: `f_acc  = f_acc * f`. The fraction `f` from a given c is the fraction for its immediate child cube, which then has to be multiplied by the existing `f_acc` to find its contribution to the target domain. 

For example, given the following ancestor chain for an missing cube: **Root -> A -> AB -> ABC -> MissingCube**. We initiate the cube domain as zero and add the corresponding payload fraction from each ancestor cube, updating `f_acc` at each step:

1. f_acc = f1 = f(ABC)
2. f2 = f(AB), f_acc *= f2, domain += f_acc * |AB|
3. f3 = f(A), f_acc *= f3, domain += f_acc * |A|
4. f4 = f(Root), f_acc *= f4, domain += f_acc * |Root|

### Summary
- Cube weights are now computed through the computation of cube domains
- Since partition data are different, different local trees have different topologies
- If the cube is present in a local tree, this can be computed using a cube's tree size
- Otherwise, an estimation of the cube domain upper-bound is done, and we do so by estimating the domain of our missing cube has left in each ancestor cube

### Potential improvements
- [ ] Do we need to improve the efficiency of the `populateTreeSize` method, used to compute local cube tree sizes?
- [ ] Merge local trees. Currently we are creating a SortedSet from all LocalTree keys, and use this to traverse branches. For each distinct cube we have to go through all localtrees to extract |Nc,i|.
- [ ] Unlike the existing implementation where a Seq[CubeNormalizedWeight] is created for each partition, Map[CubeId, (NormalizedWeight, TreeSize)] is used as LocalTree  for each partition. This increases the size of our collect from each partition, do we need to make this less memory consuming?
