### PR TITLE
Compressing leaves - vanilla DP

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -236,7 +236,7 @@ trait TableChanges {
   val isNewRevision: Boolean
   val isOptimizeOperation: Boolean
   val updatedRevision: Revision
-  val compressionMap: Map[CubeId, CubeId]
+  val compressedLeaves: Set[CubeId]
   val deltaReplicatedSet: Set[CubeId]
   val announcedOrReplicatedSet: Set[CubeId]
   def cubeState(cubeId: CubeId): Option[String]

--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -236,6 +236,7 @@ trait TableChanges {
   val isNewRevision: Boolean
   val isOptimizeOperation: Boolean
   val updatedRevision: Revision
+  val compressionMap: Map[CubeId, CubeId]
   val deltaReplicatedSet: Set[CubeId]
   val announcedOrReplicatedSet: Set[CubeId]
   def cubeState(cubeId: CubeId): Option[String]

--- a/core/src/test/scala/io/qbeast/core/model/PointWeightIndexerTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/PointWeightIndexerTest.scala
@@ -20,7 +20,7 @@ class PointWeightIndexerTest extends AnyFlatSpec with Matchers {
     val isNewRevision: Boolean = false
     val isOptimizeOperation: Boolean = false
     val deltaReplicatedSet: Set[CubeId] = Set.empty
-    val compressionMap: Map[CubeId, CubeId] = Map.empty
+    val compressedLeaves: Set[CubeId] = Set.empty
 
     val updatedRevision: Revision =
       Revision(-1L, System.currentTimeMillis(), QTableID(""), 0, Vector.empty, Vector.empty)

--- a/core/src/test/scala/io/qbeast/core/model/PointWeightIndexerTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/PointWeightIndexerTest.scala
@@ -20,6 +20,7 @@ class PointWeightIndexerTest extends AnyFlatSpec with Matchers {
     val isNewRevision: Boolean = false
     val isOptimizeOperation: Boolean = false
     val deltaReplicatedSet: Set[CubeId] = Set.empty
+    val compressionMap: Map[CubeId, CubeId] = Map.empty
 
     val updatedRevision: Revision =
       Revision(-1L, System.currentTimeMillis(), QTableID(""), 0, Vector.empty, Vector.empty)

--- a/src/main/scala/io/qbeast/core/model/BroadcastedTableChanges.scala
+++ b/src/main/scala/io/qbeast/core/model/BroadcastedTableChanges.scala
@@ -45,15 +45,15 @@ object BroadcastedTableChanges {
       (announcedSet -- replicatedSet).map(id => id -> State.ANNOUNCED)
 
     val isNewRevision = revisionChanges.isDefined
-    val compressionMap =
-      if (!isNewRevision) Map.empty[CubeId, CubeId]
+    val compressedLeaves =
+      if (!isNewRevision) Set.empty[CubeId]
       else LeafCompression.compress(deltaNormalizedCubeWeights, updatedRevision.desiredCubeSize)
 
     BroadcastedTableChanges(
       isNewRevision = isNewRevision,
       isOptimizeOperation = deltaReplicatedSet.nonEmpty,
       updatedRevision = updatedRevision,
-      compressionMap = compressionMap,
+      compressedLeaves = compressedLeaves,
       deltaReplicatedSet = deltaReplicatedSet,
       announcedOrReplicatedSet = announcedSet ++ replicatedSet,
       cubeStates = SparkSession.active.sparkContext.broadcast(cubeStates.toMap),
@@ -66,7 +66,7 @@ case class BroadcastedTableChanges(
     isNewRevision: Boolean,
     isOptimizeOperation: Boolean,
     updatedRevision: Revision,
-    compressionMap: Map[CubeId, CubeId],
+    compressedLeaves: Set[CubeId],
     deltaReplicatedSet: Set[CubeId],
     announcedOrReplicatedSet: Set[CubeId],
     cubeStates: Broadcast[Map[CubeId, String]],

--- a/src/main/scala/io/qbeast/core/model/LeafCompression.scala
+++ b/src/main/scala/io/qbeast/core/model/LeafCompression.scala
@@ -6,19 +6,19 @@ object LeafCompression {
 
   def compress(
       cubeNormalizedWeights: Map[CubeId, NormalizedWeight],
-      desiredCubeSize: Int): Map[CubeId, CubeId] = {
+      desiredCubeSize: Int): Set[CubeId] = {
     if (cubeNormalizedWeights.isEmpty ||
       (cubeNormalizedWeights.size == 1 && cubeNormalizedWeights.keys.head.isRoot)) {
-      Map.empty[CubeId, CubeId]
+      Set.empty[CubeId]
     } else {
-      val compressionMap = mutable.Map.newBuilder[CubeId, CubeId]
-      compressionMap.sizeHint(cubeNormalizedWeights.size)
+      val compressedLeaves = mutable.Seq.newBuilder[CubeId]
+      compressedLeaves.sizeHint(cubeNormalizedWeights.size)
 
       cubeNormalizedWeights
         .filterNot(_._1.children.exists(cubeNormalizedWeights.contains))
         .mapValues(desiredCubeSize / _)
         .groupBy(_._1.parent.get)
-        .foreach { case (parent, leafSizes) =>
+        .foreach { case (_, leafSizes) =>
           val leafSizeIter = leafSizes.toSeq.sortBy(_._2).toIterator
           var continue = true
           var accSize = 0L
@@ -26,14 +26,14 @@ object LeafCompression {
             val (leaf, leafSize) = leafSizeIter.next()
             if (accSize + leafSize <= desiredCubeSize) {
               accSize += leafSize.toInt
-              compressionMap += leaf -> parent
+              compressedLeaves += leaf
             } else {
               continue = false
             }
           }
         }
 
-      compressionMap.result().toMap
+      compressedLeaves.result().toSet
     }
   }
 

--- a/src/main/scala/io/qbeast/core/model/LeafCompression.scala
+++ b/src/main/scala/io/qbeast/core/model/LeafCompression.scala
@@ -1,0 +1,40 @@
+package io.qbeast.core.model
+
+import scala.collection.mutable
+
+object LeafCompression {
+
+  def compress(
+      cubeNormalizedWeights: Map[CubeId, NormalizedWeight],
+      desiredCubeSize: Int): Map[CubeId, CubeId] = {
+    if (cubeNormalizedWeights.isEmpty ||
+      (cubeNormalizedWeights.size == 1 && cubeNormalizedWeights.keys.head.isRoot)) {
+      Map.empty[CubeId, CubeId]
+    } else {
+      val compressionMap = mutable.Map.newBuilder[CubeId, CubeId]
+      compressionMap.sizeHint(cubeNormalizedWeights.size)
+
+      cubeNormalizedWeights
+        .filterNot(_._1.children.exists(cubeNormalizedWeights.contains))
+        .mapValues(desiredCubeSize / _)
+        .groupBy(_._1.parent.get)
+        .foreach { case (parent, leafSizes) =>
+          val leafSizeIter = leafSizes.toSeq.sortBy(_._2).toIterator
+          var continue = true
+          var accSize = 0L
+          while (continue && leafSizeIter.hasNext) {
+            val (leaf, leafSize) = leafSizeIter.next()
+            if (accSize + leafSize <= desiredCubeSize) {
+              accSize += leafSize.toInt
+              compressionMap += leaf -> parent
+            } else {
+              continue = false
+            }
+          }
+        }
+
+      compressionMap.result().toMap
+    }
+  }
+
+}

--- a/src/main/scala/io/qbeast/core/model/LeafCompression.scala
+++ b/src/main/scala/io/qbeast/core/model/LeafCompression.scala
@@ -6,6 +6,7 @@ object LeafCompression {
 
   def compress(
       cubeNormalizedWeights: Map[CubeId, NormalizedWeight],
+      announcedOrReplicatedSet: Set[CubeId],
       desiredCubeSize: Int): Set[CubeId] = {
     if (cubeNormalizedWeights.isEmpty ||
       (cubeNormalizedWeights.size == 1 && cubeNormalizedWeights.keys.head.isRoot)) {
@@ -15,9 +16,12 @@ object LeafCompression {
       compressedLeaves.sizeHint(cubeNormalizedWeights.size)
 
       cubeNormalizedWeights
-        .filterNot(_._1.children.exists(cubeNormalizedWeights.contains))
+        .filterNot(cw =>
+          cw._1.children.exists(cubeNormalizedWeights.contains) ||
+            announcedOrReplicatedSet.contains(cw._1))
         .mapValues(desiredCubeSize / _)
         .groupBy(_._1.parent.get)
+        .filterNot(pCw => announcedOrReplicatedSet.contains(pCw._1))
         .foreach { case (_, leafSizes) =>
           val leafSizeIter = leafSizes.toSeq.sortBy(_._2).toIterator
           var continue = true

--- a/src/main/scala/io/qbeast/spark/index/QbeastColumns.scala
+++ b/src/main/scala/io/qbeast/spark/index/QbeastColumns.scala
@@ -36,12 +36,17 @@ object QbeastColumns {
    */
   val cubeToReplicateColumnName = "_qbeastCubeToReplicate"
 
-  val columnNames = Set(
+  val isCompressedColumnName = "_isCompressed"
+
+  val cubeAndIsCompressionColumnName = "_compressionResult"
+
+  val columnNames: Set[String] = Set(
     weightColumnName,
     cubeColumnName,
     stateColumnName,
     revisionColumnName,
-    cubeToReplicateColumnName)
+    cubeToReplicateColumnName,
+    isCompressedColumnName)
 
   /**
    * Creates an instance for a given data frame.
@@ -64,7 +69,8 @@ object QbeastColumns {
       cubeColumnIndex = columnIndexes.getOrElse(cubeColumnName, -1),
       stateColumnIndex = columnIndexes.getOrElse(stateColumnName, -1),
       revisionColumnIndex = columnIndexes.getOrElse(revisionColumnName, -1),
-      cubeToReplicateColumnIndex = columnIndexes.getOrElse(cubeToReplicateColumnName, -1))
+      cubeToReplicateColumnIndex = columnIndexes.getOrElse(cubeToReplicateColumnName, -1),
+      isCompressedColumnIndex = columnIndexes.getOrElse(isCompressedColumnName, -1))
   }
 
   /**
@@ -107,7 +113,8 @@ case class QbeastColumns(
     cubeColumnIndex: Int,
     stateColumnIndex: Int,
     revisionColumnIndex: Int,
-    cubeToReplicateColumnIndex: Int) {
+    cubeToReplicateColumnIndex: Int,
+    isCompressedColumnIndex: Int) {
 
   /**
    * Returns whether a given column is one of the Qbeast columns.
@@ -120,7 +127,8 @@ case class QbeastColumns(
     columnIndex == cubeColumnIndex ||
     columnIndex == stateColumnIndex ||
     columnIndex == revisionColumnIndex ||
-    columnIndex == cubeToReplicateColumnIndex
+    columnIndex == cubeToReplicateColumnIndex ||
+    columnIndex == isCompressedColumnIndex
   }
 
   /**
@@ -158,4 +166,5 @@ case class QbeastColumns(
    */
   def hasCubeToReplicateColumn: Boolean = cubeToReplicateColumnIndex >= 0
 
+  def hasIsCompressedColumnIndex: Boolean = isCompressedColumnIndex >= 0
 }

--- a/src/main/scala/io/qbeast/spark/index/SparkPointWeightIndexer.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkPointWeightIndexer.scala
@@ -17,9 +17,7 @@ private class SparkPointWeightIndexer(tableChanges: TableChanges, isReplication:
 
   private def compressionMapping(cube: CubeId): CompressionResult = {
     val (bytes, isCompressed) =
-      if (tableChanges.announcedOrReplicatedSet.contains(cube)) {
-        (cube.bytes, false)
-      } else if (tableChanges.compressedLeaves.contains(cube)) {
+      if (tableChanges.compressedLeaves.contains(cube)) {
         (cube.parent.get.bytes, true)
       } else {
         (cube.bytes, false)

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -140,4 +140,17 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         metrics.avgFanout.isNaN shouldBe true
       }
     }
+
+  it should "append data correctly" in withSparkAndTmpDir((spark, tmpDir) => {
+    val df = loadTestData(spark)
+    df.write
+      .mode("overwrite")
+      .format("qbeast")
+      .option("columnsToIndex", "user_id,price")
+      .option("cubeSize", "5000")
+      .save(tmpDir)
+
+    val metrics = QbeastTable.forPath(spark, tmpDir).getIndexMetrics()
+    println(metrics)
+  })
 }


### PR DESCRIPTION
## Description

Having too many small leaf cubes can hinder the read performance, which is the case when the resulting otree index has many levels.

These changes aim to test whether reducing the number of small files by collapsing small leaf cubes to their parent cube and creating a separate block can improve read performance.

## Type of change
- Enhancement

## Checklist:
- [ ] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [ ] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)
No collapsing:
![Screenshot 2022-12-23 at 17 07 30](https://user-images.githubusercontent.com/47899566/209368060-c8966c2f-98c5-413a-af3f-d1d00cac9a03.png)

Collapsing:
![Screenshot 2022-12-23 at 17 06 40](https://user-images.githubusercontent.com/47899566/209368089-8ffa9483-cb56-4ef4-8159-9ba5e9fc6a57.png)

**Test Configuration**:
* Spark Version:
* Hadoop Version:
* Cluster or local?