### PR TITLE
Fix column stats

### DIFF
--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -61,6 +61,10 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable {
   private[index] def calculateRevisionChanges(
       row: Row,
       revision: Revision): Option[RevisionChange] = {
+    // TODO: When all indexing columns are provided with a boundary, a new revision is
+    //  created directly. If the actual data boundaries are not contained by those
+    //  values, the RevisionID would then increase again by 1, leaving a discontinued
+    //  sequence of RevisionIDs in the metadata.
 
     val newTransformation =
       revision.columnTransformers.map(_.makeTransformation(colName => row.getAs[Object](colName)))

--- a/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
+++ b/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.{AnalysisExceptionFactory, DataFrame, SparkSession}
  * @param columnsToIndex value of columnsToIndex option
  * @param cubeSize value of cubeSize option
  */
-case class QbeastOptions(columnsToIndex: Seq[String], cubeSize: Int, stats: DataFrame)
+case class QbeastOptions(columnsToIndex: Seq[String], cubeSize: Int, stats: Option[DataFrame])
 
 /**
  * Options available when trying to write in qbeast format
@@ -61,14 +61,14 @@ object QbeastOptions {
    * @param options the options passed on the dataframe
    * @return
    */
-  private def getStats(options: Map[String, String]): DataFrame = {
+  private def getStats(options: Map[String, String]): Option[DataFrame] = {
     val spark = SparkSession.active
 
     options.get(STATS) match {
       case Some(value) =>
         import spark.implicits._
-        spark.read.json(Seq(value).toDS)
-      case None => spark.emptyDataFrame
+        Some(spark.read.json(Seq(value).toDS))
+      case None => None
     }
   }
 

--- a/src/test/scala/io/qbeast/spark/index/NewRevisionTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/NewRevisionTest.scala
@@ -219,7 +219,7 @@ class NewRevisionTest
         val revision = qbeastSnapshot.loadLatestRevision
         val transformation = revision.transformations.head
 
-        revision.revisionID shouldBe >(0)
+        revision.revisionID should be > 0L
         transformation shouldBe a[LinearTransformation]
         transformation.asInstanceOf[LinearTransformation].minNumber shouldBe 1
         transformation.asInstanceOf[LinearTransformation].maxNumber shouldBe 10

--- a/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
@@ -103,7 +103,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
           QbeastOptions.STATS -> """{ "a_min": 0, "a_max": 10 }"""))
 
     revision.tableID shouldBe qid
-    revision.revisionID shouldBe 0
+    // the reason while it's 1 is because columnStats are provided here
+    revision.revisionID shouldBe 1
     revision.desiredCubeSize shouldBe 10
     revision.columnTransformers shouldBe Vector(LinearTransformer("a", IntegerDataType))
 
@@ -131,7 +132,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
               """{ "a_min": 0, "a_max": 10, "b_min": 10.0, "b_max": 20.0}""".stripMargin))
 
       revision.tableID shouldBe qid
-      revision.revisionID shouldBe 0
+      // the reason while it's 1 is because columnStats are provided here
+      revision.revisionID shouldBe 1
       revision.desiredCubeSize shouldBe 10
       revision.columnTransformers shouldBe Vector(
         LinearTransformer("a", IntegerDataType),


### PR DESCRIPTION
## Description

Fixes #176

#176 is caused by `calculateRevisionChanges` not being able to detect a change of revision because the revision used is already updated with valid columnStats.

The solution provided here is to directly update the `RevisonID` when dimension boundaries are provided for all indexing columns before any further processing. So, if there's no `SpaceChanges` detected, the revision we use would still have the proper value: `latestRevision.revisionID + 1`.

An unintended consequence of this approach would be incrementing the `RevisionID` twice if column boundaries are provided for all indexing columns but some or all are smaller than that from the actual data - once during revision creation, and again during `spaceChanges.createNewRevision`. This 'issue' has no affect on the data or the integrity of the index at all, though it'd be nice to remove it.

When the `columnStats` provided are valid, that is, larger than the min/max of the actual data, we face with an inconsistency for the value of `isNewRevision` from `BroadcastedTableChanges`; it'd be set to `false` when it should be `true`. Currently this leads to no harm by the way `isNewRevision` is defined in `updateQbeastMetadata`, but it is something to take into account.
 
## Type of change

**Bug fix**
## Checklist:
- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)
- Test RevisionID = 0 is not created when valid columnStats are used during the first write.
