### PR TITLE
Add cube information to QbeastBlock

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
@@ -15,7 +15,7 @@ package io.qbeast.core.model
 
 case class QbeastBlock(
     path: String,
-    cube: String,
+    cubeId: String,
     revision: Long,
     minWeight: Weight,
     maxWeight: Weight,
@@ -30,7 +30,7 @@ case class QbeastBlock(
 object QbeastBlock {
 
   private val metadataKeys =
-    Set("minWeight", "maxWeight", "state", "revision", "elementCount", "cube")
+    Set("minWeight", "maxWeight", "state", "revision", "elementCount", "cubeId")
 
   private def checkBlockMetadata(blockMetadata: Map[String, String]): Unit = {
     metadataKeys.foreach(key =>
@@ -56,7 +56,7 @@ object QbeastBlock {
 
     QbeastBlock(
       path,
-      blockMetadata("cube"),
+      blockMetadata("cubeId"),
       blockMetadata("revision").toLong,
       Weight(blockMetadata("minWeight").toInt),
       Weight(blockMetadata("maxWeight").toInt),

--- a/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
@@ -15,7 +15,7 @@ package io.qbeast.core.model
 
 case class QbeastBlock(
     path: String,
-    cubeId: String,
+    cube: String,
     revision: Long,
     minWeight: Weight,
     maxWeight: Weight,
@@ -30,7 +30,7 @@ case class QbeastBlock(
 object QbeastBlock {
 
   private val metadataKeys =
-    Set("minWeight", "maxWeight", "state", "revision", "elementCount", "cubeId")
+    Set("minWeight", "maxWeight", "state", "revision", "elementCount", "cube")
 
   private def checkBlockMetadata(blockMetadata: Map[String, String]): Unit = {
     metadataKeys.foreach(key =>
@@ -56,7 +56,7 @@ object QbeastBlock {
 
     QbeastBlock(
       path,
-      blockMetadata("cubeId"),
+      blockMetadata("cube"),
       blockMetadata("revision").toLong,
       Weight(blockMetadata("minWeight").toInt),
       Weight(blockMetadata("maxWeight").toInt),

--- a/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
@@ -3,6 +3,7 @@ package io.qbeast.core.model
 /**
  * Container class for Qbeast file's metadata
  * @param path
+ * @param cube
  * @param revision
  * @param minWeight
  * @param maxWeight
@@ -14,6 +15,7 @@ package io.qbeast.core.model
 
 case class QbeastBlock(
     path: String,
+    cube: String,
     revision: Long,
     minWeight: Weight,
     maxWeight: Weight,
@@ -28,7 +30,7 @@ case class QbeastBlock(
 object QbeastBlock {
 
   private val metadataKeys =
-    Set("minWeight", "maxWeight", "state", "revision", "elementCount")
+    Set("minWeight", "maxWeight", "state", "revision", "elementCount", "cube")
 
   private def checkBlockMetadata(blockMetadata: Map[String, String]): Unit = {
     metadataKeys.foreach(key =>
@@ -54,6 +56,7 @@ object QbeastBlock {
 
     QbeastBlock(
       path,
+      blockMetadata("cube"),
       blockMetadata("revision").toLong,
       Weight(blockMetadata("minWeight").toInt),
       Weight(blockMetadata("maxWeight").toInt),

--- a/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
@@ -7,12 +7,14 @@ class QbeastBlockTest extends AnyFlatSpec with Matchers {
   "QbeastBlock" should "find all the keys in the map" in {
     val blockMetadata: Map[String, String] = Map(
       "minWeight" -> "19217",
+      "cube" -> "",
       "maxWeight" -> "11111111",
       "state" -> "FlOODED",
       "revision" -> "1",
       "elementCount" -> "777")
 
     val qbeastBlock = QbeastBlock("path", blockMetadata, 0L, 0L)
+    qbeastBlock.cube shouldBe ""
     qbeastBlock.minWeight shouldBe Weight(19217)
     qbeastBlock.maxWeight shouldBe Weight(11111111)
     qbeastBlock.state shouldBe "FlOODED"
@@ -28,6 +30,7 @@ class QbeastBlockTest extends AnyFlatSpec with Matchers {
   it should "throw error if the types are different" in {
     val blockMetadata: Map[String, String] = Map(
       "minWeight" -> "19217",
+      "cube" -> "",
       "maxWeight" -> "11111111",
       "state" -> "FlOODED",
       "revision" -> "bad_type",

--- a/src/main/scala/io/qbeast/spark/delta/IndexStatusBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/delta/IndexStatusBuilder.scala
@@ -56,6 +56,7 @@ private[delta] class IndexStatusBuilder(
       .map(addFile =>
         QbeastBlock(
           addFile.path,
+          "",
           revision.revisionID,
           Weight.MinValue,
           maxWeight,

--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
@@ -26,7 +26,7 @@ object QbeastMetadataSQL {
   val qblock: Column =
     struct(
       col("path"),
-      TagColumns.cube.as("cube"),
+      TagColumns.cube.as("cubeId"),
       col("size"),
       col("modificationTime"),
       weight(TagColumns.minWeight).as("minWeight"),

--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
@@ -26,7 +26,7 @@ object QbeastMetadataSQL {
   val qblock: Column =
     struct(
       col("path"),
-      TagColumns.cube.as("cubeId"),
+      TagColumns.cube.as("cube"),
       col("size"),
       col("modificationTime"),
       weight(TagColumns.minWeight).as("minWeight"),

--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
@@ -26,6 +26,7 @@ object QbeastMetadataSQL {
   val qblock: Column =
     struct(
       col("path"),
+      TagColumns.cube.as("cube"),
       col("size"),
       col("modificationTime"),
       weight(TagColumns.minWeight).as("minWeight"),

--- a/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
@@ -24,8 +24,8 @@ class IndexStatusBuilderTest extends QbeastIntegrationTestSpec {
 
       indexStatus.revision.revisionID shouldBe 1
       indexStatus.cubesStatuses.foreach(_._2.files.size shouldBe 1)
-      indexStatus.cubesStatuses.foreach { case (cubeId: CubeId, cubeStatus: CubeStatus) =>
-        cubeStatus.files.foreach(block => block.cubeId shouldBe cubeId.string)
+      indexStatus.cubesStatuses.foreach { case (cube: CubeId, cubeStatus: CubeStatus) =>
+        cubeStatus.files.foreach(block => block.cube shouldBe cube.string)
       }
       indexStatus.replicatedSet shouldBe Set.empty
       indexStatus.announcedSet shouldBe Set.empty

--- a/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
@@ -24,6 +24,9 @@ class IndexStatusBuilderTest extends QbeastIntegrationTestSpec {
 
       indexStatus.revision.revisionID shouldBe 1
       indexStatus.cubesStatuses.foreach(_._2.files.size shouldBe 1)
+      indexStatus.cubesStatuses.foreach { case (cube: CubeId, cubeStatus: CubeStatus) =>
+        cubeStatus.files.foreach(block => block.cube shouldBe cube.string)
+      }
       indexStatus.replicatedSet shouldBe Set.empty
       indexStatus.announcedSet shouldBe Set.empty
     })

--- a/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
@@ -24,8 +24,8 @@ class IndexStatusBuilderTest extends QbeastIntegrationTestSpec {
 
       indexStatus.revision.revisionID shouldBe 1
       indexStatus.cubesStatuses.foreach(_._2.files.size shouldBe 1)
-      indexStatus.cubesStatuses.foreach { case (cube: CubeId, cubeStatus: CubeStatus) =>
-        cubeStatus.files.foreach(block => block.cube shouldBe cube.string)
+      indexStatus.cubesStatuses.foreach { case (cubeId: CubeId, cubeStatus: CubeStatus) =>
+        cubeStatus.files.foreach(block => block.cubeId shouldBe cubeId.string)
       }
       indexStatus.replicatedSet shouldBe Set.empty
       indexStatus.announcedSet shouldBe Set.empty

--- a/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
@@ -72,6 +72,7 @@ case class WriteTestSpec(numDistinctCubes: Int, spark: SparkSession, tmpDir: Str
             // Create a QbeastBlock under the revision
             QbeastBlock(
               UUID.randomUUID().toString,
+              cubeId.string,
               rev.revisionID,
               Weight.MinValue,
               maxWeight,


### PR DESCRIPTION
## Description

This PR adds the information of the `CubeID` to `QbeastBlock` structure to help debugging the behaviour of the code. 

## Type of change

It is a change on both `core` and `spark`. It is not a breaking change, because we do not change any written information. 


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Add a small test on `IndexBuilderStatusTest` in which we ensure that each `QbeastBlock` contains the correct `cubeID`. 