### PR TITLE
Unified Catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ For example:
 sbt assembly
 
 $SPARK_HOME/bin/spark-shell \
---jars ./target/scala-2.12/qbeast-spark-assembly-0.3.0-alpha.jar \
+--jars ./target/scala-2.12/qbeast-spark-assembly-0.3.0.jar \
 --conf spark.sql.extensions=io.qbeast.spark.internal.QbeastSparkSessionExtension \
 --packages io.delta:delta-core_2.12:1.2.0
 ```

--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ export SPARK_HOME=$PWD/spark-3.1.1-bin-hadoop3.2
 
 ```bash
 $SPARK_HOME/bin/spark-shell \
+--repositories https://s01.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.sql.extensions=io.qbeast.spark.internal.QbeastSparkSessionExtension \
 --conf spark.sql.catalog.spark_catalog=io.qbeast.spark.internal.sources.catalog.QbeastCatalog \
---packages io.qbeast:qbeast-spark_2.12:0.3.0,io.delta:delta-core_2.12:1.0.0
+--packages io.qbeast:qbeast-spark_2.12:0.3.0-SNAPSHOT,io.delta:delta-core_2.12:1.2.0
 ```
 
 ### 2. Indexing a dataset
@@ -173,11 +174,11 @@ qbeastTable.analyze()
 Go to [QbeastTable documentation](./docs/QbeastTable.md) for more detailed information.
 
 # Dependencies and Version Compatibility
-| Version     | Spark | Hadoop | Delta Lake |
-|-------------|:-----:|:------:|:----------:|
-| 0.1.0       | 3.0.0 | 3.2.0  |   0.8.0    |
-| 0.2.0       | 3.1.x | 3.2.0  |   1.0.0    |
-| 0.3.0-alpha | 3.2.x | 3.3.x  |   1.2.x    |
+| Version    | Spark | Hadoop | Delta Lake |
+|------------|:-----:|:------:|:----------:|
+| 0.1.0      | 3.0.0 | 3.2.0  |   0.8.0    |
+| 0.2.0      | 3.1.x | 3.2.0  |   1.0.0    |
+| 0.3.0 | 3.2.x | 3.3.x  |   1.2.x    |
 
 Check [here](https://docs.delta.io/latest/releases.html) for **Delta Lake** and **Apache Spark** version compatibility.  
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ export SPARK_HOME=$PWD/spark-3.1.1-bin-hadoop3.2
 $SPARK_HOME/bin/spark-shell \
 --conf spark.sql.extensions=io.qbeast.spark.internal.QbeastSparkSessionExtension \
 --conf spark.sql.catalog.spark_catalog=io.qbeast.spark.internal.sources.catalog.QbeastCatalog \
---packages io.qbeast:qbeast-spark_2.12:0.2.0,io.delta:delta-core_2.12:1.0.0
+--packages io.qbeast:qbeast-spark_2.12:0.3.0,io.delta:delta-core_2.12:1.0.0
 ```
 
 ### 2. Indexing a dataset

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import xerial.sbt.Sonatype._
 
-val mainVersion = "0.3.0-alpha"
+val mainVersion = "0.3.0"
 
 lazy val qbeastCore = (project in file("core"))
   .settings(

--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.AnalysisException
 class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with CatalogTestSuite {
 
   "QbeastCatalog" should
-    "coexist with Delta Catalog" in withTmpDir(tmpDir =>
+    "coexist with Delta tables" in withTmpDir(tmpDir =>
       withExtendedSpark(sparkConf = new SparkConf()
         .setMaster("local[8]")
         .set("spark.sql.extensions", "io.qbeast.spark.internal.QbeastSparkSessionExtension")

--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.AnalysisException
 class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with CatalogTestSuite {
 
   "QbeastCatalog" should
-    "coexist with Delta tables" in withTmpDir(tmpDir =>
+    "coexist with Delta Catalog" in withTmpDir(tmpDir =>
       withExtendedSpark(sparkConf = new SparkConf()
         .setMaster("local[8]")
         .set("spark.sql.extensions", "io.qbeast.spark.internal.QbeastSparkSessionExtension")
@@ -21,7 +21,6 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
 
         data.write.format("delta").saveAsTable("delta_table") // delta catalog
 
-        // spark.sql("USE CATALOG qbeast_catalog")
         data.write
           .format("qbeast")
           .option("columnsToIndex", "id")
@@ -40,6 +39,33 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
           ignoreNullable = true)
 
       }))
+
+  it should
+    "coexist with Delta tables in the same catalog" in withQbeastContextSparkAndTmpWarehouse(
+      (spark, _) => {
+
+        val data = createTestData(spark)
+
+        data.write.format("delta").saveAsTable("delta_table") // delta catalog
+
+        data.write
+          .format("qbeast")
+          .option("columnsToIndex", "id")
+          .saveAsTable("qbeast_table") // qbeast catalog
+
+        val tables = spark.sessionState.catalog.listTables("default")
+        tables.size shouldBe 2
+
+        val deltaTable = spark.read.table("delta_table")
+        val qbeastTable = spark.read.table("qbeast_table")
+
+        assertSmallDatasetEquality(
+          deltaTable,
+          qbeastTable,
+          orderedComparison = false,
+          ignoreNullable = true)
+
+      })
 
   it should "crate table" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
 


### PR DESCRIPTION
## Description

In this PR, we are modifying the `QbeastCatalog` to process also writes in Delta (or other formats such Iceberg or Hudi once they're integrated). 

## Type of change

It is an improvement of an existing Catalog feature. Instead of managing two catalogs at the same time, the user would only need to set up one by adding the following configuration to any Spark Application:

`--conf spark.sql.catalog.spark_catalog=io.qbeast.spark.internal.sources.catalog.QbeastCatalog`

Then, the user can create `qbeast` tables and `delta` tables with either DataFrame API or SQL:

```scala
data.write.format("delta").saveAsTable("delta_table")

data.write
 .format("qbeast")
 .option("columnsToIndex", "id")
 .saveAsTable("qbeast_table")
```


```scala
spark.sql(
  s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
    "OPTIONS ('columnsToIndex'='id')")

spark.sql(
  s"CREATE TABLE student (id INT, name STRING, age INT) USING delta")

```

**The user can also choose to configure them as separate catalogs**. But for some integrations (such as `dbt`) it's not recommended.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Please describe the tests that you ran to verify your changes.

We add a test in `QbeastCatalogIntegrationTest` in which we try to write as `delta` and `qbeast` with the same Catalog.
