### PR TITLE
Align cube stats columns when printing

### DIFF
--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -127,8 +127,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         val rootSizeStd =
           metrics.innerCubeSizeMetrics.levelStats
             .split("\n")(1)
-            .split(",")(1)
-            .replaceAll("\t", "")
+            .split(" +")(3)
 
         rootSizeStd shouldBe "0"
       }


### PR DESCRIPTION
## Description
Pretty print for level-wise cube stats when computing index metrics:

From this:
```
Level-wise stats:
level, avgCubeSize, stdCubeSize, cubeCount, avgWeight:
- 0:	980206,		0,		1,	8.005429992453528E-4
- 1:	980363,		660,		4,	0.0041565194852083275
- 2:	981671,		1548,		16,	0.018375531352561786
- 3:	997715,		67997,		56,	0.06759438497324209
- 4:	1000715,		70513,		84,	0.13032458088667634
- 5:	1001532,		70545,		84,	0.19846727799566344
- 6:	1015797,		93392,		84,	0.26661787450512003
- 7:	1000883,		2053,		84,	0.33609457503115037
- 8:	1000840,		1790,		84,	0.4055793517315446
- 9:	1000673,		1229,		84,	0.47510466986543376
- 10:	1000951,		1101,		84,	0.544636712225923
- 11:	1001080,		1283,		84,	0.6141759610357659
- 12:	1001121,		1178,		84,	0.6837241991124626
- 13:	1001160,		1102,		99,	0.7945777163997536
- 14:	1001361,		1300,		78,	0.8341979974172398
- 15:	1001616,		1087,		60,	0.8836494600556286
- 16:	1001793,		1101,		34,	0.9102269840861432
- 17:	1001548,		1303,		15,	0.9527713498456337
```

to this:
```
Level-wise stats:
level avgCubeSize stdCubeSize cubeCount avgWeight
    0      980206           0         1    8.0E-4
    1      980363         660         4   0.00415
    2      981671        1548        16   0.01837
    3      997715       67997        56   0.06759
    4     1000715       70513        84   0.13032
    5     1001532       70545        84   0.19846
    6     1015797       93392        84   0.26661
    7     1000883        2053        84   0.33609
    8     1000840        1790        84   0.40557
    9     1000673        1229        84    0.4751
   10     1000951        1101        84   0.54463
   11     1001080        1283        84   0.61417
   12     1001121        1178        84   0.68372
   13     1001160        1102        99   0.79457
   14     1001361        1300        78   0.83419
   15     1001616        1087        60   0.88364
   16     1001793        1101        34   0.91022
   17     1001548        1303        15   0.95277


```
## Type of change

Describe the change you're making: how it affects the API, user experience...
- "bug" fix