### PR TITLE
Revert #200 and new version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import xerial.sbt.Sonatype._
 
-val mainVersion = "0.3.3"
+val mainVersion = "0.4.0"
 
 lazy val qbeastCore = (project in file("core"))
   .settings(

--- a/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
+++ b/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
@@ -59,6 +59,22 @@ trait MetadataManager[DataSchema, FileDescriptor] {
   def updateTable(tableID: QTableID, tableChanges: TableChanges): Unit
 
   /**
+   * This function checks if there's a conflict. A conflict happens if there
+   * are new cubes that have been optimized but they were not announced.
+   *
+   * @param tableID the table ID
+   * @param revisionID the revision ID
+   * @param knownAnnounced the cubes we know they were announced when the write operation started.
+   * @param oldReplicatedSet the old replicated set
+   * @return true if there is a conflict, false otherwise
+   */
+  def hasConflicts(
+      tableID: QTableID,
+      revisionID: RevisionID,
+      knownAnnounced: Set[CubeId],
+      oldReplicatedSet: ReplicatedSet): Boolean
+
+  /**
    * Checks if there's an existing log directory for the table
    * @param tableID the table ID
    * @return

--- a/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastBlock.scala
@@ -2,24 +2,24 @@ package io.qbeast.core.model
 
 /**
  * Container class for Qbeast file's metadata
- *
- * @param path the file path
- * @param cube the cube identifier
- * @param revision the revision identifier
- * @param minWeight the minimum weight of element
- * @param maxWeight the maximum weight of element
- * @param replicated the file is replicated
- * @param elementCount the number of elements
- * @param size the size in bytes
- * @param modificationTime the modification timestamp
+ * @param path
+ * @param cube
+ * @param revision
+ * @param minWeight
+ * @param maxWeight
+ * @param state
+ * @param elementCount
+ * @param size
+ * @param modificationTime
  */
+
 case class QbeastBlock(
     path: String,
     cube: String,
     revision: Long,
     minWeight: Weight,
     maxWeight: Weight,
-    replicated: Boolean,
+    state: String,
     elementCount: Long,
     size: Long,
     modificationTime: Long)
@@ -30,7 +30,7 @@ case class QbeastBlock(
 object QbeastBlock {
 
   private val metadataKeys =
-    Set("minWeight", "maxWeight", "replicated", "revision", "elementCount", "cube")
+    Set("minWeight", "maxWeight", "state", "revision", "elementCount", "cube")
 
   private def checkBlockMetadata(blockMetadata: Map[String, String]): Unit = {
     metadataKeys.foreach(key =>
@@ -60,7 +60,7 @@ object QbeastBlock {
       blockMetadata("revision").toLong,
       Weight(blockMetadata("minWeight").toInt),
       Weight(blockMetadata("maxWeight").toInt),
-      blockMetadata("replicated").toBoolean,
+      blockMetadata("state"),
       blockMetadata("elementCount").toLong,
       size,
       modificationTime)

--- a/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
+++ b/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
@@ -1,11 +1,6 @@
 package io.qbeast.core.model
 
-import io.qbeast.core.transform.{
-  HashTransformation,
-  LinearTransformation,
-  Transformation,
-  Transformer
-}
+import io.qbeast.core.transform.{HashTransformation, LinearTransformation, Transformation, Transformer}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/QbeastBlockTest.scala
@@ -9,7 +9,7 @@ class QbeastBlockTest extends AnyFlatSpec with Matchers {
       "minWeight" -> "19217",
       "cube" -> "",
       "maxWeight" -> "11111111",
-      "replicated" -> "true",
+      "state" -> "FlOODED",
       "revision" -> "1",
       "elementCount" -> "777")
 
@@ -17,7 +17,7 @@ class QbeastBlockTest extends AnyFlatSpec with Matchers {
     qbeastBlock.cube shouldBe ""
     qbeastBlock.minWeight shouldBe Weight(19217)
     qbeastBlock.maxWeight shouldBe Weight(11111111)
-    qbeastBlock.replicated shouldBe true
+    qbeastBlock.state shouldBe "FlOODED"
     qbeastBlock.revision shouldBe 1
     qbeastBlock.elementCount shouldBe 777
   }
@@ -32,7 +32,7 @@ class QbeastBlockTest extends AnyFlatSpec with Matchers {
       "minWeight" -> "19217",
       "cube" -> "",
       "maxWeight" -> "11111111",
-      "replicated" -> "false",
+      "state" -> "FlOODED",
       "revision" -> "bad_type",
       "elementCount" -> "777")
 

--- a/src/main/scala/io/qbeast/spark/delta/CubeDataLoader.scala
+++ b/src/main/scala/io/qbeast/spark/delta/CubeDataLoader.scala
@@ -4,7 +4,7 @@
 package io.qbeast.spark.delta
 
 import io.qbeast.core.model.{CubeId, QTableID, Revision}
-import io.qbeast.spark.utils.TagColumns
+import io.qbeast.spark.utils.{State, TagColumns}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -64,7 +64,7 @@ case class CubeDataLoader(tableID: QTableID) {
       .where(
         TagColumns.revision === lit(revision.revisionID.toString) &&
           TagColumns.cube === lit(cube.string) &&
-          TagColumns.replicated === lit(false.toString()))
+          TagColumns.state != lit(State.ANNOUNCED))
       .collect()
 
     val fileNames = cubeBlocks.map(f => new Path(tableID.id, f.path).toString)

--- a/src/main/scala/io/qbeast/spark/delta/IndexStatusBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/delta/IndexStatusBuilder.scala
@@ -5,15 +5,11 @@ package io.qbeast.spark.delta
 
 import io.qbeast.core.model._
 import io.qbeast.spark.delta.QbeastMetadataSQL._
+import io.qbeast.spark.utils.State.FLOODED
 import io.qbeast.spark.utils.TagColumns
-import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.actions.AddFile
-import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.functions.collect_list
-import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.functions.min
-import org.apache.spark.sql.functions.sum
+import org.apache.spark.sql.functions.{col, collect_list, lit, min, sum}
+import org.apache.spark.sql.{Dataset, SparkSession}
 
 import scala.collection.immutable.SortedMap
 
@@ -24,7 +20,11 @@ import scala.collection.immutable.SortedMap
  * @param announcedSet the announced set available for the revision
  * @param replicatedSet the replicated set available for the revision
  */
-private[delta] class IndexStatusBuilder(qbeastSnapshot: DeltaQbeastSnapshot, revision: Revision)
+private[delta] class IndexStatusBuilder(
+    qbeastSnapshot: DeltaQbeastSnapshot,
+    revision: Revision,
+    replicatedSet: ReplicatedSet,
+    announcedSet: Set[CubeId] = Set.empty)
     extends Serializable
     with StagingUtils {
 
@@ -37,19 +37,15 @@ private[delta] class IndexStatusBuilder(qbeastSnapshot: DeltaQbeastSnapshot, rev
     qbeastSnapshot.loadRevisionBlocks(revision.revisionID)
 
   def build(): IndexStatus = {
-    val cubeStatuses =
+    val cubeStatus =
       if (isStaging(revision)) stagingCubeStatuses
       else buildCubesStatuses
-
-    val (replicatedSet, announcedSet): (Set[CubeId], Set[CubeId]) =
-      if (isStaging(revision)) (Set.empty, Set.empty)
-      else buildReplicatedAndAnnouncedSets(cubeStatuses)
 
     IndexStatus(
       revision = revision,
       replicatedSet = replicatedSet,
       announcedSet = announcedSet,
-      cubesStatuses = cubeStatuses)
+      cubesStatuses = cubeStatus)
   }
 
   def stagingCubeStatuses: SortedMap[CubeId, CubeStatus] = {
@@ -64,7 +60,7 @@ private[delta] class IndexStatusBuilder(qbeastSnapshot: DeltaQbeastSnapshot, rev
           revision.revisionID,
           Weight.MinValue,
           maxWeight,
-          false,
+          FLOODED,
           0,
           addFile.size,
           addFile.modificationTime))
@@ -95,34 +91,13 @@ private[delta] class IndexStatusBuilder(qbeastSnapshot: DeltaQbeastSnapshot, rev
       .select(
         createCube(col("cube"), lit(ndims)).as("cubeId"),
         col("maxWeight"),
-        normalizeWeight(col("maxWeight"), col("elementCount"), lit(rev.desiredCubeSize))
-          .as("normalizedWeight"),
+        normalizeWeight(col("maxWeight"), col("elementCount"), lit(rev.desiredCubeSize)).as(
+          "normalizedWeight"),
         col("files"))
       .as[CubeStatus]
       .collect()
       .foreach(row => builder += row.cubeId -> row)
     builder.result()
-  }
-
-  def buildReplicatedAndAnnouncedSets(
-      cubeStatuses: Map[CubeId, CubeStatus]): (Set[CubeId], Set[CubeId]) = {
-    val replicatedSet = Set.newBuilder[CubeId]
-    val announcedSet = Set.newBuilder[CubeId]
-    cubeStatuses.foreach { case (id, status) =>
-      var hasReplicated = false
-      var hasUnreplicated = false
-      status.files.foreach(file =>
-        if (file.replicated) hasReplicated = true
-        else hasUnreplicated = true)
-      if (hasReplicated) {
-        if (hasUnreplicated) {
-          announcedSet += id
-        } else {
-          replicatedSet += id
-        }
-      }
-    }
-    (replicatedSet.result(), announcedSet.result())
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.spark.delta
 
-import io.qbeast.core.model.{Revision, StagingUtils, TableChanges, mapper}
+import io.qbeast.core.model.{ReplicatedSet, Revision, StagingUtils, TableChanges, mapper}
 import io.qbeast.spark.utils.MetadataConfig
 import io.qbeast.spark.utils.MetadataConfig.{lastRevisionID, revision}
 import org.apache.spark.sql.SparkSession
@@ -36,10 +36,38 @@ private[delta] class QbeastMetadataOperation extends ImplicitMetadataOperation w
     }
   }
 
+  /**
+   * Updates Delta Metadata Configuration with new replicated set
+   * for given revision
+   * @param baseConfiguration Delta Metadata Configuration
+   * @param revision the new revision to persist
+   * @param deltaReplicatedSet the new set of replicated cubes
+   */
+
+  private def updateQbeastReplicatedSet(
+      baseConfiguration: Configuration,
+      revision: Revision,
+      deltaReplicatedSet: ReplicatedSet): Configuration = {
+
+    val revisionID = revision.revisionID
+    assert(baseConfiguration.contains(s"${MetadataConfig.revision}.$revisionID"))
+
+    val newReplicatedSet = deltaReplicatedSet.map(_.string)
+    // Save the replicated set of cube id's as String representation
+
+    baseConfiguration.updated(
+      s"${MetadataConfig.replicatedSet}.$revisionID",
+      mapper.writeValueAsString(newReplicatedSet))
+
+  }
+
   private def overwriteQbeastConfiguration(baseConfiguration: Configuration): Configuration = {
     val revisionKeys = baseConfiguration.keys.filter(_.startsWith(MetadataConfig.revision))
+    val replicatedSetKeys = {
+      baseConfiguration.keys.filter(_.startsWith(MetadataConfig.replicatedSet))
+    }
     val other = baseConfiguration.keys.filter(_ == MetadataConfig.lastRevisionID)
-    val qbeastKeys = revisionKeys ++ other
+    val qbeastKeys = revisionKeys ++ replicatedSetKeys ++ other
     baseConfiguration -- qbeastKeys
   }
 
@@ -122,6 +150,11 @@ private[delta] class QbeastMetadataOperation extends ImplicitMetadataOperation w
     val configuration =
       if (isNewRevision || isOverwriteMode) {
         updateQbeastRevision(baseConfiguration, latestRevision)
+      } else if (isOptimizeOperation) {
+        updateQbeastReplicatedSet(
+          baseConfiguration,
+          latestRevision,
+          tableChanges.announcedOrReplicatedSet)
       } else baseConfiguration
 
     if (txn.readVersion == -1) {

--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataSQL.scala
@@ -30,8 +30,9 @@ object QbeastMetadataSQL {
       col("size"),
       col("modificationTime"),
       weight(TagColumns.minWeight).as("minWeight"),
-      weight(TagColumns.maxWeight).as("maxWeight"),
-      TagColumns.replicated.cast("boolean").as("replicated"),
+      weight(TagColumns.maxWeight)
+        .as("maxWeight"),
+      TagColumns.state,
       TagColumns.revision.cast("bigint").as("revision"),
       TagColumns.elementCount.cast("bigint").as("elementCount"))
 

--- a/src/main/scala/io/qbeast/spark/delta/ReplicatedFile.scala
+++ b/src/main/scala/io/qbeast/spark/delta/ReplicatedFile.scala
@@ -3,7 +3,7 @@
  */
 package io.qbeast.spark.delta
 
-import io.qbeast.spark.utils.TagUtils
+import io.qbeast.spark.utils.{State, TagUtils}
 import org.apache.spark.sql.delta.actions.AddFile
 
 /**
@@ -12,8 +12,7 @@ import org.apache.spark.sql.delta.actions.AddFile
 object ReplicatedFile {
 
   def apply(addFile: AddFile): AddFile = {
-    val newTags = addFile.tags
-      .updated(TagUtils.replicated, true.toString())
+    val newTags = addFile.tags.updated(TagUtils.state, State.REPLICATED)
     addFile.copy(tags = newTags, modificationTime = System.currentTimeMillis())
   }
 

--- a/src/main/scala/io/qbeast/spark/delta/SparkDeltaMetadataManager.scala
+++ b/src/main/scala/io/qbeast/spark/delta/SparkDeltaMetadataManager.scala
@@ -59,6 +59,21 @@ object SparkDeltaMetadataManager extends MetadataManager[StructType, FileAction]
     DeltaQbeastLog(DeltaLog.forTable(SparkSession.active, tableID.id))
   }
 
+  override def hasConflicts(
+      tableID: QTableID,
+      revisionID: RevisionID,
+      knownAnnounced: Set[CubeId],
+      oldReplicatedSet: ReplicatedSet): Boolean = {
+
+    val snapshot = loadSnapshot(tableID)
+    if (snapshot.isInitial) return false
+
+    val newReplicatedSet = snapshot.loadIndexStatus(revisionID).replicatedSet
+    val deltaReplicatedSet = newReplicatedSet -- oldReplicatedSet
+    val diff = deltaReplicatedSet -- knownAnnounced
+    diff.nonEmpty
+  }
+
   /**
    * Checks if there's an existing log directory for the table
    *

--- a/src/main/scala/io/qbeast/spark/delta/writer/BlockStats.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/BlockStats.scala
@@ -11,14 +11,14 @@ import io.qbeast.core.model.Weight
  * @param cube the cube
  * @param maxWeight the maximum weight
  * @param minWeight the minimum weight
- * @param replicated the cube block is replicated
+ * @param state the cube state
  * @param elementCount the number of rows
  */
 case class BlockStats protected (
     cube: String,
     maxWeight: Weight,
     minWeight: Weight,
-    replicated: Boolean,
+    state: String,
     elementCount: Long) {
 
   /**
@@ -33,7 +33,7 @@ case class BlockStats protected (
   }
 
   override def toString: String =
-    s"BlocksStats($cube,$maxWeight,$minWeight,$replicated,$elementCount)"
+    s"BlocksStats($cube,$maxWeight,$minWeight,$state,$elementCount)"
 
 }
 
@@ -45,11 +45,11 @@ object BlockStats {
   /**
    * Use this constructor to build the first BlockStat
    * @param cube the block's cubeId
-   * @param replicated the block is replicated
+   * @param state the status of the block
    * @param maxWeight the maxWeight of the block
    * @return a new empty instance of BlockStats
    */
-  def apply(cube: String, replicated: Boolean, maxWeight: Weight): BlockStats =
-    BlockStats(cube, maxWeight, minWeight = Weight.MaxValue, replicated, 0)
+  def apply(cube: String, state: String, maxWeight: Weight): BlockStats =
+    BlockStats(cube, maxWeight, minWeight = Weight.MaxValue, state, 0)
 
 }

--- a/src/main/scala/io/qbeast/spark/delta/writer/Compactor.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/Compactor.scala
@@ -57,7 +57,6 @@ case class Compactor(
     })
 
     val state = tableChanges.cubeState(cubeId).getOrElse(State.FLOODED)
-    val replicated = state != State.FLOODED
     val revision = tableChanges.updatedRevision
 
     // Update the tags of the block with the information of the cubeBlocks
@@ -68,7 +67,7 @@ case class Compactor(
           TagUtils.cube -> cubeId.string,
           TagUtils.minWeight -> minWeight.value.toString,
           TagUtils.maxWeight -> maxWeight.value.toString,
-          TagUtils.replicated -> replicated.toString,
+          TagUtils.state -> state,
           TagUtils.revision -> revision.revisionID.toString,
           TagUtils.elementCount -> elementCount.toString)
       }

--- a/src/main/scala/io/qbeast/spark/utils/Params.scala
+++ b/src/main/scala/io/qbeast/spark/utils/Params.scala
@@ -21,7 +21,7 @@ object TagColumns {
   final val cube = col("tags.cube")
   final val minWeight = col("tags.minWeight")
   final val maxWeight = col("tags.maxWeight")
-  final val replicated = col("tags.replicated")
+  final val state = col("tags.state")
   final val revision = col("tags.revision")
   final val elementCount = col("tags.elementCount")
 }
@@ -30,12 +30,13 @@ object TagUtils {
   final val cube = "cube"
   final val minWeight = "minWeight"
   final val maxWeight = "maxWeight"
-  final val replicated = "replicated"
+  final val state = "state"
   final val revision = "revision"
   final val elementCount = "elementCount"
 }
 
 object MetadataConfig {
   final val revision = "qbeast.revision"
+  final val replicatedSet = "qbeast.replicatedSet"
   final val lastRevisionID = "qbeast.lastRevisionID"
 }

--- a/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
@@ -142,7 +142,10 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           val deltaLog = DeltaLog.forTable(spark, tmpDir)
           val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
           val builder =
-            new IndexStatusBuilder(qbeastSnapshot, qbeastSnapshot.loadLatestIndexStatus.revision)
+            new IndexStatusBuilder(
+              qbeastSnapshot,
+              qbeastSnapshot.loadLatestIndexStatus.revision,
+              Set.empty)
           val revisionState = builder.buildCubesStatuses
 
           val overflowed = qbeastSnapshot.loadLatestIndexStatus.overflowedSet

--- a/src/test/scala/io/qbeast/spark/delta/writer/SparkDeltaDataWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/SparkDeltaDataWriterTest.scala
@@ -4,7 +4,7 @@ import io.qbeast.TestClasses._
 import io.qbeast.core.model.{CubeId, IndexStatus, QTableID, Weight}
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.index.{SparkOTreeManager, SparkRevisionFactory}
-import io.qbeast.spark.utils.TagUtils
+import io.qbeast.spark.utils.{State, TagUtils}
 import org.apache.spark.qbeast.config.{
   MIN_COMPACTION_FILE_SIZE_IN_BYTES,
   MAX_COMPACTION_FILE_SIZE_IN_BYTES
@@ -126,10 +126,14 @@ class SparkDeltaDataWriterTest extends QbeastIntegrationTestSpec {
       addedFiles
         .foreach(a => {
           val cube = CubeId(1, a.tags(TagUtils.cube))
-          val realReplicated = !writeTestSpec.replicatedSet.contains(cube) &&
-            !writeTestSpec.announcedSet.contains(cube)
-          val tagReplicated = a.tags(TagUtils.replicated).toBoolean
-          tagReplicated shouldBe realReplicated
+          val realState = {
+            if (writeTestSpec.replicatedSet.contains(cube)) State.REPLICATED
+            else if (writeTestSpec.announcedSet.contains(cube)) State.ANNOUNCED
+            else State.FLOODED
+          }
+          val tagState = a.tags(TagUtils.state)
+          tagState shouldBe realState
+
         })
   }
 

--- a/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
@@ -76,7 +76,7 @@ case class WriteTestSpec(numDistinctCubes: Int, spark: SparkSession, tmpDir: Str
               rev.revisionID,
               Weight.MinValue,
               maxWeight,
-              false,
+              "FLOODED",
               i * 10,
               i * 1000L,
               System.currentTimeMillis())

--- a/src/test/scala/io/qbeast/spark/index/NormalizedWeightIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/NormalizedWeightIntegrationTest.scala
@@ -39,7 +39,7 @@ class NormalizedWeightIntegrationTest extends QbeastIntegrationTestSpec {
         val files = deltaLog.snapshot.allFiles
         files.count() shouldBe 1
         files.map(_.tags(TagUtils.maxWeight).toInt).collect()(0) shouldBe <=(Int.MaxValue)
-        files.map(_.tags(TagUtils.replicated)).collect()(0) shouldBe false.toString
+        files.map(_.tags(TagUtils.state)).collect()(0) shouldBe "FLOODED"
 
     }
 

--- a/src/test/scala/io/qbeast/spark/keeper/ProtocolMockTest.scala
+++ b/src/test/scala/io/qbeast/spark/keeper/ProtocolMockTest.scala
@@ -3,9 +3,60 @@ package io.qbeast.spark.keeper
 import io.qbeast.core.keeper.{Keeper, LocalKeeper}
 
 class ProtocolMockTest extends ProtocolMockTestSpec {
+  "the qbeast-spark client" should
+    "throw an execution when an inconstant state is found" in withContext(LocalKeeper) {
+      context =>
+        implicit val keeper: Keeper = LocalKeeper
 
-  "The qbeast-spark client" should "not cause inconsistency when there are not conflicts" in
-    withContext(RandomKeeper) { context =>
+        val initProcess = new InitProcess(context)
+        val announcer = new AnnouncerProcess(context, Seq("", "A", "AA", "AAA"))
+        val writer = new WritingProcess(context)
+        val badOptimizer = new OptimizingProcessBad(context, Seq("gA", "g"))
+
+        initProcess.startTransactionAndWait()
+        initProcess.finishTransaction()
+
+        announcer.start()
+        announcer.join()
+
+        writer.startTransactionAndWait()
+
+        badOptimizer.startTransactionAndWait()
+
+        badOptimizer.finishTransaction()
+
+        writer.finishTransaction()
+
+        writer.succeeded shouldBe Some(false)
+
+    }
+  "A faulty keeper" should "not cause inconsistency with conflicts" in withContext(RandomKeeper) {
+    context =>
+      implicit val keeper: Keeper = RandomKeeper
+      val initProcess = new InitProcess(context)
+      val announcer = new AnnouncerProcess(context, Seq("", "A", "AA", "AAA"))
+      val writer = new WritingProcess(context)
+      val optim = new OptimizingProcessGood(context)
+
+      initProcess.startTransactionAndWait()
+      initProcess.finishTransaction()
+
+      announcer.start()
+      announcer.join()
+
+      writer.startTransactionAndWait()
+
+      optim.startTransactionAndWait()
+
+      optim.finishTransaction()
+
+      writer.finishTransaction()
+      writer.succeeded shouldBe Some(false)
+
+  }
+
+  it should "not cause inconsistency when there are not conflicts" in withContext(RandomKeeper) {
+    context =>
       implicit val keeper: Keeper = RandomKeeper
       val initProcess = new InitProcess(context)
       val announcer = new AnnouncerProcess(context, Seq("", "A", "AA", "AAA"))
@@ -26,8 +77,7 @@ class ProtocolMockTest extends ProtocolMockTestSpec {
 
       writer.succeeded shouldBe Some(true)
 
-    }
-
+  }
   "A crashed with timeouts" should "not cause inconsistency in normal scenario" in withContext(
     LocalKeeper) { context =>
     implicit val keeper: Keeper = LocalKeeper
@@ -50,6 +100,35 @@ class ProtocolMockTest extends ProtocolMockTestSpec {
 
     writer.succeeded shouldBe Some(true)
   }
+
+  "A write timout" should
+    "not cause inconsistency when a a timeout may interfere with an optimization" in withContext(
+      LocalKeeper) { context =>
+      implicit val keeper = LocalKeeper
+      val initProcess = new InitProcess(context)
+      val announcer = new AnnouncerProcess(context, Seq("", "A", "AA"))
+      val writer = new WritingProcess(context)
+      val optim = new OptimizingProcessGood(context)
+
+      initProcess.startTransactionAndWait()
+      initProcess.finishTransaction()
+
+      writer.startTransactionAndWait()
+      Thread.sleep(1000) // We make sure the keeper forgot about this write operations
+
+      announcer.start() // so that when we announce, we are not aware of a running write operation
+      announcer.join()
+
+      // which should lead the optim to optimize something it should not be touched.
+
+      optim.startTransactionAndWait()
+      optim.finishTransaction()
+
+      // But the write should detect it and fail
+      writer.finishTransaction()
+      writer.succeeded shouldBe Some(false)
+
+    }
 
   "A crashed optimization" should "not caused problems" in withContext(LocalKeeper) { context =>
     implicit val keeper = LocalKeeper

--- a/src/test/scala/io/qbeast/spark/table/HasConflictsTest.scala
+++ b/src/test/scala/io/qbeast/spark/table/HasConflictsTest.scala
@@ -1,0 +1,60 @@
+package io.qbeast.spark.table
+
+import io.qbeast.core.model.{CubeId, QTableID}
+import io.qbeast.spark.delta.SparkDeltaMetadataManager
+import io.qbeast.spark.{QbeastIntegrationTestSpec, QbeastTable}
+
+class HasConflictsTest extends QbeastIntegrationTestSpec {
+
+  /**
+   *  A conflict happens if there
+   * are new cubes that have been optimized but they were not announced.
+   */
+
+  "Has conflict method" should
+    "be true on replicated conflicts" in withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+      {
+
+        val data = loadTestData(spark)
+        writeTestData(data, Seq("user_id", "product_id"), 10000, tmpDir)
+
+        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+        qbeastTable.analyze()
+        qbeastTable.optimize()
+
+        // If the announced cubes is empty,
+        // means that the process is not aware of the cubes optimized in the middle
+        // and the conflict is not solvable
+        SparkDeltaMetadataManager.hasConflicts(
+          QTableID(tmpDir),
+          1L,
+          Set.empty, // knowAnnounced is empty
+          Set.empty // old replicated set is empty
+        ) shouldBe true
+
+      }
+    }
+
+  it should
+    "be false when there is no conflict " +
+    "between optimization and write" in withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
+      {
+        val data = loadTestData(spark)
+        writeTestData(data, Seq("user_id", "product_id"), 10000, tmpDir)
+
+        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
+        val knowAnnounced = qbeastTable.analyze()
+        qbeastTable.optimize()
+
+        // If we are aware of the announced cubes,
+        // the process has to end successfully and no conflicts are raised
+        SparkDeltaMetadataManager.hasConflicts(
+          QTableID(tmpDir),
+          1L,
+          knowAnnounced.map(CubeId(2, _)).toSet, // know announced is set
+          Set.empty // old replicated set is empty
+        ) shouldBe false
+
+      }
+    }
+}


### PR DESCRIPTION
This PR reverts the changes made on #200 because we move to a different strategy on #207 

So history is clean and we upgrade to version 0.4.0 accordingly to the next available release for Apache Spark 3.3.0 and Delta Lake 2.1.0.