### PR TITLE
Enrich index metrics

### DIFF
--- a/docs/QbeastTable.md
+++ b/docs/QbeastTable.md
@@ -66,7 +66,7 @@ indexingColumns: ss_sold_date_sk,ss_item_sk
 avgFanout: 4.0
 depthOnBalance: 1.206019253488489
 
-Cubes size stats:
+Stats on cube sizes:
 Quartiles:
 - min: 456367
 - 1stQ: 498510

--- a/docs/QbeastTable.md
+++ b/docs/QbeastTable.md
@@ -41,9 +41,9 @@ qbeastTable.compact() // compacts small files into bigger ones
 
 ## Index Metrics
 
-`IndexMetrics` is a **case class** implemented to retrieve information about your table's **OTree index**.
+`IndexMetrics` aims to provide an overview for a given revision of the index.
 
-You can use it to **compare the index** build **with different indexing parameters** such as the `desiredCubeSize` and `columnsToIndex`.
+You can use it during development to compare different indexes built using different indexing parameters such as the `desiredCubeSize` and `columnsToIndex`.
 
 This is meant to be used as an easy access point to analyze the resulting index, which should come handy for comparing different index parameters or even implementations.
 
@@ -51,52 +51,61 @@ This is meant to be used as an easy access point to analyze the resulting index,
 val metrics = qbeastTable.getIndexMetrics()
 
 println(metrics)
+```
 
+```
 // EXAMPLE OUTPUT
 
-Tree Index Metrics:
-dimensionCount: 3
+OTree Index Metrics:
+dimensionCount: 2
 elementCount: 2879966589
-depth: 7
-cubeCount: 22217
+depth: 8
+cubeCount: 13141
 desiredCubeSize: 500000
-avgFan0ut: 8.0
-depthOnBalance: 1.4740213633300192
+indexingColumns: ss_sold_date_sk,ss_item_sk
+avgFanout: 4.0
+depthOnBalance: 1.206019253488489
 
-Non-Leaf Cube Size Stats
-Quantiles:
-- min: 482642
-- 1stQ: 542859
-- 2ndQ: 557161
-- 3rdQ: 576939
-- max: 633266
-- dev(l1, l2): (0.11743615196254953, 0.0023669553335121983)
-
-(level, average weight, average cube size):
-(0, (1.6781478192839184E-4,482642))
-(1, (0.001726577786432248,550513))
-(2, (0.014704148241220776,566831))
-(3, (0.1260420146029599,570841))
-(4, (0.7243052757165773, 557425))
-(5, (0.4040913470739245,527043))
-(6, (0.8873759316622165, 513460))
+Cubes size stats:
+Quartiles:
+- min: 456367
+- 1stQ: 498510
+- 2ndQ: 499954
+- 3rdQ: 501410
+- max: 536430
+Stats:
+- count: 3285
+- l1_dev: 0.00449603896499239
+- l2_dev: 1.3487574366807247E-4
+Level-wise stats:
+level, avgCubeSize, stdCubeSize, cubeCount, avgWeight:
+- 0:	497810,		4442,		1,	1.7361319627929786E-4
+- 1:	494798,		6480,		4,	8.689350799817908E-4
+- 2:	499781,		3871,		16,	0.003668841950401859
+- 3:	500516,		3899,		64,	0.015534089088738918
+- 4:	500289,		3876,		256,	0.06698862054431544
+- 5:	499966,		3865,		1024,	0.287867372830027
+- 6:	499962,		3865,		1792,	0.6729941083529944
+- 7:	500142,		3867,		128,	0.7959112180321912
 ```
 
 ## Metrics
 ### 1. General index metadata:
 
-- **dimensionCount**: the number of dimensions (indexed columns) in the index.
-- **elementCount**: the number of rows in the table.
-- **desiredCubeSize**: the desired cube size chosen at the moment of indexing.
-- **Number of cubes**: the number of nodes in the index tree.
-- **depth**: the number of levels in the tree.
-- **avgFanOut**: the average number of children per non-leaf cube. The max value for this metrics is `2 ^ dimensionCount`.
-- **depthOnBalance**: how far the depth of the tree is to the theoretical value if we were to have the same number of cubes and max fan out.
+- **dimensionCount**: the number of dimensions (indexed columns) in the index
+- **elementCount**: the number of records for this revision
+- **desiredCubeSize**: the desired cube size chosen at the moment of indexing
+- **Number of cubes**: the number of nodes in the index tree
+- **depth**: the number of levels in the tree
+- **avgFanOut**: the average number of children per non-leaf cube. The max value for this metrics is `2 ^ dimensionCount`
+- **depthOnBalance**: how far the depth of the tree is from the theoretical value, assuming all inner cubes have max fan out
+- **indexingColumns**: the indexing column names
 
-### 2. Cube sizes for non-leaf cubes:
-`Non-leaf cube size stats` is meant to describe the distribution of inner cube sizes:
+### 2. Cube sizes stats:
+Meant to describe the distribution of cube sizes:
+- `metrics.innerCubeSizeMetrics` for inner cubes. `metrics.leafCubeSizeMetrics` for leaf cubes
 - **min**, **max**, **quartiles**, and how far the cube sizes are from the `desiredCubeSize`(**l1 and l2 error**).
-- The average normalizedWeight and cube size per level.
+- The average normalizedWeight, cube size, count, and standard deviation per level.
 
 ### 3. `Map[CubeId, CubeStatus]`
-- More information can be extracted from the index tree through `metrics.cubeStatuses`.
+- More information can be extracted from the index tree through `metrics.cubeStatuses`

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -173,7 +173,7 @@ class QbeastTable private (
     val cubeStatuses = indexStatus.cubesStatuses
 
     val cubeCount = cubeStatuses.size
-    val depth = if (cubeCount == 0) 0 else cubeStatuses.map(_._1.depth).max
+    val depth = if (cubeCount == 0) -1 else cubeStatuses.map(_._1.depth).max + 1
     val elementCount = cubeStatuses.flatMap(_._2.files.map(_.elementCount)).sum
 
     val indexingColumns = revision.columnTransformers.map(_.columnName)

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -5,8 +5,7 @@ package io.qbeast.spark
 
 import io.qbeast.context.QbeastContext
 import io.qbeast.core.model.RevisionUtils.isStaging
-import io.qbeast.core.model.{CubeId, CubeStatus, QTableID, RevisionID}
-import io.qbeast.spark.MathOps.{depthOnBalance, l1Deviation, l2Deviation, std}
+import io.qbeast.core.model.{QTableID, RevisionID}
 import io.qbeast.spark.delta.DeltaQbeastSnapshot
 import io.qbeast.spark.internal.commands.{
   AnalyzeTableCommand,
@@ -14,10 +13,10 @@ import io.qbeast.spark.internal.commands.{
   OptimizeTableCommand
 }
 import io.qbeast.spark.table._
-import org.apache.spark.sql.{AnalysisExceptionFactory, SparkSession}
+import io.qbeast.spark.utils.{CubeSizeMetrics, IndexMetrics}
+import io.qbeast.spark.utils.MathOps.depthOnBalance
 import org.apache.spark.sql.delta.DeltaLog
-
-import scala.collection.immutable.SortedMap
+import org.apache.spark.sql.{AnalysisExceptionFactory, SparkSession}
 
 /**
  * Class for interacting with QbeastTable at a user level
@@ -109,78 +108,6 @@ class QbeastTable private (
     compact(latestRevisionAvailableID)
   }
 
-  def getIndexMetrics(revisionID: Option[RevisionID] = None): IndexMetrics = {
-    val allCubeStatuses = revisionID match {
-      case Some(id) => qbeastSnapshot.loadIndexStatus(id).cubesStatuses
-      case None => qbeastSnapshot.loadLatestIndexStatus.cubesStatuses
-    }
-
-    val cubeCount = allCubeStatuses.size
-    val depth = if (cubeCount == 0) 0 else allCubeStatuses.map(_._1.depth).max
-    val rowCount = allCubeStatuses.flatMap(_._2.files.map(_.elementCount)).sum
-
-    val dimensionCount = indexedColumns().size
-    val desiredCubeSize = cubeSize()
-
-    val (avgFanout, details) = getInnerCubeSizeDetails(allCubeStatuses, desiredCubeSize)
-
-    IndexMetrics(
-      allCubeStatuses,
-      dimensionCount,
-      rowCount,
-      depth,
-      cubeCount,
-      desiredCubeSize,
-      avgFanout,
-      depthOnBalance(depth, cubeCount, dimensionCount),
-      details)
-  }
-
-  private def getInnerCubeSizeDetails(
-      cubeStatuses: SortedMap[CubeId, CubeStatus],
-      desiredCubeSize: Int): (Double, NonLeafCubeSizeDetails) = {
-    val innerCubeStatuses = cubeStatuses.filterKeys(_.children.exists(cubeStatuses.contains))
-    val innerCubeSizes =
-      innerCubeStatuses.values.map(_.files.map(_.elementCount).sum).toSeq.sorted
-    val innerCubeCount = innerCubeSizes.size.toDouble
-
-    val avgFanout = innerCubeStatuses.keys.toSeq
-      .map(_.children.count(cubeStatuses.contains))
-      .sum / innerCubeCount
-
-    val details =
-      if (innerCubeCount == 0) {
-        NonLeafCubeSizeDetails(0, 0, 0, 0, 0, 0, 0, "")
-      } else {
-        val l1_dev = l1Deviation(innerCubeSizes, desiredCubeSize)
-        val l2_dev = l2Deviation(innerCubeSizes, desiredCubeSize)
-
-        val levelStats = "\n(level, average weight, average cube size):\n" +
-          innerCubeStatuses
-            .groupBy(cs => cs._1.depth)
-            .mapValues { m =>
-              val weights = m.values.map(_.normalizedWeight)
-              val elementCounts = m.values.map(_.files.map(_.elementCount).sum).toSeq
-              val mean = elementCounts.sum / elementCounts.size
-              (weights.sum / weights.size, mean, std(elementCounts, mean))
-            }
-            .toSeq
-            .sortBy(_._1)
-            .mkString("\n")
-
-        NonLeafCubeSizeDetails(
-          innerCubeSizes.min,
-          innerCubeSizes((innerCubeCount * 0.25).toInt),
-          innerCubeSizes((innerCubeCount * 0.50).toInt),
-          innerCubeSizes((innerCubeCount * 0.75).toInt),
-          innerCubeSizes.max,
-          l1_dev,
-          l2_dev,
-          levelStats)
-      }
-    (avgFanout, details)
-  }
-
   /**
    * Outputs the indexed columns of the table
    * @param revisionID the identifier of the revision.
@@ -231,93 +158,55 @@ class QbeastTable private (
     latestRevisionAvailableID
   }
 
+  /**
+   * Gather an overview of the index for a given revision
+   * @param revisionID optional RevisionID
+   * @return
+   */
+  def getIndexMetrics(revisionID: Option[RevisionID] = None): IndexMetrics = {
+    val indexStatus = revisionID match {
+      case Some(id) => qbeastSnapshot.loadIndexStatus(id)
+      case None => qbeastSnapshot.loadLatestIndexStatus
+    }
+
+    val revision = indexStatus.revision
+    val cubeStatuses = indexStatus.cubesStatuses
+
+    val cubeCount = cubeStatuses.size
+    val depth = if (cubeCount == 0) 0 else cubeStatuses.map(_._1.depth).max
+    val elementCount = cubeStatuses.flatMap(_._2.files.map(_.elementCount)).sum
+
+    val indexingColumns = revision.columnTransformers.map(_.columnName)
+    val dimensionCount = indexingColumns.size
+    val desiredCubeSize = revision.desiredCubeSize
+
+    val innerCs = cubeStatuses.filterKeys(_.children.exists(cubeStatuses.contains))
+
+    val avgFanout = if (innerCs.nonEmpty) {
+      innerCs.keys.toSeq
+        .map(_.children.count(cubeStatuses.contains))
+        .sum / innerCs.size.toDouble
+    } else 0d
+
+    IndexMetrics(
+      cubeStatuses,
+      dimensionCount,
+      elementCount,
+      depth,
+      cubeCount,
+      desiredCubeSize,
+      indexingColumns.mkString(","),
+      avgFanout,
+      depthOnBalance(depth, cubeCount, dimensionCount),
+      CubeSizeMetrics(innerCs, desiredCubeSize))
+  }
+
 }
 
 object QbeastTable {
 
   def forPath(sparkSession: SparkSession, path: String): QbeastTable = {
     new QbeastTable(sparkSession, new QTableID(path), QbeastContext.indexedTableFactory)
-  }
-
-}
-
-case class NonLeafCubeSizeDetails(
-    min: Long,
-    firstQuartile: Long,
-    secondQuartile: Long,
-    thirdQuartile: Long,
-    max: Long,
-    l1_dev: Double,
-    l2_dev: Double,
-    levelStats: String) {
-
-  override def toString: String = {
-    s"""Non-leaf Cube Size Stats:
-       |Quartiles:
-       |- min: $min
-       |- 1stQ: $firstQuartile
-       |- 2ndQ: $secondQuartile
-       |- 3rdQ: $thirdQuartile
-       |- max: $max
-       |- l1_dev: $l1_dev
-       |- l2_dev: $l2_dev
-       |$levelStats
-       |""".stripMargin
-  }
-
-}
-
-case class IndexMetrics(
-    cubeStatuses: Map[CubeId, CubeStatus],
-    dimensionCount: Int,
-    elementCount: Long,
-    depth: Int,
-    cubeCount: Int,
-    desiredCubeSize: Int,
-    avgFanout: Double,
-    depthOnBalance: Double,
-    nonLeafCubeSizeDetails: NonLeafCubeSizeDetails) {
-
-  override def toString: String = {
-    s"""OTree Index Metrics:
-       |dimensionCount: $dimensionCount
-       |elementCount: $elementCount
-       |depth: $depth
-       |cubeCount: $cubeCount
-       |desiredCubeSize: $desiredCubeSize
-       |avgFanout: $avgFanout
-       |depthOnBalance: $depthOnBalance
-       |\n$nonLeafCubeSizeDetails
-       |""".stripMargin
-  }
-
-}
-
-object MathOps {
-
-  def depthOnBalance(depth: Int, cubeCount: Int, dimensionCount: Int): Double = {
-    val c = math.pow(2, dimensionCount).toInt
-    val theoreticalDepth = logOfBase(c, 1 - cubeCount * (1 - c)) - 1
-    depth / theoreticalDepth
-  }
-
-  def logOfBase(base: Int, value: Double): Double = {
-    math.log10(value) / math.log10(base)
-  }
-
-  def l1Deviation(nums: Seq[Long], target: Int): Double =
-    nums
-      .map(num => math.abs(num - target))
-      .sum / nums.size.toDouble / target
-
-  def l2Deviation(nums: Seq[Long], target: Int): Double =
-    math.sqrt(
-      nums
-        .map(num => (num - target) * (num - target))
-        .sum) / nums.size.toDouble / target
-
-  def std(nums: Seq[Long], mean: Long): Long = {
-    math.sqrt(nums.map(n => (n - mean) * (n - mean)).sum / nums.size.toDouble).toLong
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
+++ b/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
@@ -1,0 +1,159 @@
+package io.qbeast.spark.utils
+
+import io.qbeast.core.model.{CubeId, CubeStatus}
+import io.qbeast.spark.utils.MathOps.{l1Deviation, l2Deviation, std}
+
+/**
+ * Metrics that aim to provide an overview for a given index revision
+ * @param cubeStatuses cube-wise metadata
+ * @param dimensionCount the number of indexing columns
+ * @param elementCount the total number of records
+ * @param depth the largest cube depth
+ * @param cubeCount the number of cubes
+ * @param desiredCubeSize the target cube size for all inner cubes
+ * @param indexingColumns columns on which the index is built
+ * @param avgFanout the average number of child cubes for all inner cubes
+ * @param depthOnBalance measurement for tree imbalance
+ * @param innerCubeSizeMetrics stats on inner cube sizes
+ */
+case class IndexMetrics(
+    cubeStatuses: Map[CubeId, CubeStatus],
+    dimensionCount: Int,
+    elementCount: Long,
+    depth: Int,
+    cubeCount: Int,
+    desiredCubeSize: Int,
+    indexingColumns: String,
+    avgFanout: Double,
+    depthOnBalance: Double,
+    innerCubeSizeMetrics: CubeSizeMetrics) {
+
+  /**
+   * Stats on leaf cube sizes.
+   */
+  lazy val leafCubeSizeMetrics: CubeSizeMetrics = {
+    val leafCs = cubeStatuses.filterKeys(!_.children.exists(cubeStatuses.contains))
+    CubeSizeMetrics(leafCs, desiredCubeSize)
+  }
+
+  override def toString: String = {
+    s"""OTree Index Metrics:
+       |dimensionCount: $dimensionCount
+       |elementCount: $elementCount
+       |depth: $depth
+       |cubeCount: $cubeCount
+       |desiredCubeSize: $desiredCubeSize
+       |indexingColumns: $indexingColumns
+       |avgFanout: $avgFanout
+       |depthOnBalance: $depthOnBalance
+       |\n$innerCubeSizeMetrics
+       |""".stripMargin
+  }
+
+}
+
+case class CubeSizeMetrics(
+    min: Long,
+    firstQuartile: Long,
+    secondQuartile: Long,
+    thirdQuartile: Long,
+    max: Long,
+    count: Int,
+    l1_dev: Double,
+    l2_dev: Double,
+    levelStats: String) {
+
+  override def toString: String = {
+    s"""Cubes size stats:
+       |Quartiles:
+       |- min: $min
+       |- 1stQ: $firstQuartile
+       |- 2ndQ: $secondQuartile
+       |- 3rdQ: $thirdQuartile
+       |- max: $max
+       |Stats:
+       |- count: $count
+       |- l1_dev: $l1_dev
+       |- l2_dev: $l2_dev
+       |$levelStats
+       |""".stripMargin
+  }
+
+}
+
+object CubeSizeMetrics {
+
+  def apply(cubeStatuses: Map[CubeId, CubeStatus], desiredCubeSize: Int): CubeSizeMetrics = {
+    if (cubeStatuses.isEmpty) CubeSizeMetrics(0, 0, 0, 0, 0, 0, 0, 0, "")
+    else {
+      val cubeSizes = cubeStatuses.values.map(_.files.map(_.elementCount).sum).toSeq.sorted
+      val cubeCount = cubeStatuses.size.toDouble
+
+      val l1_dev = l1Deviation(cubeSizes, desiredCubeSize)
+      val l2_dev = l2Deviation(cubeSizes, desiredCubeSize)
+
+      val levelStats = "\n(level, avgWeight, avgCubeSize, stdCubeSize, cubeCount):\n" +
+        cubeStatuses
+          .groupBy(cs => cs._1.depth)
+          .toSeq
+          .sortBy(_._1)
+          .map { case (level, m) =>
+            val cnt = m.size
+            val avgWeight = m.values.map(_.normalizedWeight).sum / cnt
+            val cubeSizeSum = m.values.map(_.files.map(_.elementCount).sum).sum
+            val avgCubeSize = cubeSizeSum / cnt
+            s"- $level:\t $avgWeight, $avgCubeSize, ${std(cubeSizes, avgCubeSize)}, $cnt"
+          }
+          .mkString("\n")
+
+      CubeSizeMetrics(
+        cubeSizes.min,
+        cubeSizes((cubeCount * 0.25).toInt),
+        cubeSizes((cubeCount * 0.50).toInt),
+        cubeSizes((cubeCount * 0.75).toInt),
+        cubeSizes.max,
+        cubeStatuses.size,
+        l1_dev,
+        l2_dev,
+        levelStats)
+    }
+  }
+
+}
+
+object MathOps {
+
+  /**
+   * Compute the relation between the actual depth over the theoretical depth of an index
+   * assuming full fanout for all inner cubes. The result can be used to measure tree imbalance.
+   * @param depth actual depth of the index
+   * @param cubeCount the number of actual cubes
+   * @param dimensionCount the number of dimensions
+   * @return
+   */
+  def depthOnBalance(depth: Int, cubeCount: Int, dimensionCount: Int): Double = {
+    val c = math.pow(2, dimensionCount).toInt
+    val theoreticalDepth = logOfBase(c, 1 - cubeCount * (1 - c)) - 1
+    depth / theoreticalDepth
+  }
+
+  def logOfBase(base: Int, value: Double): Double = {
+    math.log10(value) / math.log10(base)
+  }
+
+  def l1Deviation(nums: Seq[Long], target: Int): Double =
+    nums
+      .map(num => math.abs(num - target))
+      .sum / nums.size.toDouble / target
+
+  def l2Deviation(nums: Seq[Long], target: Int): Double =
+    math.sqrt(
+      nums
+        .map(num => (num - target) * (num - target))
+        .sum) / nums.size.toDouble / target
+
+  def std(nums: Seq[Long], mean: Long): Long = {
+    math.sqrt(nums.map(n => (n - mean) * (n - mean)).sum / nums.size.toDouble).toLong
+  }
+
+}

--- a/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
+++ b/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
@@ -78,6 +78,7 @@ case class CubeSizeMetrics(
        |- count: $count
        |- l1_dev: $l1_dev
        |- l2_dev: $l2_dev
+       |Level-wise stats:
        |$levelStats
        |""".stripMargin
   }
@@ -95,7 +96,7 @@ object CubeSizeMetrics {
       val l1_dev = l1Deviation(cubeSizes, desiredCubeSize)
       val l2_dev = l2Deviation(cubeSizes, desiredCubeSize)
 
-      val levelStats = "\n(level, avgWeight, avgCubeSize, stdCubeSize, cubeCount):\n" +
+      val levelStats = "level, avgCubeSize, stdCubeSize, cubeCount, avgWeight:\n" +
         cubeStatuses
           .groupBy(cs => cs._1.depth)
           .toSeq
@@ -105,7 +106,7 @@ object CubeSizeMetrics {
             val avgWeight = m.values.map(_.normalizedWeight).sum / cnt
             val cubeSizeSum = m.values.map(_.files.map(_.elementCount).sum).sum
             val avgCubeSize = cubeSizeSum / cnt
-            s"- $level:\t $avgWeight, $avgCubeSize, ${std(cubeSizes, avgCubeSize)}, $cnt"
+            s"- $level:\t$avgCubeSize,\t\t${std(cubeSizes, avgCubeSize)},\t\t$cnt,\t$avgWeight"
           }
           .mkString("\n")
 

--- a/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
+++ b/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
@@ -67,7 +67,7 @@ case class CubeSizeMetrics(
     levelStats: String) {
 
   override def toString: String = {
-    s"""Cubes size stats:
+    s"""Stats on cube sizes:
        |Quartiles:
        |- min: $min
        |- 1stQ: $firstQuartile
@@ -88,7 +88,7 @@ case class CubeSizeMetrics(
 object CubeSizeMetrics {
 
   def apply(cubeStatuses: Map[CubeId, CubeStatus], desiredCubeSize: Int): CubeSizeMetrics = {
-    if (cubeStatuses.isEmpty) CubeSizeMetrics(0, 0, 0, 0, 0, 0, 0, 0, "")
+    if (cubeStatuses.isEmpty) CubeSizeMetrics(-1, -1, -1, -1, -1, 0, -1, -1, "")
     else {
       val cubeSizes = cubeStatuses.values.map(_.files.map(_.elementCount).sum).toSeq.sorted
       val cubeCount = cubeStatuses.size.toDouble

--- a/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
+++ b/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
@@ -104,8 +104,7 @@ object CubeSizeMetrics {
           .map { case (level, m) =>
             val cnt = m.size
             val avgWeight = m.values.map(_.normalizedWeight).sum / cnt
-            val cubeSizeSum = m.values.map(_.files.map(_.elementCount).sum).sum
-            val avgCubeSize = cubeSizeSum / cnt
+            val avgCubeSize = m.values.map(_.files.map(_.elementCount).sum).sum / cnt
             s"- $level:\t$avgCubeSize,\t\t${std(cubeSizes, avgCubeSize)},\t\t$cnt,\t$avgWeight"
           }
           .mkString("\n")

--- a/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
+++ b/src/main/scala/io/qbeast/spark/utils/IndexMetrics.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
 package io.qbeast.spark.utils
 
 import io.qbeast.core.model.{CubeId, CubeStatus}

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -131,7 +131,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       }
   }
 
-  it should "single cube tree correctly" in
+  it should "handle single cube index correctly" in
     withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
       {
         val data = createDF(spark)
@@ -140,10 +140,20 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         writeTestData(data, columnsToIndex, cubeSize, tmpDir)
 
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
-        val metrics = qbeastTable.getIndexMetrics()
+        val metrics = qbeastTable.getIndexMetrics(Some(1L))
 
         metrics.depth shouldBe 0
-        metrics.avgFanout.isNaN shouldBe true
+        metrics.avgFanout shouldBe 0d
+
+        // There is no inner cube
+        metrics.innerCubeSizeMetrics.count shouldBe 0
+
+        val leafCsMetrics = metrics.leafCubeSizeMetrics
+        // scalastyle:off println
+        println(leafCsMetrics)
+        // scalastyle:on
+
+        leafCsMetrics.count shouldBe 1
       }
     }
 }


### PR DESCRIPTION
## Description
Fixes #142 

Add more index metrics such as indexingColumns, level cube count, level cube size deviation, and cube size metrics for the leaf cubes.

Example index metrics output:
```
OTree Index Metrics:
dimensionCount: 2
elementCount: 2879966589
depth: 8
cubeCount: 13141
desiredCubeSize: 500000
indexingColumns: ss_sold_date_sk,ss_item_sk
avgFanout: 4.0
depthOnBalance: 1.206019253488489
Cubes size stats:
Quartiles:
- min: 456367
- 1stQ: 498510
- 2ndQ: 499954
- 3rdQ: 501410
- max: 536430
Stats:
- count: 3285
- l1_dev: 0.00449603896499239
- l2_dev: 1.3487574366807247E-4
Level-wise stats:
level, avgCubeSize, stdCubeSize, cubeCount, avgWeight:
- 0:	497810,		4442,		1,	1.7361319627929786E-4
- 1:	494798,		6480,		4,	8.689350799817908E-4
- 2:	499781,		3871,		16,	0.003668841950401859
- 3:	500516,		3899,		64,	0.015534089088738918
- 4:	500289,		3876,		256,	0.06698862054431544
- 5:	499966,		3865,		1024,	0.287867372830027
- 6:	499962,		3865,		1792,	0.6729941083529944
- 7:	500142,		3867,		128,	0.7959112180321912
```

Access to leaf cube size metrics:
```
import io.qbeast.spark.QbeastTable

val metrics = QbeastTable.forPath(spark, path).getIndexMetrics()
val leafMetrics = metrics.leafCubeSizeMetrics

println(leafMetrics)
```

## Type of change

- Enhancement
- Documentation change

## Checklist:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).