### PR TITLE
Change version and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ export SPARK_HOME=$PWD/spark-3.1.1-bin-hadoop3.2
 
 ```bash
 $SPARK_HOME/bin/spark-shell \
---repositories https://s01.oss.sonatype.org/content/repositories/snapshots \
 --conf spark.sql.extensions=io.qbeast.spark.internal.QbeastSparkSessionExtension \
 --conf spark.sql.catalog.spark_catalog=io.qbeast.spark.internal.sources.catalog.QbeastCatalog \
---packages io.qbeast:qbeast-spark_2.12:0.3.0-SNAPSHOT,io.delta:delta-core_2.12:1.2.0
+--packages io.qbeast:qbeast-spark_2.12:0.3.1,io.delta:delta-core_2.12:1.2.0
 ```
 
 ### 2. Indexing a dataset
@@ -174,11 +173,11 @@ qbeastTable.analyze()
 Go to [QbeastTable documentation](./docs/QbeastTable.md) for more detailed information.
 
 # Dependencies and Version Compatibility
-| Version    | Spark | Hadoop | Delta Lake |
-|------------|:-----:|:------:|:----------:|
-| 0.1.0      | 3.0.0 | 3.2.0  |   0.8.0    |
-| 0.2.0      | 3.1.x | 3.2.0  |   1.0.0    |
-| 0.3.0 | 3.2.x | 3.3.x  |   1.2.x    |
+| Version | Spark | Hadoop | Delta Lake |
+|---------|:-----:|:------:|:----------:|
+| 0.1.0   | 3.0.0 | 3.2.0  |   0.8.0    |
+| 0.2.0   | 3.1.x | 3.2.0  |   1.0.0    |
+| 0.3.1   | 3.2.x | 3.3.x  |   1.2.x    |
 
 Check [here](https://docs.delta.io/latest/releases.html) for **Delta Lake** and **Apache Spark** version compatibility.  
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import xerial.sbt.Sonatype._
 
-val mainVersion = "0.3.0"
+val mainVersion = "0.4.0-alpha"
 
 lazy val qbeastCore = (project in file("core"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import xerial.sbt.Sonatype._
 
-val mainVersion = "0.4.0-alpha"
+val mainVersion = "0.3.0"
 
 lazy val qbeastCore = (project in file("core"))
   .settings(

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -17,7 +17,7 @@ Inside the project folder, launch a spark-shell with the required **dependencies
 $SPARK_HOME/bin/spark-shell \
 --conf spark.sql.extensions=io.qbeast.spark.internal.QbeastSparkSessionExtension \
 --conf spark.sql.catalog.spark_catalog=io.qbeast.spark.internal.sources.catalog.QbeastCatalog \
---packages io.qbeast:qbeast-spark_2.12:0.3.0,io.delta:delta-core_2.12:1.2.0
+--packages io.qbeast:qbeast-spark_2.12:0.3.1,io.delta:delta-core_2.12:1.2.0
 ```
 As an **_extra configuration_**, you can also change two global parameters of the index:
 


### PR DESCRIPTION
## Description

This PR is to fix the documentation with the new release version `0.3.1`. 

I've missed the new merge commit 0bdee8eafb31836e1fab10badf1b3b870bb5caee in the `0.3.0 `released package. That's why the final version for the **latest release is 0.3.1** (as it does not break any API, it only adds a new feature to the Catalog). Sorry for the inconvenience.  

Thanks to all the collaborators for making this possible, and Merry Christmas!