### PR TITLE
Filter revisions through the creation of empty query spaces

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
@@ -88,8 +88,7 @@ object QuerySpace {
       .zip(to)
       .zip(transformations)
       .map {
-        case ((_, _), _: HashTransformation) || ((None, None), _) => (true, true)
-        case ((None, None), _) => (true, true)
+        case ((_, _), _: HashTransformation) | ((None, None), _) => (true, true)
         case ((Some(f), Some(t)), _) =>
           (f <= t && f <= 1d && t >= 0d, f <= t && f <= 0d && t >= 1d)
         case ((None, Some(t)), _) => (t >= 0d, t >= 1d)

--- a/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 
 class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
 
-  val toSpaceCoordinates
+  private val toSpaceCoordinates
       : (Seq[Option[Any]], Seq[Transformation]) => Seq[Option[NormalizedWeight]] =
     (originalValues: Seq[Option[Any]], transformations: Seq[Transformation]) => {
       originalValues.zip(transformations).map {
@@ -30,7 +30,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
   }
 
   it should "exclude beyond left limit" in {
-    val cube = CubeId.root(3)
+    val cube = CubeId.root(1)
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
     val from = toSpaceCoordinates(Seq(Some(-1)), transformation)
     val to = toSpaceCoordinates(Seq(Some(0)), transformation)
@@ -40,7 +40,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
   }
 
   it should "exclude beyond right limit" in {
-    val cube = CubeId.root(3)
+    val cube = CubeId.root(1)
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
     val from = toSpaceCoordinates(Seq(Some(3)), transformation)
     val to = toSpaceCoordinates(Seq(Some(4)), transformation)
@@ -50,7 +50,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
   }
 
   it should "include the left limit" in {
-    val cube = CubeId.root(3)
+    val cube = CubeId.root(1)
     val from = Seq(Some(1))
     val to = Seq(Some(1))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
@@ -61,7 +61,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
   }
 
   it should "include the right SPACE limit" in {
-    val cube = CubeId.root(3)
+    val cube = CubeId.root(1)
     val from = Seq(Some(2))
     val to = Seq(Some(2))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
@@ -72,7 +72,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
   }
 
   it should "include the left limit and beyond" in {
-    val cube = CubeId.root(3)
+    val cube = CubeId.root(1)
     val from = Seq(Some(0))
     val to = Seq(Some(1))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
@@ -83,7 +83,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
   }
 
   it should "include the right SPACE limit and beyond" in {
-    val cube = CubeId.root(3)
+    val cube = CubeId.root(1)
     val from = Seq(Some(2))
     val to = Seq(Some(3))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
@@ -95,7 +95,7 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
 
   it should "include query range to, though not really desired" in {
     // For the implementation of LessThanOrEqual
-    val cube = CubeId.root(3)
+    val cube = CubeId.root(1)
     val from = Seq(Some(-1))
     val to = Seq(Some(1))
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
@@ -134,12 +134,35 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
       emptySpace.intersectsWith(cube) shouldBe false
     }
 
-  it should "create an empty space when the query is smaller than the revision left limit" in {
-    val from = Seq(Some(-1))
-    val to = Seq(Some(0))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val emptySpace = QuerySpace(from, to, transformation)
+  it should
+    "create an empty space when the query space is smaller than the revision left limit" in {
+      val from = Seq(Some(-1))
+      val to = Seq(Some(0))
+      val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+      val emptySpace = QuerySpace(from, to, transformation)
 
-    emptySpace shouldBe a[EmptySpace]
-  }
+      emptySpace shouldBe a[EmptySpace]
+    }
+
+  it should
+    "create an AllSpace instance when the query space is identical to the revision space" in {
+      val from = Seq(Some(1))
+      val to = Seq(Some(2))
+      val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+      val allSpace = QuerySpace(from, to, transformation)
+
+      allSpace shouldBe a[AllSpace]
+    }
+
+  it should
+    "create an AllSpace instance when the query space contains the revision space" in {
+      val cube = CubeId.root(1)
+      val from = Seq(Some(-1))
+      val to = Seq(Some(3))
+      val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+      val allSpace = QuerySpace(from, to, transformation)
+
+      allSpace shouldBe a[AllSpace]
+      allSpace.intersectsWith(cube)
+    }
 }

--- a/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
@@ -1,100 +1,116 @@
 package io.qbeast.core.model
 
-import io.qbeast.core.transform.LinearTransformation
+import io.qbeast.core.transform.{LinearTransformation, Transformation}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
 
-  "QuerySpace from to" should "intersect correctly" in {
+  val toSpaceCoordinates
+      : (Seq[Option[Any]], Seq[Transformation]) => Seq[Option[NormalizedWeight]] =
+    (originalValues: Seq[Option[Any]], transformations: Seq[Transformation]) => {
+      originalValues.zip(transformations).map {
+        case (Some(f), transformation) => Some(transformation.transform(f))
+        case _ => None
+      }
+    }
 
+  "QuerySpaceFromTo" should "intersect correctly" in {
+    val cube = CubeId.root(3)
     val from = Seq(Some(1), Some(2), Some(3))
     val to = Seq(Some(2), Some(4), Some(5))
     val transformation = Seq(
       LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType),
       LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType),
       LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
+    val querySpaceFromTo = QuerySpace(from, to, transformation)
 
-    val cube = CubeId.root(3)
-    querySpaceFromTo.intersectsWith(cube) shouldBe true
-  }
-
-  it should "not intersect with query space larger than the max value" in {
-    val from = Seq(Some(3))
-    val to = Seq(Some(4))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
-
-    val cube = CubeId.root(3)
-    querySpaceFromTo.intersectsWith(cube) shouldBe false
-  }
-
-  it should "not intersect with query space smaller than the min value" in {
-    val from = Seq(Some(-1))
-    val to = Seq(Some(0))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
-
-    val cube = CubeId.root(3)
-    querySpaceFromTo.intersectsWith(cube) shouldBe false
-  }
-
-  it should "include the right limit" in {
-    val from = Seq(Some(2))
-    val to = Seq(Some(2))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
-
-    val cube = CubeId.root(3)
-    querySpaceFromTo.intersectsWith(cube) shouldBe true
-  }
-
-  it should "include the right limit and beyond" in {
-    val from = Seq(Some(2))
-    val to = Seq(Some(3))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
-
-    val cube = CubeId.root(3)
-    querySpaceFromTo.intersectsWith(cube) shouldBe true
-  }
-
-  it should "include the left limit" in {
-    val from = Seq(Some(1))
-    val to = Seq(Some(1))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
-
-    val cube = CubeId.root(3)
-    querySpaceFromTo.intersectsWith(cube) shouldBe true
-  }
-
-  it should "include query range to, though not really desired" in {
-    val from = Seq(Some(-1))
-    val to = Seq(Some(1))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
-
-    val cube = CubeId.root(3)
+    querySpaceFromTo shouldBe a[QuerySpaceFromTo]
     querySpaceFromTo.intersectsWith(cube) shouldBe true
   }
 
   it should "exclude beyond left limit" in {
-    val from = Seq(Some(-1))
-    val to = Seq(Some(0))
-    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
-    val querySpaceFromTo = QuerySpaceFromTo(from, to, transformation)
-
     val cube = CubeId.root(3)
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val from = toSpaceCoordinates(Seq(Some(-1)), transformation)
+    val to = toSpaceCoordinates(Seq(Some(0)), transformation)
+    val querySpaceFromTo = new QuerySpaceFromTo(from, to)
+
     querySpaceFromTo.intersectsWith(cube) shouldBe false
+  }
+
+  it should "exclude beyond right limit" in {
+    val cube = CubeId.root(3)
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val from = toSpaceCoordinates(Seq(Some(3)), transformation)
+    val to = toSpaceCoordinates(Seq(Some(4)), transformation)
+    val querySpaceFromTo = new QuerySpaceFromTo(from, to)
+
+    querySpaceFromTo.intersectsWith(cube) shouldBe false
+  }
+
+  it should "include the left limit" in {
+    val cube = CubeId.root(3)
+    val from = Seq(Some(1))
+    val to = Seq(Some(1))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpace(from, to, transformation)
+
+    querySpaceFromTo shouldBe a[QuerySpaceFromTo]
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "include the right SPACE limit" in {
+    val cube = CubeId.root(3)
+    val from = Seq(Some(2))
+    val to = Seq(Some(2))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpace(from, to, transformation)
+
+    querySpaceFromTo shouldBe a[QuerySpaceFromTo]
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "include the left limit and beyond" in {
+    val cube = CubeId.root(3)
+    val from = Seq(Some(0))
+    val to = Seq(Some(1))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpace(from, to, transformation)
+
+    querySpaceFromTo shouldBe a[QuerySpaceFromTo]
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "include the right SPACE limit and beyond" in {
+    val cube = CubeId.root(3)
+    val from = Seq(Some(2))
+    val to = Seq(Some(3))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpace(from, to, transformation)
+
+    querySpaceFromTo shouldBe a[QuerySpaceFromTo]
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
+  it should "include query range to, though not really desired" in {
+    // For the implementation of LessThanOrEqual
+    val cube = CubeId.root(3)
+    val from = Seq(Some(-1))
+    val to = Seq(Some(1))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val querySpaceFromTo = QuerySpace(from, to, transformation)
+
+    querySpaceFromTo shouldBe a[QuerySpaceFromTo]
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
   }
 
   it should "throw error if dimensions size is different" in {
     val from = Seq(Some(1), Some(2), Some(3))
     val to = Seq(Some(2), Some(4), Some(5))
     val transformation = Seq(LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType))
-    a[AssertionError] shouldBe thrownBy(QuerySpaceFromTo(from, to, transformation))
+
+    a[AssertionError] shouldBe thrownBy(QuerySpace(from, to, transformation))
   }
 
   it should "throw error if coordinates size is different" in {
@@ -103,6 +119,25 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
     val transformation = Seq(
       LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType),
       LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType))
-    a[AssertionError] shouldBe thrownBy(QuerySpaceFromTo(from, to, transformation))
+    a[AssertionError] shouldBe thrownBy(QuerySpace(from, to, transformation))
+  }
+
+  "QuerySpace" should
+    "create an empty space when the query space is larger than the revision right limit" in {
+      val from = Seq(Some(3))
+      val to = Seq(Some(4))
+      val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+      val emptySpace = QuerySpace(from, to, transformation)
+
+      emptySpace shouldBe a[EmptySpace]
+    }
+
+  it should "create an empty space when the query is smaller than the revision left limit" in {
+    val from = Seq(Some(-1))
+    val to = Seq(Some(0))
+    val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
+    val emptySpace = QuerySpace(from, to, transformation)
+
+    emptySpace shouldBe a[EmptySpace]
   }
 }

--- a/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
@@ -124,12 +124,14 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
 
   "QuerySpace" should
     "create an empty space when the query space is larger than the revision right limit" in {
+      val cube = CubeId.root(3)
       val from = Seq(Some(3))
       val to = Seq(Some(4))
       val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))
       val emptySpace = QuerySpace(from, to, transformation)
 
       emptySpace shouldBe a[EmptySpace]
+      emptySpace.intersectsWith(cube) shouldBe false
     }
 
   it should "create an empty space when the query is smaller than the revision left limit" in {

--- a/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
@@ -24,7 +24,7 @@ class QueryExecutor(querySpecBuilder: QuerySpecBuilder, qbeastSnapshot: QbeastSn
     qbeastSnapshot.loadAllRevisions.flatMap { revision =>
       val querySpec = querySpecBuilder.build(revision)
       (querySpec.isSampling, querySpec.querySpace) match {
-        case (_, _: QuerySpaceFromTo) || (true, _: AllSpace) =>
+        case (_, _: QuerySpaceFromTo) | (true, _: AllSpace) =>
           val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
           val matchingBlocks = executeRevision(querySpec, indexStatus)
           matchingBlocks
@@ -33,7 +33,7 @@ class QueryExecutor(querySpecBuilder: QuerySpecBuilder, qbeastSnapshot: QbeastSn
           indexStatus.cubesStatuses.values.flatMap { status =>
             status.files.filter(_.state == State.FLOODED)
           }
-        case (_, _: EmptySpace) => Seq.empty[QbeastBlock]
+        case _ => Seq.empty[QbeastBlock]
       }
     }
   }

--- a/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
@@ -23,10 +23,13 @@ class QueryExecutor(querySpecBuilder: QuerySpecBuilder, qbeastSnapshot: QbeastSn
 
     qbeastSnapshot.loadAllRevisions.flatMap { revision =>
       val querySpec = querySpecBuilder.build(revision)
-      val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
-
-      val matchingBlocks = executeRevision(querySpec, indexStatus)
-      matchingBlocks
+      querySpec.querySpace match {
+        case _: QuerySpaceFromTo =>
+          val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
+          val matchingBlocks = executeRevision(querySpec, indexStatus)
+          matchingBlocks
+        case _: EmptySpace => Seq.empty[QbeastBlock]
+      }
     }
   }
 

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpec.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpec.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.spark.index.query
 
-import io.qbeast.core.model.{QuerySpace, WeightRange}
+import io.qbeast.core.model.{QuerySpace, Weight, WeightRange}
 
 /**
  * Query specification
@@ -11,4 +11,9 @@ import io.qbeast.core.model.{QuerySpace, WeightRange}
  * @param weightRange the weight range
  * @param querySpace the query space
  */
-case class QuerySpec(weightRange: WeightRange, querySpace: QuerySpace)
+case class QuerySpec(weightRange: WeightRange, querySpace: QuerySpace) {
+
+  def isSampling: Boolean =
+    weightRange.from > Weight.MinValue || weightRange.to < Weight.MaxValue
+
+}

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -102,7 +102,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
 
         // Get the coordinates of the column in the filters,
         // if not found, use the overall coordinates
-        val from_ = columnFilters
+        val columnFrom = columnFilters
           .collectFirst {
             case GreaterThan(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case GreaterThanOrEqual(_, Literal(value, _)) => sparkTypeToCoreType(value)
@@ -110,7 +110,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
             case IsNull(_) => null
           }
 
-        val to_ = columnFilters
+        val columnTo = columnFilters
           .collectFirst {
             case LessThan(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case LessThanOrEqual(_, Literal(value, _)) => sparkTypeToCoreType(value)
@@ -118,7 +118,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
             case IsNull(_) => null
           }
 
-        (from_, to_)
+        (columnFrom, columnTo)
       }.unzip
 
     QuerySpace(from, to, revision.transformations)

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -7,6 +7,7 @@ import io.qbeast.core.model._
 import io.qbeast.spark.index.query
 import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.{
   And,
   BinaryComparison,
@@ -29,8 +30,8 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Serializable {
 
-  lazy val spark = SparkSession.active
-  lazy val nameEquality = spark.sessionState.analyzer.resolver
+  lazy val spark: SparkSession = SparkSession.active
+  lazy val nameEquality: Resolver = spark.sessionState.analyzer.resolver
 
   private def hasQbeastColumnReference(expr: Expression, indexedColumns: Seq[String]): Boolean = {
     expr.references.forall { r =>
@@ -92,16 +93,16 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
 
     // Split conjunctive predicates
     val filters = dataFilters.flatMap(filter => splitConjunctivePredicates(filter))
-
     val indexedColumns = revision.columnTransformers.map(_.columnName)
-    val fromTo =
+
+    val (from, to) =
       indexedColumns.map { columnName =>
         // Get the filters related to the column
         val columnFilters = filters.filter(hasColumnReference(_, columnName))
 
         // Get the coordinates of the column in the filters,
         // if not found, use the overall coordinates
-        val from = columnFilters
+        val from_ = columnFilters
           .collectFirst {
             case GreaterThan(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case GreaterThanOrEqual(_, Literal(value, _)) => sparkTypeToCoreType(value)
@@ -109,7 +110,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
             case IsNull(_) => null
           }
 
-        val to = columnFilters
+        val to_ = columnFilters
           .collectFirst {
             case LessThan(_, Literal(value, _)) => sparkTypeToCoreType(value)
             case LessThanOrEqual(_, Literal(value, _)) => sparkTypeToCoreType(value)
@@ -117,12 +118,10 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
             case IsNull(_) => null
           }
 
-        (from, to)
-      }
+        (from_, to_)
+      }.unzip
 
-    val from = fromTo.map(_._1)
-    val to = fromTo.map(_._2)
-    QuerySpaceFromTo(from, to, revision.transformations)
+    QuerySpace(from, to, revision.transformations)
   }
 
   /**

--- a/src/test/scala/io/qbeast/spark/index/query/QuerySpecBuilderTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QuerySpecBuilderTest.scala
@@ -54,12 +54,11 @@ class QuerySpecBuilderTest
     val expression = weightFilters(weightRange)
     val revision = createRevision()
     val queryWeightRange = new QuerySpecBuilder(Seq(expression)).build(revision).weightRange
-    queryWeightRange shouldBe weightRange
 
+    queryWeightRange shouldBe weightRange
   })
 
   "extractQueryRange" should "extract query range" in withSpark(spark => {
-
     val (from, to) = (3, 8)
     val expression = expr(s"id >= $from and id < $to").expr
     val revision = createRevision()
@@ -69,11 +68,9 @@ class QuerySpecBuilderTest
 
     querySpace invokePrivate privateFrom() shouldBe Seq(Some(tFrom))
     querySpace invokePrivate privateTo() shouldBe Seq(Some(tTo))
-
   })
 
   it should "extract query range when equal to" in withSpark(spark => {
-
     val revision = createRevision()
     val expression = expr("id == 3").expr
     val querySpace = new QuerySpecBuilder(Seq(expression)).build(revision).querySpace
@@ -81,7 +78,6 @@ class QuerySpecBuilderTest
 
     querySpace invokePrivate privateFrom() shouldBe Seq(Some(t))
     querySpace invokePrivate privateTo() shouldBe Seq(Some(t))
-
   })
 
   it should "extract query range when is null" in withSpark(spark => {
@@ -92,11 +88,9 @@ class QuerySpecBuilderTest
 
     querySpace invokePrivate privateFrom() shouldBe Seq(Some(t))
     querySpace invokePrivate privateTo() shouldBe Seq(Some(t))
-
   })
 
-  it should "extract query range when column is string" in withSpark(spark => {
-
+  it should "extract proper query space when column is string" in withSpark(spark => {
     val nameTransformation = HashTransformation()
     val transformations = Seq(nameTransformation).toIndexedSeq
     val columnTransformers = Seq(Transformer("hashing", "name", StringDataType)).toIndexedSeq
@@ -111,37 +105,28 @@ class QuerySpecBuilderTest
 
     val (from, to) = ("qbeast", "QBEAST")
 
-    val expression = expr(s"name == '$from'").expr
-    val t = nameTransformation.transform("qbeast")
-    val querySpace = new QuerySpecBuilder(Seq(expression)).build(revision).querySpace
-    querySpace invokePrivate privateFrom() shouldBe Seq(Some(t))
-    querySpace invokePrivate privateTo() shouldBe Seq(Some(t))
+    val equalToExpression = expr(s"name == '$from'").expr
+    val equalToSpace = new QuerySpecBuilder(Seq(equalToExpression)).build(revision).querySpace
+    equalToSpace shouldBe a[QuerySpaceFromTo]
 
     val rangeExpression = expr(s"name >= '$from' and name < '$to'").expr
-    val rangeQuerySpace = new QuerySpecBuilder(Seq(rangeExpression)).build(revision).querySpace
-    val resultFrom = Seq(Some(nameTransformation.transform(from)))
-    val resultTo = Seq(Some(nameTransformation.transform(to)))
-    rangeQuerySpace invokePrivate privateFrom() shouldBe resultFrom
-    rangeQuerySpace invokePrivate privateTo() shouldBe resultTo
-
+    val rangeSpace = new QuerySpecBuilder(Seq(rangeExpression)).build(revision).querySpace
+    rangeSpace shouldBe a[AllSpace]
   })
 
   it should "extract all query range when expressions is empty" in withSpark(spark => {
-
     val revision = createRevision()
     val querySpace = new QuerySpecBuilder(Seq.empty).build(revision).querySpace
-    querySpace invokePrivate privateFrom() shouldBe Seq(None)
-    querySpace invokePrivate privateTo() shouldBe Seq(None)
+
+    querySpace shouldBe a[AllSpace]
   })
 
   it should "not process disjunctive predicates" in withSpark(spark => {
-
     val revision = createRevision()
-    val expression = expr(s"id >= 3 OR id < 8").expr
+    val expression = expr(s"3 <= id OR id < 8").expr
     val querySpace = new QuerySpecBuilder(Seq(expression)).build(revision).querySpace
-    querySpace invokePrivate privateFrom() shouldBe Seq(None)
-    querySpace invokePrivate privateTo() shouldBe Seq(None)
 
+    querySpace shouldBe a[AllSpace]
   })
 
   it should "leverage otree index when filtering with GreaterThan and LessThanOrEqual" in withSpark(
@@ -185,6 +170,7 @@ class QuerySpecBuilderTest
         val querySpec = new QuerySpecBuilder(expression :: Nil).build(revision)
         querySpec.querySpace match {
           case _: QuerySpaceFromTo => true
+          case _: AllSpace => true
           case _: EmptySpace => false
         }
       } shouldBe answer
@@ -199,6 +185,7 @@ class QuerySpecBuilderTest
       val querySpec = new QuerySpecBuilder(Seq.empty).build(revision)
       querySpec.querySpace match {
         case _: QuerySpaceFromTo => true
+        case _: AllSpace => true
         case _: EmptySpace => false
       }
     } shouldBe revisions.size


### PR DESCRIPTION
## Description
The construction of IndexStatus when the entire Revision is out of query space is a waste.
The changes from this PR filter the Revisions out of the query space before their corresponding index construction from the log and cube filtering.

## Type of change
**Improvement for filtering**

## Checklist:
- [x] New feature/bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)
- Test 1: Modify QuerySpaceFromToTest to skip Revisions that create EmptySpace instances for a given query. Revisions that create AllSpace instances don't need to traverse the index; they can return all FLOODED blocks directly.
- Test 2: QuerySpecBuilderTest: Filter QuerySpaces that are not QuerySpaceFromTo

**Test Configuration**:
* Spark Version: 3.1.2
* Hadoop Version: 3.2
* Cluster or local: Local