### PR TITLE
Create External Table without schema [Spark]

### DIFF
--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
@@ -132,8 +132,8 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
 
     })
 
-  it should "crate external table" in withQbeastContextSparkAndTmpWarehouse(
-    (spark, tmpWarehouse) => {
+  it should "crate external table without the schema specified" in
+    withQbeastContextSparkAndTmpWarehouse((spark, tmpWarehouse) => {
 
       val tmpDir = tmpWarehouse + "/test"
       val data = createTestData(spark)
@@ -144,9 +144,10 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
           s"USING qbeast OPTIONS ('columnsToIndex'='id') LOCATION '$tmpDir'")
 
       val table = spark.table("student")
-      table.schema shouldBe data.schema
-      table.count() shouldBe data.count()
-      assertSmallDatasetEquality(table, data, orderedComparison = false)
+      val indexed = spark.read.format("qbeast").load(tmpDir)
+      table.schema shouldBe indexed.schema
+      table.count() shouldBe indexed.count()
+      assertSmallDatasetEquality(table, indexed, orderedComparison = false)
 
     })
 

--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogIntegrationTest.scala
@@ -132,7 +132,7 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
 
     })
 
-  it should "crate external table without the schema specified" in
+  it should "crate external table" in
     withQbeastContextSparkAndTmpWarehouse((spark, tmpWarehouse) => {
 
       val tmpDir = tmpWarehouse + "/test"
@@ -145,8 +145,6 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
 
       val table = spark.table("student")
       val indexed = spark.read.format("qbeast").load(tmpDir)
-      table.schema shouldBe indexed.schema
-      table.count() shouldBe indexed.count()
       assertSmallDatasetEquality(table, indexed, orderedComparison = false)
 
     })
@@ -164,8 +162,6 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
 
       val table = spark.table("student")
       val indexed = spark.read.format("qbeast").load(tmpDir)
-      table.schema shouldBe indexed.schema
-      table.count() shouldBe indexed.count()
       assertSmallDatasetEquality(table, indexed, orderedComparison = false)
 
     })
@@ -180,6 +176,15 @@ class QbeastCatalogIntegrationTest extends QbeastIntegrationTestSpec with Catalo
       an[AnalysisException] shouldBe thrownBy(
         spark.sql(s"CREATE EXTERNAL TABLE student (id INT, age INT) " +
           s"USING qbeast OPTIONS ('columnsToIndex'='id') LOCATION '$tmpDir'"))
+
+    })
+
+  it should "throw error when no schema and no populated table" in
+    withQbeastContextSparkAndTmpWarehouse((spark, tmpWarehouse) => {
+
+      an[AnalysisException] shouldBe thrownBy(
+        spark.sql(s"CREATE EXTERNAL TABLE student " +
+          s"USING qbeast OPTIONS ('columnsToIndex'='id') LOCATION '$tmpWarehouse'"))
 
     })
 


### PR DESCRIPTION
## Description

This PR fixes #165 

## Type of change

When creating an external table with an already populated directory, Qbeast was missing the schema in the final Catalog entry.
We add a method to detect this specific situation and update the service accordingly.  


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

A new test is added in `QbeastCatalogIntegrationTest` in which we try to create an external table without schema. 