### PR TITLE
ColumnStats on Append and Timestamp handling

### DIFF
--- a/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
+++ b/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
@@ -67,7 +67,15 @@ object QbeastOptions {
     options.get(STATS) match {
       case Some(value) =>
         import spark.implicits._
-        Some(spark.read.json(Seq(value).toDS))
+        val ds = Seq(value).toDS()
+        val df = spark.read
+          .option("inferTimestamp", "true")
+          .option("timestampFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS'Z'")
+          .json(ds)
+        // scalastyle:off
+        println("value " + value)
+        println("schema " + df.schema)
+        Some(df)
       case None => None
     }
   }


### PR DESCRIPTION
## Description

This PR fixes bugs #204 and #195 

## Type of change

It is a bug fix for Timestamp and Column Stats handling. Both issues were touching the same code, so I find more useful to solve them both together. 

1. Issue #195 was due to an inconsistent creation of Revisions when appending new data. The merge of Revisions was not done correctly if the user specify a wider region of the space. 
2. Issue #204 was due to bad parsing of JSON Timestamps.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

This is tested with two different tests in `SparkRevisionFactoryTest`. 

**Test Configuration**:
* Spark Version: 3.3.x
* Hadoop Version: 3.3.4
* Cluster or local? Local