### PR TITLE
Support for OR and IN operator

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
@@ -11,9 +11,9 @@ import io.qbeast.core.transform.{HashTransformation, Transformation}
 trait QuerySpace {
 
   /**
-   * Checks if other query space is contained in the current
+   * Checks if this QuerySpace contains other QuerySpace
    * @param other the other query space
-   * @return true if they overlap
+   * @return true if this QuerySpace contains the other QuerySpace
    */
 
   def contains(other: QuerySpace): Boolean
@@ -44,7 +44,9 @@ case class EmptySpace() extends QuerySpace {
 
   override def intersectsWith(cube: CubeId): Boolean = false
 
-  override def contains(other: QuerySpace): Boolean = false
+  // The only case in which EmptySpace contains other QuerySpace
+  // is when other QuerySpace is an EmptySpace
+  override def contains(other: QuerySpace): Boolean = other.isInstanceOf[EmptySpace]
 }
 
 /**

--- a/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QuerySpace.scala
@@ -124,21 +124,13 @@ object QuerySpace {
     //  without transforming the values first
     from.indices.foreach { i =>
       val (isOverlappingDim, isAllDim) = (from(i), to(i), transformations(i)) match {
-        case (
-              Some(f),
-              Some(t),
-              _: HashTransformation
-            ) => // Accept Range Filters for HashTransformation only if they have min and max values
-          if (f == t) {
-            isPointStringSearch = true
-            (true, true)
-          } else {
-            (f <= t && f <= 1d && t >= 0d, f <= t && f <= 0d && t >= 1d)
-          }
-        case (_, _, _: HashTransformation) | (None, None, _) =>
+        case (Some(f), Some(t), _: HashTransformation) if (f == t) =>
+          isPointStringSearch = true
           (true, true)
         case (Some(f), Some(t), _) =>
           (f <= t && f <= 1d && t >= 0d, f <= t && f <= 0d && t >= 1d)
+        case (_, _, _: HashTransformation) | (None, None, _) =>
+          (true, true)
         case (None, Some(t), _) =>
           (t >= 0d, t >= 1d)
         case (Some(f), None, _) =>

--- a/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
+++ b/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
@@ -45,7 +45,7 @@ case class OTreeIndex(index: TahoeLogFileIndex) extends FileIndex with Logging {
 
   protected def matchingBlocks(
       partitionFilters: Seq[Expression],
-      dataFilters: Seq[Expression]): Seq[QbeastBlock] = {
+      dataFilters: Seq[Expression]): Iterable[QbeastBlock] = {
 
     val querySpecBuilder = new QuerySpecBuilder(dataFilters ++ partitionFilters)
     val queryExecutor = new QueryExecutor(querySpecBuilder, qbeastSnapshot)

--- a/src/main/scala/io/qbeast/spark/index/query/QbeastFilters.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QbeastFilters.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
 package io.qbeast.spark.index.query
 
 import org.apache.spark.sql.catalyst.expressions.Expression

--- a/src/main/scala/io/qbeast/spark/index/query/QbeastFilters.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QbeastFilters.scala
@@ -1,0 +1,5 @@
+package io.qbeast.spark.index.query
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+case class QbeastFilters(weightFilters: Seq[Expression], queryFilters: Seq[Expression])

--- a/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
@@ -23,7 +23,7 @@ class QueryExecutor(querySpecBuilder: QuerySpecBuilder, qbeastSnapshot: QbeastSn
 
     qbeastSnapshot.loadAllRevisions.flatMap { revision =>
       val querySpecs = querySpecBuilder.build(revision)
-      querySpecs.par.flatMap { querySpec =>
+      querySpecs.flatMap { querySpec =>
         (querySpec.isSampling, querySpec.querySpace) match {
           case (_, _: QuerySpaceFromTo) | (true, _: AllSpace) =>
             val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)

--- a/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryExecutor.scala
@@ -22,18 +22,20 @@ class QueryExecutor(querySpecBuilder: QuerySpecBuilder, qbeastSnapshot: QbeastSn
   def execute(): Seq[QbeastBlock] = {
 
     qbeastSnapshot.loadAllRevisions.flatMap { revision =>
-      val querySpec = querySpecBuilder.build(revision)
-      (querySpec.isSampling, querySpec.querySpace) match {
-        case (_, _: QuerySpaceFromTo) | (true, _: AllSpace) =>
-          val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
-          val matchingBlocks = executeRevision(querySpec, indexStatus)
-          matchingBlocks
-        case (false, _: AllSpace) =>
-          val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
-          indexStatus.cubesStatuses.values.flatMap { status =>
-            status.files.filter(_.state == State.FLOODED)
-          }
-        case _ => Seq.empty[QbeastBlock]
+      val querySpecs = querySpecBuilder.build(revision)
+      querySpecs.flatMap { querySpec =>
+        (querySpec.isSampling, querySpec.querySpace) match {
+          case (_, _: QuerySpaceFromTo) | (true, _: AllSpace) =>
+            val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
+            val matchingBlocks = executeRevision(querySpec, indexStatus)
+            matchingBlocks
+          case (false, _: AllSpace) =>
+            val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
+            indexStatus.cubesStatuses.values.flatMap { status =>
+              status.files.filter(_.state == State.FLOODED)
+            }
+          case _ => Seq.empty[QbeastBlock]
+        }
       }
     }
   }

--- a/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
@@ -5,6 +5,7 @@ package io.qbeast.spark.index.query
 
 import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.execution.InSubqueryExec
@@ -12,11 +13,10 @@ import org.apache.spark.unsafe.types.UTF8String
 
 private[query] trait QueryFiltersUtils {
 
-  def hasQbeastColumnReference(
-      expr: Expression,
-      indexedColumns: Seq[String],
-      spark: SparkSession): Boolean = {
-    val nameEquality = spark.sessionState.analyzer.resolver
+  lazy val spark: SparkSession = SparkSession.active
+  lazy val nameEquality: Resolver = spark.sessionState.analyzer.resolver
+
+  def hasQbeastColumnReference(expr: Expression, indexedColumns: Seq[String]): Boolean = {
     expr.references.forall { r =>
       indexedColumns.exists(nameEquality(r.name, _))
     }
@@ -49,8 +49,7 @@ private[query] trait QueryFiltersUtils {
     }
   }
 
-  def hasColumnReference(expr: Expression, columnName: String, spark: SparkSession): Boolean = {
-    val nameEquality = spark.sessionState.analyzer.resolver
+  def hasColumnReference(expr: Expression, columnName: String): Boolean = {
     expr.references.forall(r => nameEquality(r.name, columnName))
   }
 

--- a/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
@@ -106,6 +106,22 @@ private[query] trait QueryFiltersUtils {
     }
   }
 
+  def isStringRangeExpression(expression: Expression): Boolean = {
+    val value = expression match {
+      case GreaterThan(_, l: Literal) => l
+      case GreaterThanOrEqual(_, l: Literal) => l
+      case LessThan(l: Literal, _) => l
+      case LessThanOrEqual(l: Literal, _) => l
+      case LessThan(_, l: Literal) => l
+      case LessThanOrEqual(_, l: Literal) => l
+      case GreaterThan(l: Literal, _) => l
+      case GreaterThanOrEqual(l: Literal, _) => l
+      case _ => return false
+    }
+
+    value.dataType.isInstanceOf[StringType]
+  }
+
   /**
    * Transform an expression
    * Based on Delta DataSkippingReader

--- a/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
 package io.qbeast.spark.index.query
 
 import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash

--- a/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
@@ -1,0 +1,104 @@
+package io.qbeast.spark.index.query
+
+import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.TypeUtils
+import org.apache.spark.sql.execution.InSubqueryExec
+import org.apache.spark.unsafe.types.UTF8String
+
+private[query] trait QueryFiltersUtils {
+
+  lazy val spark: SparkSession = SparkSession.active
+  lazy val nameEquality: Resolver = spark.sessionState.analyzer.resolver
+
+  def hasQbeastColumnReference(expr: Expression, indexedColumns: Seq[String]): Boolean = {
+    expr.references.forall { r =>
+      indexedColumns.exists(nameEquality(r.name, _))
+    }
+  }
+
+  def isQbeastWeightExpression(expression: Expression): Boolean = {
+    expression match {
+      case BinaryComparison(_: QbeastMurmur3Hash, _) => true
+      case _ => false
+    }
+  }
+
+  def isDisjunctivePredicate(condition: Expression): Boolean = {
+    condition.isInstanceOf[Or]
+  }
+
+  def splitDisjunctivePredicates(condition: Expression): Seq[Expression] = {
+    condition match {
+      case Or(cond1, cond2) =>
+        splitDisjunctivePredicates(cond1) ++ splitDisjunctivePredicates(cond2)
+      case other => other :: Nil
+    }
+  }
+
+  def splitConjunctivePredicates(condition: Expression): Seq[Expression] = {
+    condition match {
+      case And(cond1, cond2) =>
+        splitConjunctivePredicates(cond1) ++ splitConjunctivePredicates(cond2)
+      case other => other :: Nil
+    }
+  }
+
+  def hasColumnReference(expr: Expression, columnName: String): Boolean = {
+    expr.references.forall(r => nameEquality(r.name, columnName))
+  }
+
+  def sparkTypeToCoreType(value: Any): Any = {
+    value match {
+      case s: UTF8String => s.toString
+      case _ => value
+    }
+  }
+
+  // Based on Delta DataSkippingReader
+  // Since we already know this filter are eligible for skipping
+  // we directly output the RangePredicate
+  def inToDataFilter(column: Expression, values: Seq[Any]): Seq[Expression] = {
+
+    val dataType = column.dataType
+    lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
+    val min = Literal(values.min(ordering), dataType)
+    val max = Literal(values.max(ordering), dataType)
+    Seq(LessThanOrEqual(column, max), GreaterThanOrEqual(column, min))
+
+  }
+
+  def transformPredicates(expression: Expression): Seq[Expression] = {
+    expression match {
+      case in @ In(a, values) if in.inSetConvertible =>
+        inToDataFilter(a, values.map(_.asInstanceOf[Literal].value))
+
+      // The optimizer automatically converts all but the shortest eligible IN-lists to InSet.
+      case InSet(a, values) =>
+        inToDataFilter(a, values.toSeq)
+
+      // Treat IN(... subquery ...) as a normal IN-list, since the subquery already ran before now.
+      case in: InSubqueryExec =>
+        // At this point the subquery has been materialized so it is safe to call get on the Option.
+        inToDataFilter(in.child, in.values().get.toSeq)
+
+      // Move the literal in the left to the right of the operator
+      // to parse them easily in QuerySpecBuilder
+      case LessThan(l: Literal, column) => GreaterThanOrEqual(column, l) :: Nil
+
+      case LessThanOrEqual(l: Literal, column) => GreaterThan(column, l) :: Nil
+
+      case EqualTo(l: Literal, column) => EqualTo(column, l) :: Nil
+
+      case GreaterThan(l: Literal, column) => LessThanOrEqual(column, l) :: Nil
+
+      case GreaterThanOrEqual(l: Literal, column) => LessThan(column, l) :: Nil
+
+      // If the Filter involves any other predicates, return without pre-processing
+      case other => other :: Nil
+    }
+  }
+
+}

--- a/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
@@ -9,10 +9,7 @@ import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.execution.InSubqueryExec
-import org.apache.spark.sql.types.StringType
 import org.apache.spark.unsafe.types.UTF8String
-
-import scala.util.hashing.MurmurHash3
 
 private[query] trait QueryFiltersUtils {
 
@@ -106,22 +103,6 @@ private[query] trait QueryFiltersUtils {
     }
   }
 
-  def isStringRangeExpression(expression: Expression): Boolean = {
-    val value = expression match {
-      case GreaterThan(_, l: Literal) => l
-      case GreaterThanOrEqual(_, l: Literal) => l
-      case LessThan(l: Literal, _) => l
-      case LessThanOrEqual(l: Literal, _) => l
-      case LessThan(_, l: Literal) => l
-      case LessThanOrEqual(_, l: Literal) => l
-      case GreaterThan(l: Literal, _) => l
-      case GreaterThanOrEqual(l: Literal, _) => l
-      case _ => return false
-    }
-
-    value.dataType.isInstanceOf[StringType]
-  }
-
   /**
    * Transform an expression
    * Based on Delta DataSkippingReader
@@ -135,35 +116,10 @@ private[query] trait QueryFiltersUtils {
   def inToRangeExpressions(column: Expression, values: Seq[Any]): Seq[Expression] = {
 
     val dataType = column.dataType
-
-    // If the type is String
-    // We need to apply first a Hash to understand what are the minimum and maximum
-    // that we need to search with Qbeast
-    if (dataType.isInstanceOf[StringType]) {
-      // Hash the values to match the search with Qbeast
-      val valuesHashed =
-        values.map(v => (v, MurmurHash3.bytesHash(v.asInstanceOf[UTF8String].getBytes)))
-
-      // Create ordering for new values
-      val ordering = new Ordering[(Any, Int)] {
-
-        /**
-         * Compare (Any, Int) by using Int comparison
-         */
-        override def compare(x: (Any, Int), y: (Any, Int)): Int =
-          Ordering[Int].compare(x._2, y._2)
-      }
-
-      val min = Literal(valuesHashed.min(ordering)._1, dataType)
-      val max = Literal(valuesHashed.max(ordering)._1, dataType)
-      Seq(LessThanOrEqual(column, max), GreaterThanOrEqual(column, min))
-
-    } else { // Otherwise we use the implicit ordering
-      lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
-      val min = Literal(values.min(ordering), dataType)
-      val max = Literal(values.max(ordering), dataType)
-      Seq(LessThanOrEqual(column, max), GreaterThanOrEqual(column, min))
-    }
+    lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
+    val min = Literal(values.min(ordering), dataType)
+    val max = Literal(values.max(ordering), dataType)
+    Seq(LessThanOrEqual(column, max), GreaterThanOrEqual(column, min))
 
   }
 

--- a/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QueryFiltersUtils.scala
@@ -16,11 +16,33 @@ private[query] trait QueryFiltersUtils {
   lazy val spark: SparkSession = SparkSession.active
   lazy val nameEquality: Resolver = spark.sessionState.analyzer.resolver
 
+  /**
+   * Checks if an expression references to a certain column
+   * @param expr the Expression
+   * @param columnName the name of the column
+   * @return
+   */
+  def hasColumnReference(expr: Expression, columnName: String): Boolean = {
+    expr.references.forall(r => nameEquality(r.name, columnName))
+  }
+
+  /**
+   * Checks if an expression references to any of the Qbeast Indexed Columns
+   * @param expr the Expression
+   * @param indexedColumns the current indexed columns
+   * @return
+   */
   def hasQbeastColumnReference(expr: Expression, indexedColumns: Seq[String]): Boolean = {
     expr.references.forall { r =>
       indexedColumns.exists(nameEquality(r.name, _))
     }
   }
+
+  /**
+   * Checks if an Expression is a Qbeast Weight filter
+   * @param expression the Expression
+   * @return
+   */
 
   def isQbeastWeightExpression(expression: Expression): Boolean = {
     expression match {
@@ -29,29 +51,50 @@ private[query] trait QueryFiltersUtils {
     }
   }
 
-  def isDisjunctivePredicate(condition: Expression): Boolean = {
+  /**
+   * Checks if an Expression is Disjunctive (OR)
+   * @param condition the expression
+   * @return
+   */
+  def isDisjunctiveExpression(condition: Expression): Boolean = {
     condition.isInstanceOf[Or]
   }
 
-  def splitDisjunctivePredicates(condition: Expression): Seq[Expression] = {
+  /**
+   * Recursively split Disjunctive operators (AND) in an expression
+   *
+   * @param condition the expression to evaluate
+   * @return
+   */
+
+  def splitDisjunctiveExpressions(condition: Expression): Seq[Expression] = {
     condition match {
       case Or(cond1, cond2) =>
-        splitDisjunctivePredicates(cond1) ++ splitDisjunctivePredicates(cond2)
+        splitDisjunctiveExpressions(cond1) ++ splitDisjunctiveExpressions(cond2)
       case other => other :: Nil
     }
   }
 
-  def splitConjunctivePredicates(condition: Expression): Seq[Expression] = {
+  /**
+   * Recursively split Conjunctive operators (OR) in an expression
+   *
+   * @param condition the expression to evaluate
+   * @return
+   */
+
+  def splitConjunctiveExpressions(condition: Expression): Seq[Expression] = {
     condition match {
       case And(cond1, cond2) =>
-        splitConjunctivePredicates(cond1) ++ splitConjunctivePredicates(cond2)
+        splitConjunctiveExpressions(cond1) ++ splitConjunctiveExpressions(cond2)
       case other => other :: Nil
     }
   }
 
-  def hasColumnReference(expr: Expression, columnName: String): Boolean = {
-    expr.references.forall(r => nameEquality(r.name, columnName))
-  }
+  /**
+   * Convert an Spark String type to a Scala core type
+   * @param value the value to convert
+   * @return
+   */
 
   def sparkTypeToCoreType(value: Any): Any = {
     value match {
@@ -63,7 +106,7 @@ private[query] trait QueryFiltersUtils {
   // Based on Delta DataSkippingReader
   // Since we already know this filter are eligible for skipping
   // we directly output the RangePredicate
-  def inToDataFilter(column: Expression, values: Seq[Any]): Seq[Expression] = {
+  private def inToRangeExpressions(column: Expression, values: Seq[Any]): Seq[Expression] = {
 
     val dataType = column.dataType
     lazy val ordering = TypeUtils.getInterpretedOrdering(dataType)
@@ -73,19 +116,30 @@ private[query] trait QueryFiltersUtils {
 
   }
 
-  def transformInPredicates(expression: Expression): Seq[Expression] = {
+  /**
+   * Transform IN expression to a Range(>=, <=)
+   *
+   * Based on Delta DataSkippingReader
+   * We match cases in which an IN predicate is called
+   * and transform them to a range predicate (>=, <=)
+   *
+   * @param expression the expression to transform
+   * @return the sequence of expressions corresponding to the range
+   */
+
+  def transformInExpressions(expression: Expression): Seq[Expression] = {
     expression match {
       case in @ In(a, values) if in.inSetConvertible =>
-        inToDataFilter(a, values.map(_.asInstanceOf[Literal].value))
+        inToRangeExpressions(a, values.map(_.asInstanceOf[Literal].value))
 
       // The optimizer automatically converts all but the shortest eligible IN-lists to InSet.
       case InSet(a, values) =>
-        inToDataFilter(a, values.toSeq)
+        inToRangeExpressions(a, values.toSeq)
 
       // Treat IN(... subquery ...) as a normal IN-list, since the subquery already ran before now.
       case in: InSubqueryExec =>
         // At this point the subquery has been materialized so it is safe to call get on the Option.
-        inToDataFilter(in.child, in.values().get.toSeq)
+        inToRangeExpressions(in.child, in.values().get.toSeq)
 
       // If the Filter involves any other predicates, return without pre-processing
       case other => other :: Nil

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -4,7 +4,6 @@
 package io.qbeast.spark.index.query
 
 import io.qbeast.core.model._
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{
   EqualTo,
   Expression,
@@ -27,8 +26,6 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
     with StagingUtils
     with QueryFiltersUtils {
 
-  private lazy val spark: SparkSession = SparkSession.active
-
   /**
    * Extracts the data filters from the query that can be used by qbeast
    *
@@ -45,7 +42,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
 
     val weightFilters = conjunctiveSplit.filter(isQbeastWeightExpression)
     val queryFilters = conjunctiveSplit
-      .filter(hasQbeastColumnReference(_, indexedColumns, spark))
+      .filter(hasQbeastColumnReference(_, indexedColumns))
       .flatMap(transformInPredicates)
 
     QbeastFilters(weightFilters, queryFilters)
@@ -69,7 +66,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
     val (from, to) =
       indexedColumns.map { columnName =>
         // Get the filters related to the column
-        val columnFilters = rangePredicate.filter(hasColumnReference(_, columnName, spark))
+        val columnFilters = rangePredicate.filter(hasColumnReference(_, columnName))
 
         // Get the coordinates of the column in the filters,
         // if not found, use the overall coordinates

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -50,10 +50,12 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
     // Extract the weight filter from conjunctiveSplit
     val weightFilters = conjunctiveSplit.filter(isQbeastWeightExpression)
 
-    // Transform the remaining filters into Range Predicates (>=, <=)
-    val transformedFilters = conjunctiveSplit.flatMap(transformInExpressions)
+    // Discard string range predicates and
+    // Transform the remaining IN filters into Range Predicates (>=, <=)
+    val transformedFilters =
+      conjunctiveSplit.filterNot(isStringRangeExpression).flatMap(transformInExpressions)
 
-    // And filter those that involve any Qbeast Indexed Column
+    // Filter those that involve any Qbeast Indexed Column
     val queryFilters = transformedFilters.filter(hasQbeastColumnReference(_, indexedColumns))
 
     QbeastFilters(weightFilters, queryFilters)

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -75,7 +75,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
     // The predicates should not be empty
     assert(rangeExpressions.nonEmpty)
 
-    val indexedColumns = revision.columnTransformers
+    val indexedColumns = revision.columnTransformers.map(_.columnName)
 
     val (from, to) =
       indexedColumns.map { columnName =>
@@ -190,7 +190,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
       })
 
       nonOverlappingQuerySpecs
-
++
     }
   }
 

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -53,7 +53,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
     // Discard string range predicates and
     // Transform the remaining IN filters into Range Predicates (>=, <=)
     val transformedFilters =
-      conjunctiveSplit.filterNot(isStringRangeExpression).flatMap(transformInExpressions)
+      conjunctiveSplit.flatMap(transformInExpressions)
 
     // Filter those that involve any Qbeast Indexed Column
     val queryFilters = transformedFilters.filter(hasQbeastColumnReference(_, indexedColumns))

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -190,7 +190,6 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
       })
 
       nonOverlappingQuerySpecs
-      +
     }
   }
 

--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -190,7 +190,7 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
       })
 
       nonOverlappingQuerySpecs
-+
+      +
     }
   }
 

--- a/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
@@ -16,7 +16,7 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
     // Testing protected method
     override def matchingBlocks(
         partitionFilters: Seq[Expression],
-        dataFilters: Seq[Expression]): Seq[QbeastBlock] =
+        dataFilters: Seq[Expression]): Iterable[QbeastBlock] =
       super.matchingBlocks(partitionFilters, dataFilters)
 
   }

--- a/src/test/scala/io/qbeast/spark/delta/writer/BlockWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/BlockWriterTest.scala
@@ -32,7 +32,7 @@ class BlockWriterTest extends AnyFlatSpec with Matchers with QbeastIntegrationTe
   }
 
   it should "not miss any cubes in high partitioning" in withSparkAndTmpDir { (spark, tmpDir) =>
-    val writeTestSpec = WriteTestSpec(numDistinctCubes = 1000, spark, tmpDir)
+    val writeTestSpec = WriteTestSpec(numDistinctCubes = 400, spark, tmpDir)
 
     val writer = writeTestSpec.writer
 

--- a/src/test/scala/io/qbeast/spark/index/query/DisjunctiveQuerySpecTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/DisjunctiveQuerySpecTest.scala
@@ -1,0 +1,82 @@
+package io.qbeast.spark.index.query
+
+import io.qbeast.core.model.{IntegerDataType, QTableID, Revision, Weight, WeightRange}
+import io.qbeast.core.transform.{LinearTransformation, Transformer}
+import io.qbeast.spark.QbeastIntegrationTestSpec
+import org.apache.spark.sql.functions.expr
+
+class DisjunctiveQuerySpecTest extends QbeastIntegrationTestSpec with QueryTestSpec {
+
+  behavior of "QuerySpecBuilder"
+
+  "QuerySpecBuilder" should "process disjunctive predicates" in withSpark(spark => {
+    val revision = createRevision()
+    val expression = expr(s"3 <= id OR id < 8").expr
+    val querySpecs = new QuerySpecBuilder(Seq(expression)).build(revision)
+
+    querySpecs.size shouldBe 2
+
+  })
+
+  it should "process disjunctive equality predicates" in withSpark(spark => {
+    val revision = createRevision()
+    val expression = expr(s"3 == id OR id == 8").expr
+    val querySpecs = new QuerySpecBuilder(Seq(expression)).build(revision)
+
+    querySpecs.size shouldBe 2
+
+  })
+
+  it should "extract each space correctly" in withSpark(spark => {
+    val revision = createRevision()
+    val expression = expr(s"3 <= id OR id > 10").expr
+    val querySpecs = new QuerySpecBuilder(Seq(expression)).build(revision)
+
+    val tFrom = revision.transformations.head.transform(3)
+    val firstQuerySpec = querySpecs.head.querySpace
+
+    firstQuerySpec invokePrivate privateFrom() shouldBe Seq(Some(tFrom))
+    firstQuerySpec invokePrivate privateTo() shouldBe Seq(None)
+
+    val tFrom2 = revision.transformations.head.transform(10)
+    val secondQuerySpec = querySpecs(1).querySpace
+
+    secondQuerySpec invokePrivate privateFrom() shouldBe Seq(Some(tFrom2))
+    secondQuerySpec invokePrivate privateTo() shouldBe Seq(None)
+  })
+
+  it should "process complex predicates" in withSpark(spark => {
+    val transformations =
+      Seq(
+        LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType),
+        LinearTransformation(Int.MinValue, Int.MaxValue, IntegerDataType)).toIndexedSeq
+    val columnTransformers = Seq(
+      Transformer("linear", "id", IntegerDataType),
+      Transformer("linear", "age", IntegerDataType)).toIndexedSeq
+
+    val revision = Revision(
+      1,
+      System.currentTimeMillis(),
+      QTableID("test"),
+      100,
+      columnTransformers,
+      transformations)
+
+    val expression = expr("id > 3 and id <= 7 or age > 6 and age <= 19").expr
+    val querySpecs = new QuerySpecBuilder(Seq(expression)).build(revision)
+
+    querySpecs.size shouldBe 2
+  })
+
+  it should "process disjunctive predicates with sample" in withSpark(spark => {
+    val revision = createRevision()
+    val weightRange = WeightRange(Weight(0.0), Weight(0.1))
+    val weightFilter = weightFilters(weightRange)
+    val expression = expr(s"3 <= id OR id < 8").expr
+    val querySpecs = new QuerySpecBuilder(Seq(expression, weightFilter)).build(revision)
+
+    querySpecs.size shouldBe 2
+    querySpecs.foreach(querySpec => querySpec.weightRange shouldBe weightRange)
+  })
+
+}

--- a/src/test/scala/io/qbeast/spark/index/query/DisjunctiveQuerySpecTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/DisjunctiveQuerySpecTest.scala
@@ -32,17 +32,14 @@ class DisjunctiveQuerySpecTest extends QbeastIntegrationTestSpec with QueryTestS
     val expression = expr(s"3 <= id OR id > 10").expr
     val querySpecs = new QuerySpecBuilder(Seq(expression)).build(revision)
 
+    // Size of the specs should be one since id > 10 is contained in the expression id >= 3
+    querySpecs.size shouldBe 1
+
     val tFrom = revision.transformations.head.transform(3)
-    val firstQuerySpec = querySpecs.head.querySpace
+    val querySpace = querySpecs.head.querySpace
 
-    firstQuerySpec invokePrivate privateFrom() shouldBe Seq(Some(tFrom))
-    firstQuerySpec invokePrivate privateTo() shouldBe Seq(None)
-
-    val tFrom2 = revision.transformations.head.transform(10)
-    val secondQuerySpec = querySpecs(1).querySpace
-
-    secondQuerySpec invokePrivate privateFrom() shouldBe Seq(Some(tFrom2))
-    secondQuerySpec invokePrivate privateTo() shouldBe Seq(None)
+    querySpace invokePrivate privateFrom() shouldBe Seq(Some(tFrom))
+    querySpace invokePrivate privateTo() shouldBe Seq(None)
   })
 
   it should "process complex predicates" in withSpark(spark => {

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -193,7 +193,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec {
       indexStatus.copy(cubesStatuses = indexStatus.cubesStatuses - cubeToRemove)
 
     val querySpecBuilder = new QuerySpecBuilder(Seq.empty)
-    val querySpec = querySpecBuilder.build(revision)
+    val querySpec = querySpecBuilder.build(revision).head
     val queryExecutor = new QueryExecutor(querySpecBuilder, qbeastSnapshot)
     val matchFiles = queryExecutor
       .executeRevision(querySpec, faultyIndexStatus)

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -1,39 +1,13 @@
 package io.qbeast.spark.index.query
 
-import io.qbeast.TestClasses.T2
 import io.qbeast.core.model.{CubeId, QbeastBlock, Weight, WeightRange}
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.delta.DeltaQbeastSnapshot
-import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash
-import org.apache.spark.sql.catalyst.expressions.{
-  And,
-  Expression,
-  GreaterThanOrEqual,
-  LessThan,
-  Literal
-}
+
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.functions.{col, expr}
-import org.apache.spark.sql.{Column, SparkSession}
 
-class QueryExecutorTest extends QbeastIntegrationTestSpec {
-
-  private def createDF(size: Int, spark: SparkSession) = {
-    import spark.implicits._
-
-    0.to(size)
-      .map(i => T2(i, i.toDouble))
-      .toDF()
-      .as[T2]
-
-  }
-
-  private def weightFilters(weightRange: WeightRange): Expression = {
-    val qbeast_hash = new QbeastMurmur3Hash(Seq(new Column("a").expr, new Column("c").expr))
-    val lessThan = LessThan(qbeast_hash, Literal(weightRange.to.value))
-    val greaterThanOrEqual = GreaterThanOrEqual(qbeast_hash, Literal(weightRange.from.value))
-    And(lessThan, greaterThanOrEqual)
-  }
+class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
 
   behavior of "QueryExecutor"
 

--- a/src/test/scala/io/qbeast/spark/index/query/QueryTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryTestSpec.scala
@@ -18,8 +18,8 @@ import org.scalatest.matchers.should.Matchers
 
 trait QueryTestSpec extends AnyFlatSpec with Matchers with PrivateMethodTester {
 
-  val privateFrom: PrivateMethod[QuerySpaceFromTo] = PrivateMethod[QuerySpaceFromTo]('from)
-  val privateTo: PrivateMethod[QuerySpaceFromTo] = PrivateMethod[QuerySpaceFromTo]('to)
+  lazy val privateFrom: PrivateMethod[QuerySpaceFromTo] = PrivateMethod[QuerySpaceFromTo]('from)
+  lazy val privateTo: PrivateMethod[QuerySpaceFromTo] = PrivateMethod[QuerySpaceFromTo]('to)
 
   def createDF(size: Int, spark: SparkSession): Dataset[T2] = {
     import spark.implicits._

--- a/src/test/scala/io/qbeast/spark/index/query/QueryTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryTestSpec.scala
@@ -1,0 +1,55 @@
+package io.qbeast.spark.index.query
+
+import io.qbeast.TestClasses.T2
+import io.qbeast.core.model.{IntegerDataType, QTableID, QuerySpaceFromTo, Revision, WeightRange}
+import io.qbeast.core.transform.{LinearTransformation, Transformer}
+import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash
+import org.apache.spark.sql.{Column, Dataset, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{
+  And,
+  Expression,
+  GreaterThanOrEqual,
+  LessThan,
+  Literal
+}
+import org.scalatest.PrivateMethodTester
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+trait QueryTestSpec extends AnyFlatSpec with Matchers with PrivateMethodTester {
+
+  val privateFrom: PrivateMethod[QuerySpaceFromTo] = PrivateMethod[QuerySpaceFromTo]('from)
+  val privateTo: PrivateMethod[QuerySpaceFromTo] = PrivateMethod[QuerySpaceFromTo]('to)
+
+  def createDF(size: Int, spark: SparkSession): Dataset[T2] = {
+    import spark.implicits._
+
+    0.to(size)
+      .map(i => T2(i, i.toDouble))
+      .toDF()
+      .as[T2]
+
+  }
+
+  def weightFilters(weightRange: WeightRange): Expression = {
+    val qbeast_hash = new QbeastMurmur3Hash(Seq(new Column("a").expr, new Column("c").expr))
+    val lessThan = LessThan(qbeast_hash, Literal(weightRange.to.value))
+    val greaterThanOrEqual = GreaterThanOrEqual(qbeast_hash, Literal(weightRange.from.value))
+    And(lessThan, greaterThanOrEqual)
+  }
+
+  def createRevision(minVal: Int = Int.MinValue, maxVal: Int = Int.MaxValue): Revision = {
+    val transformations =
+      Seq(LinearTransformation(minVal, maxVal, IntegerDataType)).toIndexedSeq
+    val columnTransformers = Seq(Transformer("linear", "id", IntegerDataType)).toIndexedSeq
+
+    Revision(
+      1,
+      System.currentTimeMillis(),
+      QTableID("test"),
+      100,
+      columnTransformers,
+      transformations)
+  }
+
+}

--- a/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
@@ -288,28 +288,6 @@ class QbeastFilterPushdownTest extends QbeastIntegrationTestSpec {
       }
   }
 
-  it should "pushdown filters with IN predicate with string" in withQbeastContextSparkAndTmpDir {
-    (spark, tmpDir) =>
-      {
-        val data = loadTestData(spark)
-
-        writeTestData(data, Seq("brand"), 10000, tmpDir)
-
-        val df = spark.read.format("qbeast").load(tmpDir)
-
-        val filter =
-          s"(brand IN ('versace', 'bioderma'))"
-        val query = df.filter(filter)
-        val originalQuery = data.filter(filter)
-
-        // OR filters are not split, so we need to match them entirely
-        checkLogicalFilterPushdown(Seq(filter), query)
-        checkFileFiltering(query)
-        assertSmallDatasetEquality(query, originalQuery, orderedComparison = false)
-
-      }
-  }
-
   it should "pushdown regex expressions on strings" in withQbeastContextSparkAndTmpDir {
     (spark, tmpDir) =>
       {


### PR DESCRIPTION
## Description


This PR fixes #183 . 

## Type of change

It includes additional functionalities on the `query` package that processes the OR query operators, creating several query spaces to iterate and union. 

The pipeline is the following:
1. SparkFilters (a sequence of `Expression`) are passed to the `OTreeIndex` from Spark Query Plan. 
2. We create a `QuerySpecBuilder`.
3. To filter the files, we load all the revisions from `QbeastSnapshot` and we build a `QuerySpec` for each of them. 
4. Now, we can have **several `QuerySpecs` for a single `Revision`**. Since the predicates contain OR's, our queries are divided into smaller filters that can be run independently. To create the QuerySpecs, we do:

    i. **Split Query Filters and Weight Filters**. Weight filters are those which indicates the size of the sample. Query Filters are those that involve any of the indexed columns. 
    ii. **Split the disjunctive and conjunctive predicates**. The predicates are parsed as a sequence of ANDs. The OR's are parsed into a single Expression. 
   iii. **Create a single `QuerySpec` with the conjunctive predicates** (AND). 
   iv. **For each disjunctive predicate (OR), create a different `QuerySpec`.** 

6. We run each query and we union the results.

For the IN predicate, we pre-process the filters in `QuerySpecBuilder` as follows:

1. Match the `IN` filter passed to the datasource.
2. We can manage IN as a sequence of OR filtering, each one retrieving one slice of the space. But this is not scalable when we have too many values in the set.
3. A solution is to **find a range `(min, max)`** and retrieve the blocks belonging to that `QuerySpaceFromTo`. When it comes to a **String indexed column, finding a range could be difficult because Strings are hashed** and, as far as I know, **`Murmur3Hash` does not respect ordering**. To solve that, we must:
    - Hash the values inside the IN set.
    - Select the `min` and `max` of those values.
    - Initialise the `QuerySpaceFromTo`. 

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

This has been tested in a separate class `io.qbeast.spark.index.query.DisjunctiveQuerySpecTest `, but also on `io.qbeast.spark.utils.QbeastFilterPushdownTest`

**Test Configuration**:
* Spark Version: 3.3.0
* Hadoop Version: 3.3.4
* Cluster or local? Local