### PR TITLE
API for passing stats

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -64,6 +64,29 @@ object Revision {
   }
 
   /**
+   * Create a new first revision for a table with pre-loaded transformations
+   * @param tableID the table identifier
+   * @param desiredCubeSize the desired cube size
+   * @param columnTransformers the column transformers
+   * @param columnTransformations the column transformations
+   * @return the new revision, with the specified transformations
+   */
+
+  def firstRevision(
+      tableID: QTableID,
+      desiredCubeSize: Int,
+      columnTransformers: IISeq[Transformer],
+      columnTransformations: IISeq[Transformation]): Revision = {
+    Revision(
+      0,
+      System.currentTimeMillis(),
+      tableID,
+      desiredCubeSize,
+      columnTransformers,
+      columnTransformations)
+  }
+
+  /**
    * Initialize Revision for table conversion. The RevisionID for a converted table is 0.
    * EmptyTransformers and EmptyTransformations are used. This Revision should always be
    * superseded.

--- a/core/src/main/scala/io/qbeast/core/transform/LinearTransformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/LinearTransformer.scala
@@ -23,6 +23,7 @@ case class LinearTransformer(columnName: String, dataType: QDataType) extends Tr
 
   private def getValue(row: Any): Any = {
     row match {
+      case d: java.lang.Long => d.intValue()
       case d: java.math.BigDecimal => d.doubleValue()
       case d: Timestamp => d.getTime()
       case d: Date => d.getTime()

--- a/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
+++ b/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
@@ -6,23 +6,30 @@ package io.qbeast.spark.internal
 import io.qbeast.core.model.QTableID
 import io.qbeast.spark.index.ColumnsToIndex
 import org.apache.spark.qbeast.config.DEFAULT_CUBE_SIZE
-import org.apache.spark.sql.AnalysisExceptionFactory
+import org.apache.spark.sql.{AnalysisExceptionFactory, DataFrame, SparkSession}
 
 /**
  * Container for Qbeast options.
  * @param columnsToIndex value of columnsToIndex option
  * @param cubeSize value of cubeSize option
  */
-case class QbeastOptions(columnsToIndex: Seq[String], cubeSize: Int)
+case class QbeastOptions(columnsToIndex: Seq[String], cubeSize: Int, stats: DataFrame)
 
 /**
  * Options available when trying to write in qbeast format
  */
+
 object QbeastOptions {
   val COLUMNS_TO_INDEX = "columnsToIndex"
   val CUBE_SIZE = "cubeSize"
   val PATH = "path"
+  val STATS = "stats"
 
+  /**
+   * Gets the columns to index from the options
+   * @param options the options passed on the dataframe
+   * @return
+   */
   private def getColumnsToIndex(options: Map[String, String]): Seq[String] = {
     val encodedColumnsToIndex = options.getOrElse(
       COLUMNS_TO_INDEX, {
@@ -33,10 +40,35 @@ object QbeastOptions {
     ColumnsToIndex.decode(encodedColumnsToIndex)
   }
 
+  /**
+   * Gets the desired cube size from the options
+   * @param options the options passed on the dataframe
+   * @return
+   */
+
   private def getDesiredCubeSize(options: Map[String, String]): Int = {
     options.get(CUBE_SIZE) match {
       case Some(value) => value.toInt
       case None => DEFAULT_CUBE_SIZE
+    }
+  }
+
+  /**
+   * Get the column stats from the options
+   * This stats should be in a JSON formatted string
+   * with the following schema
+   * {min(a):value, max(a):value, min(b):value...}
+   * @param options the options passed on the dataframe
+   * @return
+   */
+  private def getStats(options: Map[String, String]): DataFrame = {
+    val spark = SparkSession.active
+
+    options.get(STATS) match {
+      case Some(value) =>
+        import spark.implicits._
+        spark.read.json(Seq(value).toDS)
+      case None => spark.emptyDataFrame
     }
   }
 
@@ -48,7 +80,8 @@ object QbeastOptions {
   def apply(options: Map[String, String]): QbeastOptions = {
     val columnsToIndex = getColumnsToIndex(options)
     val desiredCubeSize = getDesiredCubeSize(options)
-    QbeastOptions(columnsToIndex, desiredCubeSize)
+    val stats = getStats(options)
+    QbeastOptions(columnsToIndex, desiredCubeSize, stats)
   }
 
   def loadTableIDFromParameters(parameters: Map[String, String]): QTableID = {


### PR DESCRIPTION
## Description

Fixes issue #157 . 

## Type of change

This PR includes a new feature on the DataFrame options. 

This new key/value pair allows the user to pass a set of statistics of the columns to index in a JSON formatted string. 

It will allow **a more flexible creation of `Revision`**, in order to **include values that might not be in the newly indexed `Dataframe`**, but that covers more space. For example, if you already know in advance the limits of the values you want to index, you can specify them through the `.option` method.

```scala

df.write.format("qbeast")
.option("columnsToIndex", "a,b")
.option("stats","""{"a_min":0,"a_max":10,"b_min":20.0,"b_max":70.0}""").save("/tmp/table")
```

The enforced structure of the `JSON` is:

```json
{
    "columnName_min" : value
    "columnName_max" : value

}
```





## Checklist:

Here is the list of things you should do before submitting this pull request:

- [ ] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [ ] Add tests.
- [ ] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

I've created some test under `SparkRevisionFactoryTest` class, which checks if the created `Revision` corresponds to the values introduced by the user.

**Test Configuration**:
* Spark Version: 3.2.2
* Hadoop Version: 3.3.0
* Cluster or local? Local