### PR TITLE
Avoid losing hadoop conf in writing jobs in v0.3.2

### DIFF
--- a/src/main/scala/io/qbeast/spark/delta/writer/SparkDeltaDataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/SparkDeltaDataWriter.scala
@@ -38,7 +38,7 @@ object SparkDeltaDataWriter
 
     val sparkSession = qbeastData.sparkSession
 
-    val job = Job.getInstance()
+    val job = Job.getInstance(sparkSession.sparkContext.hadoopConfiguration)
     val factory = new ParquetFileFormat().prepareWrite(sparkSession, job, Map.empty, schema)
     val serConf = new SerializableConfiguration(job.getConfiguration)
     val statsTrackers = StatsTracker.getStatsTrackers()


### PR DESCRIPTION
## Description

In Qbeast Cloud an authorization (403 Forbidden) error occurs when reading from a bucket and writing to another. The reason is that the configuration parameter

spark.hadoop.fs.s3a.aws.credentials.provider=io.qbeast.ingestion.aws.RoleCredentialsProviderWithUri

is lost when launching write jobs with the class io.qbeast.spark.delta.writer.SparkDeltaDataWriter, and consequently the default authorization classes are used instead. This is because the hadoop configuration in use with the spark session is lost due to the use of the method call Job.getInstance() of the class org.apache.hadoop.mapreduce.Job, which as explained in the documentation (https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/mapreduce/Job.html#getInstance--):

Creates a new [Job] with no particular [Cluster]. A Cluster will be created with a generic [Configuration].

To keep the configuration it is necessary to change the call to Job.getInstance(sparkSession.sparkContext.hadoopConfiguration)

In this way, the method Job.getInstance(Configuration conf) is called, which according to the documentation:

Creates a new [Job] with no particular [Cluster] and a given [Configuration]. The Job makes a copy of the Configuration so that any necessary internal modifications do not reflect on the incoming parameter. A Cluster will be created from the conf parameter only when it's needed.

## Type of change

- Bug fix (only tested with version 0.3.2)

## How Has This Been Tested? (Optional)

Tested in a qbeast-cloud deployment (locally and with a kubernetes image) with test TPC-DS test data.