### PR TITLE
Apply Delta data skipping when needed

### DIFF
--- a/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QuerySpaceFromToTest.scala
@@ -29,6 +29,18 @@ class QuerySpaceFromToTest extends AnyFlatSpec with Matchers {
     querySpaceFromTo.intersectsWith(cube) shouldBe true
   }
 
+  it should "intersect correctly with non-existing coordinates" in {
+    val cube = CubeId.root(2)
+    val transformation = Seq(
+      LinearTransformation(1, 2, IntegerDataType),
+      LinearTransformation(1, 2, IntegerDataType))
+    val from = toSpaceCoordinates(Seq(None, Some(0)), transformation)
+    val to = toSpaceCoordinates(Seq(Some(2), None), transformation)
+    val querySpaceFromTo = new QuerySpaceFromTo(from, to)
+
+    querySpaceFromTo.intersectsWith(cube) shouldBe true
+  }
+
   it should "exclude beyond left limit" in {
     val cube = CubeId.root(1)
     val transformation = Seq(LinearTransformation(1, 2, IntegerDataType))

--- a/src/main/scala/io/qbeast/spark/delta/DeltaReadingUtils.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaReadingUtils.scala
@@ -1,0 +1,16 @@
+package io.qbeast.spark.delta
+
+import org.apache.spark.sql.{SparkSession}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+/**
+ * Placeholder for all Delta Reading Utils
+ * Delta has several methods and classes that contains Data Skipping hints
+ * If you want to extend the fuctionalities, use this object
+ */
+object DeltaReadingUtils {
+
+  private lazy val spark = SparkSession.active
+
+  def useStats: Boolean = spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_STATS_SKIPPING)
+}

--- a/src/main/scala/io/qbeast/spark/delta/DeltaReadingUtils.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaReadingUtils.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
 package io.qbeast.spark.delta
 
 import org.apache.spark.sql.{SparkSession}

--- a/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
+++ b/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.spark.delta
 
-import io.qbeast.core.model.QbeastBlock
+import io.qbeast.core.model.{QbeastBlock, Weight}
 import io.qbeast.core.model.RevisionUtils.stagingID
 import io.qbeast.spark.index.query.{QueryExecutor, QuerySpecBuilder}
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -59,7 +59,15 @@ case class OTreeIndex(index: TahoeLogFileIndex) extends FileIndex {
       index
         .matchingFiles(partitionFilters, dataFilters)
         .map(a => {
-          QbeastBlock(a.path, Map.empty, a.size, a.modificationTime)
+          QbeastBlock(
+            a.path,
+            0L,
+            Weight.MinValue,
+            Weight.MaxValue,
+            "",
+            0,
+            a.size,
+            a.modificationTime)
         })
     }
 

--- a/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
+++ b/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.spark.delta
 
-import io.qbeast.core.model.{QbeastBlock, Weight}
+import io.qbeast.core.model.{QbeastBlock}
 import io.qbeast.core.model.RevisionUtils.stagingID
 import io.qbeast.spark.index.query.{QueryExecutor, QuerySpecBuilder}
 import io.qbeast.spark.utils.{State, TagUtils}

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -172,8 +172,9 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
   }
 
   val isSampling: Boolean = {
-    !sparkFilters
-      .flatMap(filter => splitConjunctivePredicates(filter)).exists(isQbeastWeightExpression)
+    sparkFilters
+      .flatMap(filter => splitConjunctivePredicates(filter))
+      .exists(isQbeastWeightExpression)
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -171,4 +171,9 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression]) extends Ser
     QuerySpec(weightRange, querySpace)
   }
 
+  val isSampling: Boolean = {
+    !sparkFilters
+      .flatMap(filter => splitConjunctivePredicates(filter)).exists(isQbeastWeightExpression)
+  }
+
 }


### PR DESCRIPTION
## Description

Partially fixes issue #153 

## Type of change

This is a small change in order to improve the way we are processing the queries.

Even though we collect per-file statistics, we do not use them for filtering log files. (We use our own Qbeast algorithm for processing the cubes). Due to the improvement in data skipping techniques from the formats, this part can be avoided when the query does not apply `Sampling`.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

This is not tested properly yet. 