### PR TITLE
Upgrade to Spark 3.4.1 and Delta 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 **Qbeast Spark** is an extension for [**Data Lakehouses**](http://cidrdb.org/cidr2021/papers/cidr2021_paper17.pdf) that enables **multi-dimensional filtering** and **sampling** directly on the storage
 
-[![apache-spark](https://img.shields.io/badge/apache--spark-3.3.x-blue)](https://spark.apache.org/releases/spark-release-3-2-2.html) 
+[![apache-spark](https://img.shields.io/badge/apache--spark-3.4.x-blue)](https://spark.apache.org/releases/spark-release-3-4-1.html) 
 [![apache-hadoop](https://img.shields.io/badge/apache--hadoop-3.3.x-blue)](https://hadoop.apache.org/release/3.3.1.html)
-[![delta-core](https://img.shields.io/badge/delta--core-2.1.0-blue)](https://github.com/delta-io/delta/releases/tag/v1.2.0)
+[![delta-core](https://img.shields.io/badge/delta--core-2.4.0-blue)](https://github.com/delta-io/delta/releases/tag/v2.4.0)
 [![codecov](https://codecov.io/gh/Qbeast-io/qbeast-spark/branch/main/graph/badge.svg?token=8WO7HGZ4MW)](https://codecov.io/gh/Qbeast-io/qbeast-spark)
 
 </div>
@@ -170,6 +170,7 @@ Use [Python index visualizer](./utils/visualizer/README.md) for your indexed tab
 | 0.2.0   | 3.1.x | 3.2.0  |   1.0.0    |
 | 0.3.x   | 3.2.x | 3.3.x  |   1.2.x    |
 | 0.4.x   | 3.3.x | 3.3.x  |   2.1.x    |
+| 0.5.x   | 3.4.x | 3.3.x  |   2.4.x    |
 
 Check [here](https://docs.delta.io/latest/releases.html) for **Delta Lake** and **Apache Spark** version compatibility.  
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import xerial.sbt.Sonatype._
 
-val mainVersion = "0.4.0"
+val mainVersion = "0.5.0-SNAPSHOT"
 
 lazy val qbeastCore = (project in file("core"))
   .settings(
@@ -104,7 +104,7 @@ ThisBuild / publishTo := {
 }
 
 // Sonatype settings
-//ThisBuild / publishMavenStyle := true
+// ThisBuild / publishMavenStyle := true
 ThisBuild / coverageEnabled := true
 ThisBuild / sonatypeProfileName := "io.qbeast"
 ThisBuild / sonatypeProjectHosting := Some(

--- a/build.sbt
+++ b/build.sbt
@@ -104,8 +104,7 @@ ThisBuild / publishTo := {
 }
 
 // Sonatype settings
-// ThisBuild / publishMavenStyle := true
-ThisBuild / coverageEnabled := true
+ThisBuild / publishMavenStyle := true
 ThisBuild / sonatypeProfileName := "io.qbeast"
 ThisBuild / sonatypeProjectHosting := Some(
   GitHubHosting(user = "Qbeast-io", repository = "qbeast-spark", email = "info@qbeast.io"))

--- a/core/src/main/scala/io/qbeast/core/model/QDataType.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QDataType.scala
@@ -92,12 +92,6 @@ object TimestampDataType extends OrderedDataType {
 
 }
 
-object TimestampNTZType extends OrderedDataType {
-  override def name: String = "TimestampNTZType"
-  override val ordering: Numeric[Any] = implicitly[Numeric[Long]].asInstanceOf[Numeric[Any]]
-
-}
-
 object DateDataType extends OrderedDataType {
   override def name: String = "DateDataType"
   override val ordering: Numeric[Any] = implicitly[Numeric[Long]].asInstanceOf[Numeric[Any]]

--- a/core/src/main/scala/io/qbeast/core/model/QDataType.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QDataType.scala
@@ -92,6 +92,12 @@ object TimestampDataType extends OrderedDataType {
 
 }
 
+object TimestampNTZType extends OrderedDataType {
+  override def name: String = "TimestampNTZType"
+  override val ordering: Numeric[Any] = implicitly[Numeric[Long]].asInstanceOf[Numeric[Any]]
+
+}
+
 object DateDataType extends OrderedDataType {
   override def name: String = "DateDataType"
   override val ordering: Numeric[Any] = implicitly[Numeric[Long]].asInstanceOf[Numeric[Any]]

--- a/core/src/main/scala/io/qbeast/core/transform/LinearTransformation.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/LinearTransformation.scala
@@ -69,8 +69,9 @@ case class LinearTransformation(
 
   /**
    * Merges two transformations. The domain of the resulting transformation is the union of this
-   * and the other transformation. The range of the resulting transformation is the intersection of
-   * this and the other transformation, which can be a LinearTransformation or IdentityTransformation
+   * and the other transformation. The range of the resulting transformation
+   * is the intersection of this and the other transformation,
+   * which can be a LinearTransformation or IdentityTransformation
    * @param other
    * @return a new Transformation that contains both this and other.
    */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,9 @@ import sbt._
  * External libraries used in the project with versions.
  */
 object Dependencies {
-  lazy val sparkVersion: String = sys.props.get("spark.version").getOrElse("3.3.0")
+  lazy val sparkVersion: String = sys.props.get("spark.version").getOrElse("3.4.1")
   lazy val hadoopVersion: String = sys.props.get("hadoop.version").getOrElse("3.3.4")
-  lazy val deltaVersion: String = "2.1.0"
+  lazy val deltaVersion: String = "2.4.0"
 
   val sparkCore = "org.apache.spark" %% "spark-core" % sparkVersion
   val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -34,7 +34,7 @@ class QbeastTable private (
   private def deltaLog: DeltaLog = DeltaLog.forTable(sparkSession, tableID.id)
 
   private def qbeastSnapshot: DeltaQbeastSnapshot =
-    delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    delta.DeltaQbeastSnapshot(deltaLog.update())
 
   private def indexedTable: IndexedTable = indexedTableFactory.getIndexedTable(tableID)
 

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -34,7 +34,7 @@ class QbeastTable private (
   private def deltaLog: DeltaLog = DeltaLog.forTable(sparkSession, tableID.id)
 
   private def qbeastSnapshot: DeltaQbeastSnapshot =
-    delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+    delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
   private def indexedTable: IndexedTable = indexedTableFactory.getIndexedTable(tableID)
 

--- a/src/main/scala/io/qbeast/spark/delta/CubeDataLoader.scala
+++ b/src/main/scala/io/qbeast/spark/delta/CubeDataLoader.scala
@@ -18,7 +18,7 @@ case class CubeDataLoader(tableID: QTableID) {
 
   private val spark = SparkSession.active
 
-  private val snapshot = DeltaLog.forTable(SparkSession.active, tableID.id).snapshot
+  private val snapshot = DeltaLog.forTable(SparkSession.active, tableID.id).unsafeVolatileSnapshot
 
   /**
    * Loads the data from a set of cubes in a specific revision

--- a/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -104,7 +104,7 @@ private[delta] case class DeltaMetadataWriter(
 
     val cubeStrings = deltaReplicatedSet.map(_.string)
     val cubeBlocks =
-      deltaLog.snapshot.allFiles
+      deltaLog.unsafeVolatileSnapshot.allFiles
         .where(TagColumns.revision === lit(revision.revisionID.toString) &&
           TagColumns.cube.isInCollection(cubeStrings))
         .collect()
@@ -145,7 +145,7 @@ private[delta] case class DeltaMetadataWriter(
       } else if (mode == SaveMode.Ignore) {
         return Nil
       } else if (mode == SaveMode.Overwrite) {
-        deltaLog.assertRemovable()
+        DeltaLog.assertRemovable(txn.snapshot)
       }
     }
     val rearrangeOnly = options.rearrangeOnly

--- a/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -104,7 +104,9 @@ private[delta] case class DeltaMetadataWriter(
 
     val cubeStrings = deltaReplicatedSet.map(_.string)
     val cubeBlocks =
-      deltaLog.unsafeVolatileSnapshot.allFiles
+      deltaLog
+        .update()
+        .allFiles
         .where(TagColumns.revision === lit(revision.revisionID.toString) &&
           TagColumns.cube.isInCollection(cubeStrings))
         .collect()

--- a/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
+++ b/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
@@ -118,7 +118,7 @@ object OTreeIndex {
 
   def apply(spark: SparkSession, path: Path): OTreeIndex = {
     val deltaLog = DeltaLog.forTable(spark, path)
-    val unsafeVolatileSnapshot = deltaLog.unsafeVolatileSnapshot
+    val unsafeVolatileSnapshot = deltaLog.update()
     val tahoe = TahoeLogFileIndex(spark, deltaLog, path, unsafeVolatileSnapshot, Seq.empty, false)
     OTreeIndex(tahoe)
   }

--- a/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
+++ b/src/main/scala/io/qbeast/spark/delta/OTreeIndex.scala
@@ -118,7 +118,8 @@ object OTreeIndex {
 
   def apply(spark: SparkSession, path: Path): OTreeIndex = {
     val deltaLog = DeltaLog.forTable(spark, path)
-    val tahoe = TahoeLogFileIndex(spark, deltaLog, path, deltaLog.snapshot, Seq.empty, false)
+    val unsafeVolatileSnapshot = deltaLog.unsafeVolatileSnapshot
+    val tahoe = TahoeLogFileIndex(spark, deltaLog, path, unsafeVolatileSnapshot, Seq.empty, false)
     OTreeIndex(tahoe)
   }
 

--- a/src/main/scala/io/qbeast/spark/delta/StagingDataManager.scala
+++ b/src/main/scala/io/qbeast/spark/delta/StagingDataManager.scala
@@ -17,7 +17,8 @@ import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 private[spark] class StagingDataManager(tableID: QTableID) extends DeltaStagingUtils {
   private val spark = SparkSession.active
 
-  protected override val snapshot: Snapshot = DeltaLog.forTable(spark, tableID.id).snapshot
+  protected override val snapshot: Snapshot =
+    DeltaLog.forTable(spark, tableID.id).unsafeVolatileSnapshot
 
   private def stagingRemoveFiles: Seq[RemoveFile] = {
     import spark.implicits._

--- a/src/main/scala/io/qbeast/spark/internal/commands/ConvertToQbeastCommand.scala
+++ b/src/main/scala/io/qbeast/spark/internal/commands/ConvertToQbeastCommand.scala
@@ -54,7 +54,8 @@ case class ConvertToQbeastCommand(
     val (fileFormat, tableId) = resolveTableFormat(spark)
 
     val deltaLog = DeltaLog.forTable(spark, tableId.table)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+    val unsafeVolatileSnapshot = deltaLog.unsafeVolatileSnapshot
+    val qbeastSnapshot = DeltaQbeastSnapshot(unsafeVolatileSnapshot)
     val isQbeast = qbeastSnapshot.loadAllRevisions.nonEmpty
 
     if (isQbeast) {
@@ -78,7 +79,7 @@ case class ConvertToQbeastCommand(
 
       // Convert delta to qbeast through metadata modification
       val tableID = QTableID(tableId.table)
-      val schema = deltaLog.snapshot.schema
+      val schema = deltaLog.unsafeVolatileSnapshot.schema
 
       SparkDeltaMetadataManager.updateMetadataWithTransaction(tableID, schema) {
         val convRevision = stagingRevision(tableID, cubeSize, columnsToIndex)

--- a/src/main/scala/io/qbeast/spark/internal/commands/ConvertToQbeastCommand.scala
+++ b/src/main/scala/io/qbeast/spark/internal/commands/ConvertToQbeastCommand.scala
@@ -54,7 +54,7 @@ case class ConvertToQbeastCommand(
     val (fileFormat, tableId) = resolveTableFormat(spark)
 
     val deltaLog = DeltaLog.forTable(spark, tableId.table)
-    val unsafeVolatileSnapshot = deltaLog.unsafeVolatileSnapshot
+    val unsafeVolatileSnapshot = deltaLog.update()
     val qbeastSnapshot = DeltaQbeastSnapshot(unsafeVolatileSnapshot)
     val isQbeast = qbeastSnapshot.loadAllRevisions.nonEmpty
 
@@ -79,7 +79,7 @@ case class ConvertToQbeastCommand(
 
       // Convert delta to qbeast through metadata modification
       val tableID = QTableID(tableId.table)
-      val schema = deltaLog.unsafeVolatileSnapshot.schema
+      val schema = deltaLog.update().schema
 
       SparkDeltaMetadataManager.updateMetadataWithTransaction(tableID, schema) {
         val convRevision = stagingRevision(tableID, cubeSize, columnsToIndex)

--- a/src/main/scala/io/qbeast/spark/internal/sources/catalog/DefaultStagedTable.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/catalog/DefaultStagedTable.scala
@@ -5,7 +5,9 @@ package io.qbeast.spark.internal.sources.catalog
 
 import org.apache.spark.sql.AnalysisExceptionFactory
 import org.apache.spark.sql.connector.catalog.{
+  Column,
   Identifier,
+  SparkCatalogV2Util,
   StagedTable,
   SupportsWrite,
   Table,
@@ -44,7 +46,9 @@ private[catalog] case class DefaultStagedTable(
 
   override def name(): String = ident.name()
 
-  override def schema(): StructType = table.schema()
+  override def schema(): StructType = SparkCatalogV2Util.v2ColumnsToStructType(columns())
+
+  override def columns(): Array[Column] = table.columns()
 
   override def partitioning(): Array[Transform] = table.partitioning()
 

--- a/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalog.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalog.scala
@@ -98,6 +98,13 @@ class QbeastCatalog[T <: TableCatalog with SupportsNamespaces with FunctionCatal
 
   override def createTable(
       ident: Identifier,
+      columns: Array[Column],
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table =
+    createTable(ident, SparkCatalogV2Util.v2ColumnsToStructType(columns), partitions, properties)
+
+  override def createTable(
+      ident: Identifier,
       schema: StructType,
       partitions: Array[Transform],
       properties: util.Map[String, String]): Table = {
@@ -120,7 +127,7 @@ class QbeastCatalog[T <: TableCatalog with SupportsNamespaces with FunctionCatal
     } else {
       getSessionCatalog(properties.asScala.toMap).createTable(
         ident,
-        schema,
+        SparkCatalogV2Util.structTypeToV2Columns(schema),
         partitions,
         properties)
     }
@@ -154,7 +161,11 @@ class QbeastCatalog[T <: TableCatalog with SupportsNamespaces with FunctionCatal
       }
       DefaultStagedTable(
         ident,
-        sessionCatalog.createTable(ident, schema, partitions, properties),
+        sessionCatalog.createTable(
+          ident,
+          SparkCatalogV2Util.structTypeToV2Columns(schema),
+          partitions,
+          properties),
         this)
     }
   }
@@ -179,10 +190,24 @@ class QbeastCatalog[T <: TableCatalog with SupportsNamespaces with FunctionCatal
       }
       DefaultStagedTable(
         ident,
-        sessionCatalog.createTable(ident, schema, partitions, properties),
+        sessionCatalog.createTable(
+          ident,
+          SparkCatalogV2Util.structTypeToV2Columns(schema),
+          partitions,
+          properties),
         this)
 
     }
+  }
+
+  override def stageCreate(
+      ident: Identifier,
+      columns: Array[Column],
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+
+    stageCreate(ident, SparkCatalogV2Util.v2ColumnsToStructType(columns), partitions, properties)
+
   }
 
   override def stageCreate(
@@ -202,7 +227,11 @@ class QbeastCatalog[T <: TableCatalog with SupportsNamespaces with FunctionCatal
       DefaultStagedTable(
         ident,
         getSessionCatalog(properties.asScala.toMap)
-          .createTable(ident, schema, partitions, properties),
+          .createTable(
+            ident,
+            SparkCatalogV2Util.structTypeToV2Columns(schema),
+            partitions,
+            properties),
         this)
     }
   }

--- a/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastStagedTableImpl.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastStagedTableImpl.scala
@@ -76,7 +76,7 @@ private[sources] class QbeastStagedTableImpl(
     // the writing of the dataFrame (if any)
     QbeastCatalogUtils.createQbeastTable(
       ident,
-      schema,
+      schema(),
       partitions,
       props,
       writeOptions,

--- a/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastWriteBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastWriteBuilder.scala
@@ -59,6 +59,8 @@ class QbeastWriteBuilder(
           // Passing the options in the query plan plus the properties
           // because columnsToIndex needs to be included in the contract
           val writeOptions = info.options().toMap ++ properties
+          // scalastyle:off
+          println("data schema " + data.schema)
           indexedTable.save(data, writeOptions, append)
         }
       }

--- a/src/main/scala/io/qbeast/spark/utils/SparkToQTypesUtils.scala
+++ b/src/main/scala/io/qbeast/spark/utils/SparkToQTypesUtils.scala
@@ -17,6 +17,7 @@ object SparkToQTypesUtils {
     case _: DecimalType => qmodel.DecimalDataType
     case _: TimestampType => qmodel.TimestampDataType
     case _: DateType => qmodel.DateDataType
+    case _: TimestampNTZType => qmodel.TimestampNTZType
     case _ => throw new RuntimeException(s"${sparkType.typeName} is not supported yet")
     // TODO add more types
   }

--- a/src/main/scala/io/qbeast/spark/utils/SparkToQTypesUtils.scala
+++ b/src/main/scala/io/qbeast/spark/utils/SparkToQTypesUtils.scala
@@ -17,7 +17,6 @@ object SparkToQTypesUtils {
     case _: DecimalType => qmodel.DecimalDataType
     case _: TimestampType => qmodel.TimestampDataType
     case _: DateType => qmodel.DateDataType
-    case _: TimestampNTZType => qmodel.TimestampNTZType
     case _ => throw new RuntimeException(s"${sparkType.typeName} is not supported yet")
     // TODO add more types
   }

--- a/src/main/scala/org/apache/spark/sql/connector/catalog/SparkCatalogV2Util.scala
+++ b/src/main/scala/org/apache/spark/sql/connector/catalog/SparkCatalogV2Util.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
+package org.apache.spark.sql.connector.catalog
+
+import org.apache.spark.sql.types.StructType
+
+object SparkCatalogV2Util {
+
+  /**
+   * Converts DS v2 columns to StructType, which encodes column comment and default value to
+   * StructField metadata. This is mainly used to define the schema of v2 scan, w.r.t. the columns
+   * of the v2 table.
+   */
+  def v2ColumnsToStructType(columns: Array[Column]): StructType = {
+    CatalogV2Util.v2ColumnsToStructType(columns)
+  }
+
+  def structTypeToV2Columns(schema: StructType): Array[Column] = {
+    CatalogV2Util.structTypeToV2Columns(schema)
+  }
+
+}

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaStatsCollectionUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaStatsCollectionUtils.scala
@@ -28,7 +28,7 @@ trait DeltaStatsCollectionUtils {
       val deltaLog = DeltaLog.forTable(sparkSession, tableID.id)
       val metadata = deltaLog.unsafeVolatileMetadata
       val outputPath = deltaLog.dataPath
-      val deltaProtocol = deltaLog.unsafeVolatileSnapshot.protocol
+      val deltaProtocol = deltaLog.update().protocol
 
       val indexedCols = DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.fromMetaData(metadata)
 

--- a/src/test/scala/io/qbeast/docs/DocumentationTests.scala
+++ b/src/test/scala/io/qbeast/docs/DocumentationTests.scala
@@ -87,7 +87,7 @@ class DocumentationTests extends QbeastIntegrationTestSpec {
       val qbeast_df = spark.read.format("qbeast").load(qbeast_table_path)
 
       val deltaLog = DeltaLog.forTable(spark, qbeast_table_path)
-      val totalNumberOfFiles = deltaLog.snapshot.allFiles.count()
+      val totalNumberOfFiles = deltaLog.unsafeVolatileSnapshot.allFiles.count()
 
       totalNumberOfFiles should be > 1L withClue
         "Total number of files in pushdown notebook changes to " + totalNumberOfFiles

--- a/src/test/scala/io/qbeast/docs/DocumentationTests.scala
+++ b/src/test/scala/io/qbeast/docs/DocumentationTests.scala
@@ -87,7 +87,7 @@ class DocumentationTests extends QbeastIntegrationTestSpec {
       val qbeast_df = spark.read.format("qbeast").load(qbeast_table_path)
 
       val deltaLog = DeltaLog.forTable(spark, qbeast_table_path)
-      val totalNumberOfFiles = deltaLog.unsafeVolatileSnapshot.allFiles.count()
+      val totalNumberOfFiles = deltaLog.update().allFiles.count()
 
       totalNumberOfFiles should be > 1L withClue
         "Total number of files in pushdown notebook changes to " + totalNumberOfFiles

--- a/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
@@ -20,7 +20,7 @@ class IndexStatusBuilderTest extends QbeastIntegrationTestSpec {
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
       val indexStatus =
-        DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot).loadLatestIndexStatus
+        DeltaQbeastSnapshot(deltaLog.update()).loadLatestIndexStatus
 
       indexStatus.revision.revisionID shouldBe 1
       indexStatus.cubesStatuses.foreach(_._2.files.size shouldBe 1)
@@ -44,7 +44,7 @@ class IndexStatusBuilderTest extends QbeastIntegrationTestSpec {
       .save(tmpDir)
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
     val firstIndexStatus =
-      DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot).loadLatestIndexStatus
+      DeltaQbeastSnapshot(deltaLog.update()).loadLatestIndexStatus
     data.write
       .format("qbeast")
       .mode("append")

--- a/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/IndexStatusBuilderTest.scala
@@ -20,7 +20,7 @@ class IndexStatusBuilderTest extends QbeastIntegrationTestSpec {
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
       val indexStatus =
-        DeltaQbeastSnapshot(deltaLog.snapshot).loadLatestIndexStatus
+        DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot).loadLatestIndexStatus
 
       indexStatus.revision.revisionID shouldBe 1
       indexStatus.cubesStatuses.foreach(_._2.files.size shouldBe 1)
@@ -43,7 +43,8 @@ class IndexStatusBuilderTest extends QbeastIntegrationTestSpec {
       .option("cubeSize", "10000")
       .save(tmpDir)
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
-    val firstIndexStatus = DeltaQbeastSnapshot(deltaLog.snapshot).loadLatestIndexStatus
+    val firstIndexStatus =
+      DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot).loadLatestIndexStatus
     data.write
       .format("qbeast")
       .mode("append")

--- a/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
@@ -45,11 +45,17 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
     val tahoeFileIndex = {
-      TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
+      TahoeLogFileIndex(
+        spark,
+        deltaLog,
+        deltaLog.dataPath,
+        deltaLog.unsafeVolatileSnapshot,
+        Seq.empty,
+        false)
     }
     val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
-    val allFiles = deltaLog.snapshot.allFiles.collect().map(_.path)
+    val allFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.path)
 
     val matchFiles = oTreeIndex.matchingBlocks(Seq.empty, Seq.empty).map(_.path)
 
@@ -73,11 +79,17 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
     val tahoeFileIndex = {
-      TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
+      TahoeLogFileIndex(
+        spark,
+        deltaLog,
+        deltaLog.dataPath,
+        deltaLog.unsafeVolatileSnapshot,
+        Seq.empty,
+        false)
     }
     val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
-    oTreeIndex.inputFiles shouldBe deltaLog.snapshot.allFiles
+    oTreeIndex.inputFiles shouldBe deltaLog.unsafeVolatileSnapshot.allFiles
       .collect()
       .map(file => new Path(deltaLog.dataPath, file.path).toString)
   })
@@ -95,10 +107,16 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
       val deltaLog = DeltaLog.forTable(spark, tmpdir)
       val tahoeFileIndex = {
-        TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
+        TahoeLogFileIndex(
+          spark,
+          deltaLog,
+          deltaLog.dataPath,
+          deltaLog.unsafeVolatileSnapshot,
+          Seq.empty,
+          false)
       }
       val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
-      val allFiles = deltaLog.snapshot.allFiles.collect().map(_.path)
+      val allFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.path)
 
       oTreeIndex.matchingBlocks(Seq.empty, Seq.empty).map(_.path).toSet shouldBe allFiles.toSet
     })
@@ -115,11 +133,17 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
     val tahoeFileIndex = {
-      TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.snapshot, Seq.empty, false)
+      TahoeLogFileIndex(
+        spark,
+        deltaLog,
+        deltaLog.dataPath,
+        deltaLog.unsafeVolatileSnapshot,
+        Seq.empty,
+        false)
     }
     val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
-    val sizeInBytes = deltaLog.snapshot.allFiles.collect().map(_.size).sum
+    val sizeInBytes = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.size).sum
     oTreeIndex.sizeInBytes shouldBe sizeInBytes
   })
 

--- a/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/OTreeIndexTest.scala
@@ -45,17 +45,11 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
     val tahoeFileIndex = {
-      TahoeLogFileIndex(
-        spark,
-        deltaLog,
-        deltaLog.dataPath,
-        deltaLog.unsafeVolatileSnapshot,
-        Seq.empty,
-        false)
+      TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.update(), Seq.empty, false)
     }
     val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
-    val allFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.path)
+    val allFiles = deltaLog.update().allFiles.collect().map(_.path)
 
     val matchFiles = oTreeIndex.matchingBlocks(Seq.empty, Seq.empty).map(_.path)
 
@@ -79,17 +73,13 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
     val tahoeFileIndex = {
-      TahoeLogFileIndex(
-        spark,
-        deltaLog,
-        deltaLog.dataPath,
-        deltaLog.unsafeVolatileSnapshot,
-        Seq.empty,
-        false)
+      TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.update(), Seq.empty, false)
     }
     val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
-    oTreeIndex.inputFiles shouldBe deltaLog.unsafeVolatileSnapshot.allFiles
+    oTreeIndex.inputFiles shouldBe deltaLog
+      .update()
+      .allFiles
       .collect()
       .map(file => new Path(deltaLog.dataPath, file.path).toString)
   })
@@ -107,16 +97,10 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
       val deltaLog = DeltaLog.forTable(spark, tmpdir)
       val tahoeFileIndex = {
-        TahoeLogFileIndex(
-          spark,
-          deltaLog,
-          deltaLog.dataPath,
-          deltaLog.unsafeVolatileSnapshot,
-          Seq.empty,
-          false)
+        TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.update(), Seq.empty, false)
       }
       val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
-      val allFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.path)
+      val allFiles = deltaLog.update().allFiles.collect().map(_.path)
 
       oTreeIndex.matchingBlocks(Seq.empty, Seq.empty).map(_.path).toSet shouldBe allFiles.toSet
     })
@@ -133,17 +117,11 @@ class OTreeIndexTest extends QbeastIntegrationTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
     val tahoeFileIndex = {
-      TahoeLogFileIndex(
-        spark,
-        deltaLog,
-        deltaLog.dataPath,
-        deltaLog.unsafeVolatileSnapshot,
-        Seq.empty,
-        false)
+      TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.update(), Seq.empty, false)
     }
     val oTreeIndex = new OTreeIndexTest(tahoeFileIndex)
 
-    val sizeInBytes = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.size).sum
+    val sizeInBytes = deltaLog.update().allFiles.collect().map(_.size).sum
     oTreeIndex.sizeInBytes shouldBe sizeInBytes
   })
 

--- a/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
@@ -36,7 +36,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val indexStatus = qbeastSnapshot.loadLatestIndexStatus
         val revision = indexStatus.revision
 
@@ -62,7 +62,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val columnTransformers = SparkRevisionFactory
           .createNewRevision(QTableID(tmpDir), df.schema, options)
           .columnTransformers
@@ -92,7 +92,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val timestamp = System.currentTimeMillis()
         qbeastSnapshot.loadRevisionAt(timestamp) shouldBe qbeastSnapshot.loadLatestRevision
 
@@ -117,7 +117,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         an[AnalysisException] shouldBe thrownBy(
           qbeastSnapshot.loadRevisionAt(invalidRevisionTimestamp))
 
@@ -140,7 +140,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
             .save(tmpDir)
 
           val deltaLog = DeltaLog.forTable(spark, tmpDir)
-          val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+          val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
           val builder =
             new IndexStatusBuilder(
               qbeastSnapshot,

--- a/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
@@ -36,7 +36,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
         val indexStatus = qbeastSnapshot.loadLatestIndexStatus
         val revision = indexStatus.revision
 
@@ -62,7 +62,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
         val columnTransformers = SparkRevisionFactory
           .createNewRevision(QTableID(tmpDir), df.schema, options)
           .columnTransformers
@@ -92,7 +92,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
         val timestamp = System.currentTimeMillis()
         qbeastSnapshot.loadRevisionAt(timestamp) shouldBe qbeastSnapshot.loadLatestRevision
 
@@ -117,7 +117,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
         an[AnalysisException] shouldBe thrownBy(
           qbeastSnapshot.loadRevisionAt(invalidRevisionTimestamp))
 
@@ -140,7 +140,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
             .save(tmpDir)
 
           val deltaLog = DeltaLog.forTable(spark, tmpDir)
-          val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+          val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
           val builder =
             new IndexStatusBuilder(
               qbeastSnapshot,

--- a/src/test/scala/io/qbeast/spark/index/AnalyzeAndOptimizeTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/AnalyzeAndOptimizeTest.scala
@@ -55,7 +55,7 @@ class AnalyzeAndOptimizeTest
     qbeastTable.optimize()
 
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
-    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
     val replicatedCubes = qbeastSnapshot.loadLatestIndexStatus.replicatedSet
 
     val announcedCubes = qbeastTable.analyze()
@@ -72,7 +72,7 @@ class AnalyzeAndOptimizeTest
         val announcedCubes = qbeastTable.analyze()
         qbeastTable.optimize()
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
         val replicatedCubes =
           qbeastSnapshot.loadLatestIndexStatus.replicatedSet.map(_.string)
 

--- a/src/test/scala/io/qbeast/spark/index/AnalyzeAndOptimizeTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/AnalyzeAndOptimizeTest.scala
@@ -55,7 +55,7 @@ class AnalyzeAndOptimizeTest
     qbeastTable.optimize()
 
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
-    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
     val replicatedCubes = qbeastSnapshot.loadLatestIndexStatus.replicatedSet
 
     val announcedCubes = qbeastTable.analyze()
@@ -72,7 +72,7 @@ class AnalyzeAndOptimizeTest
         val announcedCubes = qbeastTable.analyze()
         qbeastTable.optimize()
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val replicatedCubes =
           qbeastSnapshot.loadLatestIndexStatus.replicatedSet.map(_.string)
 

--- a/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
@@ -40,7 +40,7 @@ class CubeWeightsIntegrationTest extends QbeastIntegrationTestSpec with PrivateM
             .save(tmpDir)
 
           val deltaLog = DeltaLog.forTable(spark, tmpDir)
-          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
           val commitLogWeightMap = qbeastSnapshot.loadLatestIndexStatus.cubesStatuses
 
           // commitLogWeightMap shouldBe weightMap
@@ -62,7 +62,7 @@ class CubeWeightsIntegrationTest extends QbeastIntegrationTestSpec with PrivateM
       .save(tmpDir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
-    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
     val cubeWeights = qbeastSnapshot.loadLatestIndexStatus.cubesStatuses
 
     cubeWeights.values.foreach { case CubeStatus(_, weight, _, _) =>

--- a/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
@@ -40,7 +40,7 @@ class CubeWeightsIntegrationTest extends QbeastIntegrationTestSpec with PrivateM
             .save(tmpDir)
 
           val deltaLog = DeltaLog.forTable(spark, tmpDir)
-          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
           val commitLogWeightMap = qbeastSnapshot.loadLatestIndexStatus.cubesStatuses
 
           // commitLogWeightMap shouldBe weightMap
@@ -62,7 +62,7 @@ class CubeWeightsIntegrationTest extends QbeastIntegrationTestSpec with PrivateM
       .save(tmpDir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
-    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
     val cubeWeights = qbeastSnapshot.loadLatestIndexStatus.cubesStatuses
 
     cubeWeights.values.foreach { case CubeStatus(_, weight, _, _) =>

--- a/src/test/scala/io/qbeast/spark/index/DataStagingTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/DataStagingTest.scala
@@ -21,7 +21,7 @@ class DataStagingTest
 
   def getQbeastSnapshot(spark: SparkSession, dir: String): DeltaQbeastSnapshot = {
     val deltaLog = DeltaLog.forTable(spark, dir)
-    DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    DeltaQbeastSnapshot(deltaLog.update())
   }
 
   private val getCurrentStagingSize: PrivateMethod[Long] =

--- a/src/test/scala/io/qbeast/spark/index/DataStagingTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/DataStagingTest.scala
@@ -21,7 +21,7 @@ class DataStagingTest
 
   def getQbeastSnapshot(spark: SparkSession, dir: String): DeltaQbeastSnapshot = {
     val deltaLog = DeltaLog.forTable(spark, dir)
-    DeltaQbeastSnapshot(deltaLog.snapshot)
+    DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
   }
 
   private val getCurrentStagingSize: PrivateMethod[Long] =

--- a/src/test/scala/io/qbeast/spark/index/IndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/IndexTest.scala
@@ -127,7 +127,7 @@ class IndexTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
 
         val offset = 0.5
         val appendData = df
@@ -190,7 +190,7 @@ class IndexTest
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
 
-        deltaLog.unsafeVolatileSnapshot.allFiles.collect() foreach (f =>
+        deltaLog.update().allFiles.collect() foreach (f =>
           {
             val cubeId = CubeId(2, f.tags("cube"))
             cubeId.parent match {

--- a/src/test/scala/io/qbeast/spark/index/IndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/IndexTest.scala
@@ -127,7 +127,7 @@ class IndexTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
         val offset = 0.5
         val appendData = df
@@ -190,7 +190,7 @@ class IndexTest
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
 
-        deltaLog.snapshot.allFiles.collect() foreach (f =>
+        deltaLog.unsafeVolatileSnapshot.allFiles.collect() foreach (f =>
           {
             val cubeId = CubeId(2, f.tags("cube"))
             cubeId.parent match {

--- a/src/test/scala/io/qbeast/spark/index/NewRevisionTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/NewRevisionTest.scala
@@ -40,7 +40,7 @@ class NewRevisionTest
       spaceMultipliers.foreach(i => appendNewRevision(spark, tmpDir, i))
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
       val spaceRevisions = qbeastSnapshot.loadAllRevisions
 
       // Including the staging revision
@@ -55,7 +55,7 @@ class NewRevisionTest
         appendNewRevision(spark, tmpDir, 3)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
         val revisions = qbeastSnapshot.loadAllRevisions
         val allWM =
@@ -88,7 +88,7 @@ class NewRevisionTest
             .save(tmpDir)
 
           val deltaLog = DeltaLog.forTable(spark, tmpDir)
-          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
           qbeastSnapshot.loadLatestRevision.desiredCubeSize shouldBe cubeSize
 
@@ -121,7 +121,7 @@ class NewRevisionTest
         .save(tmpDir)
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
       // Including the staging revision
       qbeastSnapshot.loadAllRevisions.size shouldBe 3
@@ -150,7 +150,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val transformation = qbeastSnapshot.loadLatestRevision.transformations.head
 
         qbeastSnapshot.loadLatestRevision.revisionID shouldBe 1
@@ -182,7 +182,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val transformation = qbeastSnapshot.loadLatestRevision.transformations.head
 
         qbeastSnapshot.loadLatestRevision.revisionID shouldBe 1
@@ -215,7 +215,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val revision = qbeastSnapshot.loadLatestRevision
         val transformation = revision.transformations.head
 
@@ -253,7 +253,7 @@ class NewRevisionTest
         .save(tmpDir)
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
       val allRevisions = qbeastSnapshot.loadAllRevisions.sortBy(_.revisionID)
 
       val firstWriteTransformation =
@@ -303,7 +303,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val allRevisions = qbeastSnapshot.loadAllRevisions.sortBy(_.revisionID)
 
         val firstWriteTransformation =

--- a/src/test/scala/io/qbeast/spark/index/NewRevisionTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/NewRevisionTest.scala
@@ -40,7 +40,7 @@ class NewRevisionTest
       spaceMultipliers.foreach(i => appendNewRevision(spark, tmpDir, i))
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
       val spaceRevisions = qbeastSnapshot.loadAllRevisions
 
       // Including the staging revision
@@ -55,7 +55,7 @@ class NewRevisionTest
         appendNewRevision(spark, tmpDir, 3)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
 
         val revisions = qbeastSnapshot.loadAllRevisions
         val allWM =
@@ -88,7 +88,7 @@ class NewRevisionTest
             .save(tmpDir)
 
           val deltaLog = DeltaLog.forTable(spark, tmpDir)
-          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+          val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
 
           qbeastSnapshot.loadLatestRevision.desiredCubeSize shouldBe cubeSize
 
@@ -121,7 +121,7 @@ class NewRevisionTest
         .save(tmpDir)
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
 
       // Including the staging revision
       qbeastSnapshot.loadAllRevisions.size shouldBe 3
@@ -150,7 +150,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
         val transformation = qbeastSnapshot.loadLatestRevision.transformations.head
 
         qbeastSnapshot.loadLatestRevision.revisionID shouldBe 1
@@ -182,7 +182,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
         val transformation = qbeastSnapshot.loadLatestRevision.transformations.head
 
         qbeastSnapshot.loadLatestRevision.revisionID shouldBe 1
@@ -215,7 +215,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
         val revision = qbeastSnapshot.loadLatestRevision
         val transformation = revision.transformations.head
 
@@ -253,7 +253,7 @@ class NewRevisionTest
         .save(tmpDir)
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+      val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
       val allRevisions = qbeastSnapshot.loadAllRevisions.sortBy(_.revisionID)
 
       val firstWriteTransformation =
@@ -303,7 +303,7 @@ class NewRevisionTest
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = delta.DeltaQbeastSnapshot(deltaLog.update())
         val allRevisions = qbeastSnapshot.loadAllRevisions.sortBy(_.revisionID)
 
         val firstWriteTransformation =

--- a/src/test/scala/io/qbeast/spark/index/NormalizedWeightIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/NormalizedWeightIntegrationTest.scala
@@ -36,7 +36,7 @@ class NormalizedWeightIntegrationTest extends QbeastIntegrationTestSpec {
         spark.read.format("qbeast").load(tmpDir).count() shouldBe cubeSize
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val files = deltaLog.snapshot.allFiles
+        val files = deltaLog.unsafeVolatileSnapshot.allFiles
         files.count() shouldBe 1
         files.map(_.tags(TagUtils.maxWeight).toInt).collect()(0) shouldBe <=(Int.MaxValue)
         files.map(_.tags(TagUtils.state)).collect()(0) shouldBe "FLOODED"
@@ -57,7 +57,7 @@ class NormalizedWeightIntegrationTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
         val cubeNormalizedWeights =
           qbeastSnapshot.loadLatestIndexStatus.cubeNormalizedWeights
 

--- a/src/test/scala/io/qbeast/spark/index/NormalizedWeightIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/NormalizedWeightIntegrationTest.scala
@@ -36,7 +36,7 @@ class NormalizedWeightIntegrationTest extends QbeastIntegrationTestSpec {
         spark.read.format("qbeast").load(tmpDir).count() shouldBe cubeSize
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val files = deltaLog.unsafeVolatileSnapshot.allFiles
+        val files = deltaLog.update().allFiles
         files.count() shouldBe 1
         files.map(_.tags(TagUtils.maxWeight).toInt).collect()(0) shouldBe <=(Int.MaxValue)
         files.map(_.tags(TagUtils.state)).collect()(0) shouldBe "FLOODED"
@@ -57,7 +57,7 @@ class NormalizedWeightIntegrationTest extends QbeastIntegrationTestSpec {
           .save(tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
         val cubeNormalizedWeights =
           qbeastSnapshot.loadLatestIndexStatus.cubeNormalizedWeights
 

--- a/src/test/scala/io/qbeast/spark/index/RevisionTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/RevisionTest.scala
@@ -30,7 +30,7 @@ class RevisionTest
       .option("columnsToIndex", columnsToIndex)
       .save(directory)
     val deltaLog = DeltaLog.forTable(spark, directory)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
     val lastRevision = qbeastSnapshot.loadLatestRevision
     val dfqbeast = spark.read.format("qbeast").load(directory)
     dfqbeast.createTempView("dfqbeast")

--- a/src/test/scala/io/qbeast/spark/index/RevisionTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/RevisionTest.scala
@@ -30,7 +30,7 @@ class RevisionTest
       .option("columnsToIndex", columnsToIndex)
       .save(directory)
     val deltaLog = DeltaLog.forTable(spark, directory)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
     val lastRevision = qbeastSnapshot.loadLatestRevision
     val dfqbeast = spark.read.format("qbeast").load(directory)
     dfqbeast.createTempView("dfqbeast")

--- a/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
@@ -141,7 +141,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       .option("columnStats", appendColumnStats)
       .save(tmpDir)
 
-    val qbeastSnapshot = DeltaQbeastSnapshot(DeltaLog.forTable(spark, tmpDir).snapshot)
+    val qbeastSnapshot =
+      DeltaQbeastSnapshot(DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot)
     val latestRevision = qbeastSnapshot.loadLatestRevision
     val transformation = latestRevision.transformations.head
 

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -17,13 +17,13 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(source.toDF(), Seq("a", "c"), 8000, tmpdir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
     val filters = Seq.empty
 
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -42,13 +42,13 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(source.toDF(), Seq("a", "c"), 8000, tmpdir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
     val filters = Seq(weightFilters(WeightRange(Weight.MinValue, Weight(0.001))))
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -64,13 +64,13 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(source.toDF(), Seq("a", "c"), 8000, tmpdir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
     val filters = Seq(expr("a >= 2 and a < 10").expr)
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -93,7 +93,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(differentRevision, Seq("a", "c"), 10000, tmpdir, "append")
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
     // Including the staging revision
     qbeastSnapshot.loadAllRevisions.size shouldBe 3
@@ -103,7 +103,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -122,7 +122,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
       writeTestData(df, Seq("a", "c"), 10000, tmpDir)
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+      val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
       val weightRange = WeightRange(Weight(3), Weight(5))
       val expressionFilters = weightFilters(weightRange)
@@ -130,7 +130,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
 
       val queryExecutor = new QueryExecutor(querySpecBuilder, qbeastSnapshot)
 
-      val allDeltaFiles = deltaLog.snapshot.allFiles.collect()
+      val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
       val allFiles = allDeltaFiles.map(_.path)
 
       val matchFiles = queryExecutor.execute().map(_.path)
@@ -154,7 +154,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
 
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
     val revision = qbeastSnapshot.loadLatestRevision
     val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
 
@@ -173,7 +173,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
       .executeRevision(querySpec, faultyIndexStatus)
       .map(_.path)
 
-    val allFiles = deltaLog.snapshot.allFiles.collect().map(_.path)
+    val allFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.path)
 
     val diff = allFiles.toSet -- matchFiles.toSet
     diff.size shouldBe 1

--- a/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/query/QueryExecutorTest.scala
@@ -17,13 +17,13 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(source.toDF(), Seq("a", "c"), 8000, tmpdir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
     val filters = Seq.empty
 
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.update().allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -42,13 +42,13 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(source.toDF(), Seq("a", "c"), 8000, tmpdir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
 
     val filters = Seq(weightFilters(WeightRange(Weight.MinValue, Weight(0.001))))
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.update().allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -64,13 +64,13 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(source.toDF(), Seq("a", "c"), 8000, tmpdir)
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
 
     val filters = Seq(expr("a >= 2 and a < 10").expr)
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.update().allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -93,7 +93,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     writeTestData(differentRevision, Seq("a", "c"), 10000, tmpdir, "append")
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
 
     // Including the staging revision
     qbeastSnapshot.loadAllRevisions.size shouldBe 3
@@ -103,7 +103,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
     val querySpec = new QuerySpecBuilder(filters)
     val queryExecutor = new QueryExecutor(querySpec, qbeastSnapshot)
 
-    val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
+    val allDeltaFiles = deltaLog.update().allFiles.collect()
     val allFiles = allDeltaFiles.map(_.path)
 
     val matchFiles = queryExecutor.execute().map(_.path)
@@ -122,7 +122,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
       writeTestData(df, Seq("a", "c"), 10000, tmpDir)
 
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+      val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
 
       val weightRange = WeightRange(Weight(3), Weight(5))
       val expressionFilters = weightFilters(weightRange)
@@ -130,7 +130,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
 
       val queryExecutor = new QueryExecutor(querySpecBuilder, qbeastSnapshot)
 
-      val allDeltaFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
+      val allDeltaFiles = deltaLog.update().allFiles.collect()
       val allFiles = allDeltaFiles.map(_.path)
 
       val matchFiles = queryExecutor.execute().map(_.path)
@@ -154,7 +154,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
 
     val deltaLog = DeltaLog.forTable(spark, tmpdir)
 
-    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
     val revision = qbeastSnapshot.loadLatestRevision
     val indexStatus = qbeastSnapshot.loadIndexStatus(revision.revisionID)
 
@@ -173,7 +173,7 @@ class QueryExecutorTest extends QbeastIntegrationTestSpec with QueryTestSpec {
       .executeRevision(querySpec, faultyIndexStatus)
       .map(_.path)
 
-    val allFiles = deltaLog.unsafeVolatileSnapshot.allFiles.collect().map(_.path)
+    val allFiles = deltaLog.update().allFiles.collect().map(_.path)
 
     val diff = allFiles.toSet -- matchFiles.toSet
     diff.size shouldBe 1

--- a/src/test/scala/io/qbeast/spark/internal/sources/QbeastDataSourceTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/QbeastDataSourceTest.scala
@@ -5,6 +5,7 @@ package io.qbeast.spark.internal.sources
 
 import io.qbeast.core.model.QTableID
 import io.qbeast.spark.table.{IndexedTable, IndexedTableFactory}
+import org.apache.spark.sql.connector.catalog.SparkCatalogV2Util
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.sources.BaseRelation
@@ -65,10 +66,11 @@ class QbeastDataSourceTest extends FixtureAnyFlatSpec with MockitoSugar with Mat
 
   it should "return correct table" in { f =>
     val schema = StructType(Seq())
+    val columns = SparkCatalogV2Util.structTypeToV2Columns(schema)
     val partitioning = Array.empty[Transform]
     val properties = Map("path" -> path).asJava
     val table = f.dataSource.getTable(schema, partitioning, properties)
-    table.schema() shouldBe schema
+    table.columns() shouldBe columns
     table.capabilities() shouldBe Set(
       ACCEPT_ANY_SCHEMA,
       BATCH_READ,

--- a/src/test/scala/io/qbeast/spark/internal/sources/QbeastStagedTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/QbeastStagedTableTest.scala
@@ -6,6 +6,7 @@ import io.qbeast.spark.internal.sources.v2.QbeastStagedTableImpl
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.TableCapability.V1_BATCH_WRITE
+import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.write.V1Write
 
 import scala.collection.JavaConverters._
@@ -18,8 +19,8 @@ class QbeastStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestSu
       qbeastCatalog
         .stageCreate(
           Identifier.of(Array("default"), "students"),
-          schema,
-          Array.empty,
+          columns,
+          Array.empty[Transform],
           Map("provider" -> "qbeast", "columnsToIndex" -> "id").asJava) shouldBe a[
         QbeastStagedTableImpl]
 
@@ -31,8 +32,8 @@ class QbeastStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestSu
         qbeastCatalog
           .stageCreate(
             Identifier.of(Array("default"), "students"),
-            schema,
-            Array.empty,
+            columns,
+            Array.empty[Transform],
             Map("provider" -> "qbeast", "columnsToIndex" -> "id").asJava)
           .asInstanceOf[QbeastStagedTableImpl]
 
@@ -45,8 +46,8 @@ class QbeastStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestSu
       qbeastCatalog
         .stageCreate(
           Identifier.of(Array("default"), "students"),
-          schema,
-          Array.empty,
+          columns,
+          Array.empty[Transform],
           Map("provider" -> "qbeast", "columnsToIndex" -> "id").asJava)
         .asInstanceOf[QbeastStagedTableImpl]
 
@@ -59,8 +60,8 @@ class QbeastStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestSu
       qbeastCatalog
         .stageCreate(
           Identifier.of(Array("default"), "students"),
-          schema,
-          Array.empty,
+          columns,
+          Array.empty[Transform],
           Map("provider" -> "qbeast", "columnsToIndex" -> "id").asJava)
         .asInstanceOf[QbeastStagedTableImpl]
 
@@ -75,8 +76,8 @@ class QbeastStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestSu
         qbeastCatalog
           .stageCreate(
             Identifier.of(Array("default"), "students"),
-            schema,
-            Array.empty,
+            columns,
+            Array.empty[Transform],
             Map("provider" -> "qbeast", "columnsToIndex" -> "id").asJava)
           .asInstanceOf[QbeastStagedTableImpl]
 
@@ -95,8 +96,8 @@ class QbeastStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestSu
       qbeastCatalog
         .stageCreate(
           Identifier.of(Array("default"), "students"),
-          schema,
-          Array.empty,
+          columns,
+          Array.empty[Transform],
           Map("provider" -> "qbeast", "columnsToIndex" -> "id").asJava)
         .asInstanceOf[QbeastStagedTableImpl]
 

--- a/src/test/scala/io/qbeast/spark/internal/sources/QbeastTableImplTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/QbeastTableImplTest.scala
@@ -7,6 +7,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.TableCapability._
+import org.apache.spark.sql.connector.expressions.Transform
 
 import scala.collection.JavaConverters._
 
@@ -78,7 +79,7 @@ class QbeastTableImplTest extends QbeastIntegrationTestSpec with CatalogTestSuit
       val identifier = Identifier.of(defaultNamespace, "students")
       val tableIdentifier = TableIdentifier(identifier.name(), identifier.namespace().headOption)
       val properties = Map.empty[String, String]
-      qbeastCatalog.createTable(identifier, schema, Array.empty, properties.asJava)
+      qbeastCatalog.createTable(identifier, columns, Array.empty[Transform], properties.asJava)
 
       val qbeastTableImpl = new QbeastTableImpl(
         tableIdentifier,

--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/CatalogTestSuite.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/CatalogTestSuite.scala
@@ -5,6 +5,7 @@ import io.qbeast.context.QbeastContext
 import io.qbeast.spark.table.IndexedTableFactory
 import org.apache.spark.sql.{DataFrame, SparkCatalogUtils, SparkSession}
 import org.apache.spark.sql.connector.catalog.{
+  SparkCatalogV2Util,
   StagingTableCatalog,
   SupportsNamespaces,
   TableCatalog
@@ -29,6 +30,8 @@ trait CatalogTestSuite {
       StructField("id", IntegerType, true),
       StructField("name", StringType, true),
       StructField("age", IntegerType, true)))
+
+  val columns = SparkCatalogV2Util.structTypeToV2Columns(schema)
 
   val defaultNamespace: Array[String] = Array("default")
 

--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/DefaultStagedTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/DefaultStagedTableTest.scala
@@ -3,7 +3,9 @@ package io.qbeast.spark.internal.sources.catalog
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.connector.catalog.{Identifier}
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.expressions.Transform
+
 import scala.collection.JavaConverters._
 
 class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestSuite {
@@ -15,20 +17,20 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
 
       qbeastCatalog.stageCreate(
         tableIdentifier,
-        schema,
-        Array.empty,
+        columns,
+        Array.empty[Transform],
         Map.empty[String, String].asJava) shouldBe a[DefaultStagedTable]
 
       qbeastCatalog.stageReplace(
         tableIdentifier,
-        schema,
-        Array.empty,
+        columns,
+        Array.empty[Transform],
         Map.empty[String, String].asJava) shouldBe a[DefaultStagedTable]
 
       qbeastCatalog.stageCreateOrReplace(
         tableIdentifier,
-        schema,
-        Array.empty,
+        columns,
+        Array.empty[Transform],
         Map.empty[String, String].asJava) shouldBe a[DefaultStagedTable]
     })
 
@@ -36,7 +38,11 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
     val tableIdentifier = Identifier.of(Array("default"), "students")
     val catalog = sessionCatalog(spark)
     val underlyingTable =
-      catalog.createTable(tableIdentifier, schema, Array.empty, Map.empty[String, String].asJava)
+      catalog.createTable(
+        tableIdentifier,
+        columns,
+        Array.empty[Transform],
+        Map.empty[String, String].asJava)
 
     val defaultStagedTable = DefaultStagedTable
       .apply(tableIdentifier, underlyingTable, catalog)
@@ -48,7 +54,11 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
     val tableIdentifier = Identifier.of(Array("default"), "students")
     val catalog = sessionCatalog(spark)
     val underlyingTable =
-      catalog.createTable(tableIdentifier, schema, Array.empty, Map.empty[String, String].asJava)
+      catalog.createTable(
+        tableIdentifier,
+        columns,
+        Array.empty[Transform],
+        Map.empty[String, String].asJava)
 
     val defaultStagedTable = DefaultStagedTable
       .apply(tableIdentifier, underlyingTable, catalog)
@@ -60,7 +70,11 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
     val tableIdentifier = Identifier.of(Array("default"), "students")
     val catalog = sessionCatalog(spark)
     val underlyingTable =
-      catalog.createTable(tableIdentifier, schema, Array.empty, Map.empty[String, String].asJava)
+      catalog.createTable(
+        tableIdentifier,
+        columns,
+        Array.empty[Transform],
+        Map.empty[String, String].asJava)
 
     val defaultStagedTable = DefaultStagedTable
       .apply(tableIdentifier, underlyingTable, catalog)
@@ -72,19 +86,28 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
     val tableIdentifier = Identifier.of(Array("default"), "students")
     val catalog = sessionCatalog(spark)
     val underlyingTable =
-      catalog.createTable(tableIdentifier, schema, Array.empty, Map.empty[String, String].asJava)
+      catalog.createTable(
+        tableIdentifier,
+        columns,
+        Array.empty[Transform],
+        Map.empty[String, String].asJava)
 
     val defaultStagedTable = DefaultStagedTable
       .apply(tableIdentifier, underlyingTable, catalog)
 
     defaultStagedTable.schema() shouldBe schema
+    defaultStagedTable.columns() shouldBe columns
   })
 
   it should "output name" in withQbeastContextSparkAndTmpWarehouse((spark, tmpWarehouse) => {
     val tableIdentifier = Identifier.of(Array("default"), "students")
     val catalog = sessionCatalog(spark)
     val underlyingTable =
-      catalog.createTable(tableIdentifier, schema, Array.empty, Map.empty[String, String].asJava)
+      catalog.createTable(
+        tableIdentifier,
+        columns,
+        Array.empty[Transform],
+        Map.empty[String, String].asJava)
 
     val defaultStagedTable = DefaultStagedTable
       .apply(tableIdentifier, underlyingTable, catalog)
@@ -98,8 +121,8 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
       val catalog = sessionCatalog(spark)
       val underlyingTable = catalog.createTable(
         tableIdentifier,
-        schema,
-        Array.empty,
+        columns,
+        Array.empty[Transform],
         Map.empty[String, String].asJava)
 
       val defaultStagedTable = DefaultStagedTable
@@ -115,8 +138,8 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
       val catalog = sessionCatalog(spark)
       val underlyingTable = catalog.createTable(
         tableIdentifier,
-        schema,
-        Array.empty,
+        columns,
+        Array.empty[Transform],
         Map.empty[String, String].asJava)
 
       val defaultStagedTable = DefaultStagedTable
@@ -133,8 +156,8 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
       val catalog = sessionCatalog(spark)
       val underlyingTable = catalog.createTable(
         tableIdentifier,
-        schema,
-        Array.empty,
+        columns,
+        Array.empty[Transform],
         Map.empty[String, String].asJava)
 
       val defaultStagedTable = DefaultStagedTable
@@ -158,8 +181,8 @@ class DefaultStagedTableTest extends QbeastIntegrationTestSpec with CatalogTestS
       val catalog = sessionCatalog(spark)
       val underlyingTable = catalog.createTable(
         tableIdentifier,
-        schema,
-        Array.empty,
+        columns,
+        Array.empty[Transform],
         Map("provider" -> "delta").asJava)
 
       val defaultStagedTable = DefaultStagedTable

--- a/src/test/scala/io/qbeast/spark/keeper/ProtocolMock.scala
+++ b/src/test/scala/io/qbeast/spark/keeper/ProtocolMock.scala
@@ -79,7 +79,7 @@ case class ProtoTestContext(outDir: String, spark: SparkSession) {
   lazy val schema: StructType = spark.read.format("qbeast").load(tableID.id).schema
 
   lazy val rev: Revision = DeltaQbeastSnapshot(
-    DeltaLog.forTable(spark, tableID.id).snapshot).loadLatestRevision
+    DeltaLog.forTable(spark, tableID.id).unsafeVolatileSnapshot).loadLatestRevision
 
 }
 

--- a/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
@@ -51,7 +51,7 @@ class ConvertToQbeastTest
 
   def getQbeastSnapshot(spark: SparkSession, dir: String): DeltaQbeastSnapshot = {
     val deltaLog = DeltaLog.forTable(spark, dir)
-    DeltaQbeastSnapshot(deltaLog.snapshot)
+    DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
   }
 
   behavior of "ConvertToQbeastCommand"

--- a/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
@@ -51,7 +51,7 @@ class ConvertToQbeastTest
 
   def getQbeastSnapshot(spark: SparkSession, dir: String): DeltaQbeastSnapshot = {
     val deltaLog = DeltaLog.forTable(spark, dir)
-    DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+    DeltaQbeastSnapshot(deltaLog.update())
   }
 
   behavior of "ConvertToQbeastCommand"

--- a/src/test/scala/io/qbeast/spark/utils/QbeastCompactionIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastCompactionIntegrationTest.scala
@@ -71,7 +71,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
         val originalNumOfFilesRoot =
-          deltaLog.unsafeVolatileSnapshot.allFiles.filter("tags.cube == ''").count()
+          deltaLog.update().allFiles.filter("tags.cube == ''").count()
 
         // Compact the tables
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
@@ -97,7 +97,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
         val originalNumOfFilesRoot =
-          deltaLog.unsafeVolatileSnapshot.allFiles.filter("tags.cube == ''").count()
+          deltaLog.update().allFiles.filter("tags.cube == ''").count()
 
         // Compact the table
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
@@ -122,7 +122,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
     // Load the index status before manipulating the files
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
     val originalIndexStatus =
-      DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot).loadLatestIndexStatus
+      DeltaQbeastSnapshot(deltaLog.update()).loadLatestIndexStatus
 
     // Compact the table
     val qbeastTable = QbeastTable.forPath(spark, tmpDir)

--- a/src/test/scala/io/qbeast/spark/utils/QbeastCompactionIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastCompactionIntegrationTest.scala
@@ -71,7 +71,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
         val originalNumOfFilesRoot =
-          deltaLog.snapshot.allFiles.filter("tags.cube == ''").count()
+          deltaLog.unsafeVolatileSnapshot.allFiles.filter("tags.cube == ''").count()
 
         // Compact the tables
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
@@ -97,7 +97,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
         val originalNumOfFilesRoot =
-          deltaLog.snapshot.allFiles.filter("tags.cube == ''").count()
+          deltaLog.unsafeVolatileSnapshot.allFiles.filter("tags.cube == ''").count()
 
         // Compact the table
         val qbeastTable = QbeastTable.forPath(spark, tmpDir)
@@ -121,7 +121,8 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
 
     // Load the index status before manipulating the files
     val deltaLog = DeltaLog.forTable(spark, tmpDir)
-    val originalIndexStatus = DeltaQbeastSnapshot(deltaLog.snapshot).loadLatestIndexStatus
+    val originalIndexStatus =
+      DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot).loadLatestIndexStatus
 
     // Compact the table
     val qbeastTable = QbeastTable.forPath(spark, tmpDir)
@@ -159,7 +160,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
     SparkDeltaMetadataManager.loadSnapshot(tableId).loadAllRevisions.size shouldBe 3
 
     // Count files written for each revision
-    val allFiles = DeltaLog.forTable(spark, tmpDir).snapshot.allFiles
+    val allFiles = DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.allFiles
     val originalFilesRevisionOne =
       allFiles.filter("tags.revision == 1").count()
     val originalFilesRevisionTwo =
@@ -170,7 +171,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
     qbeastTable.compact()
 
     // Count files compacted for each revision
-    val newAllFiles = DeltaLog.forTable(spark, tmpDir).snapshot.allFiles
+    val newAllFiles = DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.allFiles
     val newFilesRevisionOne = newAllFiles.filter("tags.revision == 1").count()
     val newFilesRevisionTwo = newAllFiles.filter("tags.revision == 2").count()
 
@@ -200,7 +201,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
     SparkDeltaMetadataManager.loadSnapshot(tableId).loadAllRevisions.size shouldBe 3
 
     // Count files written for each revision
-    val allFiles = DeltaLog.forTable(spark, tmpDir).snapshot.allFiles
+    val allFiles = DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.allFiles
     val originalFilesRevisionOne =
       allFiles.filter("tags.revision == 1").count()
     val originalFilesRevisionTwo =
@@ -211,7 +212,7 @@ class QbeastCompactionIntegrationTest extends QbeastIntegrationTestSpec {
     qbeastTable.compact(1)
 
     // Count files compacted for each revision
-    val newAllFiles = DeltaLog.forTable(spark, tmpDir).snapshot.allFiles
+    val newAllFiles = DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.allFiles
     val newFilesRevisionOne = newAllFiles.filter("tags.revision == 1").count()
     val newFilesRevisionTwo = newAllFiles.filter("tags.revision == 2").count()
 

--- a/src/test/scala/io/qbeast/spark/utils/QbeastDeltaIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastDeltaIntegrationTest.scala
@@ -1,0 +1,85 @@
+package io.qbeast.spark.utils
+
+import io.qbeast.spark.QbeastIntegrationTestSpec
+import org.apache.spark.sql.delta.{DeltaLog, TimestampNTZTableFeature}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
+import java.time.LocalDateTime
+
+/**
+ * Tests for ensuring compatibility between Qbeast and underlying features of Delta Lake
+ */
+class QbeastDeltaIntegrationTest extends QbeastIntegrationTestSpec {
+
+  def createSimpleTestData(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    Seq(("A", 1), ("B", 2), ("C", 3)).toDF("a", "b")
+  }
+
+  "Qbeast" should "output correctly Operation Metrics in Delta History" in
+    withQbeastContextSparkAndTmpDir((spark, tmpDir) => {
+
+      val data = createSimpleTestData(spark)
+      data.write
+        .format("qbeast")
+        .option("columnsToIndex", "a,b")
+        .save(tmpDir + "/qbeast")
+
+      val qbeastHistory =
+        spark.sql(s"DESCRIBE HISTORY '$tmpDir/qbeast'").select("operationMetrics")
+
+      val historyMap = qbeastHistory.first().get(0).asInstanceOf[Map[String, String]]
+      historyMap.size should be > 0
+      historyMap.get("numFiles") shouldBe Some("1")
+      historyMap.get("numOutputRows") shouldBe Some("3")
+      historyMap.get("numOutputBytes") shouldBe Some("660")
+
+    })
+
+  it should "output correctly File Metrics in Commit Log" in withQbeastContextSparkAndTmpDir(
+    (spark, tmpDir) => {
+
+      val data = createSimpleTestData(spark)
+      data.write
+        .format("qbeast")
+        .option("columnsToIndex", "a,b")
+        .save(tmpDir)
+
+      val stats =
+        DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.allFiles.collect().map(_.stats)
+      stats.length shouldBe >(0)
+      stats.head shouldBe "{\"numRecords\":3,\"minValues\":{\"a\":\"A\",\"b\":1}," +
+        "\"maxValues\":{\"a\":\"C\",\"b\":3}," +
+        "\"nullCount\":{\"a\":0,\"b\":0}}"
+
+    })
+
+  // TODO TIMESTAMP NTZ
+  it should "index tables with Timestamp NTZ" in withQbeastContextSparkAndTmpWarehouse(
+    (spark, tmpDir) => {
+
+      spark.sql(
+        "CREATE TABLE tbl(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ) " +
+          "USING qbeast OPTIONS ('columnsToIndex'='c1')")
+
+      spark.sql("""INSERT INTO tbl (c1, c2, c3)
+          | VALUES('foo','2022-01-02 03:04:05.123456','2022-01-02 03:04:05.123456')""".stripMargin)
+
+      val protocol = DeltaLog.forTable(spark, "tbl").unsafeVolatileSnapshot.protocol
+      assert(
+        protocol ==
+          TimestampNTZTableFeature.minProtocolVersion.withFeature(TimestampNTZTableFeature))
+
+      val formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS")
+      val time = formatter.parse("2022-01-02 03:04:05.123456").getTime
+      assert(
+        spark.table("tbl").head == Row(
+          "foo",
+          new Timestamp(time),
+          LocalDateTime.of(2022, 1, 2, 3, 4, 5, 123456000)))
+
+    })
+
+}

--- a/src/test/scala/io/qbeast/spark/utils/QbeastDeltaIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastDeltaIntegrationTest.scala
@@ -1,12 +1,8 @@
 package io.qbeast.spark.utils
 
 import io.qbeast.spark.QbeastIntegrationTestSpec
-import org.apache.spark.sql.delta.{DeltaLog, TimestampNTZTableFeature}
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-
-import java.sql.Timestamp
-import java.text.SimpleDateFormat
-import java.time.LocalDateTime
+import org.apache.spark.sql.delta.{DeltaLog}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
  * Tests for ensuring compatibility between Qbeast and underlying features of Delta Lake
@@ -53,32 +49,6 @@ class QbeastDeltaIntegrationTest extends QbeastIntegrationTestSpec {
       stats.head shouldBe "{\"numRecords\":3,\"minValues\":{\"a\":\"A\",\"b\":1}," +
         "\"maxValues\":{\"a\":\"C\",\"b\":3}," +
         "\"nullCount\":{\"a\":0,\"b\":0}}"
-
-    })
-
-  // TODO TIMESTAMP NTZ
-  it should "index tables with Timestamp NTZ" in withQbeastContextSparkAndTmpWarehouse(
-    (spark, tmpDir) => {
-
-      spark.sql(
-        "CREATE TABLE tbl(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ) " +
-          "USING qbeast OPTIONS ('columnsToIndex'='c1')")
-
-      spark.sql("""INSERT INTO tbl (c1, c2, c3)
-          | VALUES('foo','2022-01-02 03:04:05.123456','2022-01-02 03:04:05.123456')""".stripMargin)
-
-      val protocol = DeltaLog.forTable(spark, "tbl").unsafeVolatileSnapshot.protocol
-      assert(
-        protocol ==
-          TimestampNTZTableFeature.minProtocolVersion.withFeature(TimestampNTZTableFeature))
-
-      val formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS")
-      val time = formatter.parse("2022-01-02 03:04:05.123456").getTime
-      assert(
-        spark.table("tbl").head == Row(
-          "foo",
-          new Timestamp(time),
-          LocalDateTime.of(2022, 1, 2, 3, 4, 5, 123456000)))
 
     })
 

--- a/src/test/scala/io/qbeast/spark/utils/QbeastDeltaStagingTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastDeltaStagingTest.scala
@@ -44,7 +44,7 @@ class QbeastDeltaStagingTest extends QbeastIntegrationTestSpec with StagingUtils
       assertLargeDatasetEquality(qbeastDf, deltaDf)
 
       // Should have the staging revision and the first revision
-      val snapshot = DeltaLog.forTable(spark, tmpDir).snapshot
+      val snapshot = DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot
       val qs = DeltaQbeastSnapshot(snapshot)
       qs.loadAllRevisions.size shouldBe 2
       qs.existsRevision(stagingID)
@@ -67,7 +67,7 @@ class QbeastDeltaStagingTest extends QbeastIntegrationTestSpec with StagingUtils
       assertLargeDatasetEquality(qbeastDf, deltaDf)
 
       // Should preserve standing staging revision behavior
-      val snapshot = DeltaLog.forTable(spark, tmpDir).snapshot
+      val snapshot = DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot
       val qbeastSnapshot = DeltaQbeastSnapshot(snapshot)
       val stagingIndexStatus = qbeastSnapshot.loadIndexStatus(stagingID)
       stagingIndexStatus.cubesStatuses.size shouldBe 1
@@ -82,7 +82,7 @@ class QbeastDeltaStagingTest extends QbeastIntegrationTestSpec with StagingUtils
 
       // Number of delta files before compaction
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qsBefore = DeltaQbeastSnapshot(deltaLog.snapshot)
+      val qsBefore = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
       val numFilesBefore = qsBefore.loadIndexStatus(stagingID).cubesStatuses.head._2.files.size
 
       // Perform compaction

--- a/src/test/scala/io/qbeast/spark/utils/QbeastDeltaStagingTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastDeltaStagingTest.scala
@@ -82,7 +82,7 @@ class QbeastDeltaStagingTest extends QbeastIntegrationTestSpec with StagingUtils
 
       // Number of delta files before compaction
       val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val qsBefore = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+      val qsBefore = DeltaQbeastSnapshot(deltaLog.update())
       val numFilesBefore = qsBefore.loadIndexStatus(stagingID).cubesStatuses.head._2.files.size
 
       // Perform compaction

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSparkCorrectnessTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSparkCorrectnessTest.scala
@@ -5,7 +5,7 @@ package io.qbeast.spark.utils
 
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.delta.DeltaQbeastSnapshot
-import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
+import org.apache.spark.sql.{AnalysisException}
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.functions.{col, lit}
 
@@ -82,7 +82,7 @@ class QbeastSparkCorrectnessTest extends QbeastIntegrationTestSpec {
         writeTestData(data, Seq("user_id", "product_id"), 10000, tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
 
         // Include the staging revision
         qbeastSnapshot.loadAllRevisions.size shouldBe 2
@@ -219,48 +219,5 @@ class QbeastSparkCorrectnessTest extends QbeastIntegrationTestSpec {
           }
         }
     }
-
-  def createSimpleTestData(spark: SparkSession): DataFrame = {
-    import spark.implicits._
-    Seq(("A", 1), ("B", 2), ("C", 3)).toDF("a", "b")
-  }
-
-  "Qbeast" should "output correctly Operation Metrics in Delta History" in
-    withQbeastContextSparkAndTmpDir((spark, tmpDir) => {
-
-      val data = createSimpleTestData(spark)
-      data.write
-        .format("qbeast")
-        .option("columnsToIndex", "a,b")
-        .save(tmpDir + "/qbeast")
-
-      val qbeastHistory =
-        spark.sql(s"DESCRIBE HISTORY '$tmpDir/qbeast'").select("operationMetrics")
-
-      val historyMap = qbeastHistory.first().get(0).asInstanceOf[Map[String, String]]
-      historyMap.size should be > 0
-      historyMap.get("numFiles") shouldBe Some("1")
-      historyMap.get("numOutputRows") shouldBe Some("3")
-      historyMap.get("numOutputBytes") shouldBe Some("660")
-
-    })
-
-  it should "output correctly File Metrics in Commit Log" in withQbeastContextSparkAndTmpDir(
-    (spark, tmpDir) => {
-
-      val data = createSimpleTestData(spark)
-      data.write
-        .format("qbeast")
-        .option("columnsToIndex", "a,b")
-        .save(tmpDir)
-
-      val stats =
-        DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.allFiles.collect().map(_.stats)
-      stats.length shouldBe >(0)
-      stats.head shouldBe "{\"numRecords\":3,\"minValues\":{\"a\":\"A\",\"b\":1}," +
-        "\"maxValues\":{\"a\":\"C\",\"b\":3}," +
-        "\"nullCount\":{\"a\":0,\"b\":0}}"
-
-    })
 
 }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSparkCorrectnessTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSparkCorrectnessTest.scala
@@ -82,7 +82,7 @@ class QbeastSparkCorrectnessTest extends QbeastIntegrationTestSpec {
         writeTestData(data, Seq("user_id", "product_id"), 10000, tmpDir)
 
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
-        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.snapshot)
+        val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.unsafeVolatileSnapshot)
 
         // Include the staging revision
         qbeastSnapshot.loadAllRevisions.size shouldBe 2
@@ -254,7 +254,8 @@ class QbeastSparkCorrectnessTest extends QbeastIntegrationTestSpec {
         .option("columnsToIndex", "a,b")
         .save(tmpDir)
 
-      val stats = DeltaLog.forTable(spark, tmpDir).snapshot.allFiles.collect().map(_.stats)
+      val stats =
+        DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.allFiles.collect().map(_.stats)
       stats.length shouldBe >(0)
       stats.head shouldBe "{\"numRecords\":3,\"minValues\":{\"a\":\"A\",\"b\":1}," +
         "\"maxValues\":{\"a\":\"C\",\"b\":3}," +


### PR DESCRIPTION
This Draft PR is for updating versions of Spark and Delta to the latest available!

Here's a summary of some interesting changes that are included in the updates. 

## Spark 3.4.x

Read the full notes here: [Apache Spark Version 3.4 ](https://spark.apache.org/releases/spark-release-3-4-0.html), [Apache Spark Version 3.4.1](https://spark.apache.org/releases/spark-release-3-4-1.html)

- **Python Client for Spark Connect**.
- Timestamp without timezone support. (`TimestampNTZ` Type ).
- Support **timestamp in seconds** for TimeTravel using Dataframe options
- Better Spark UI scalability and Driver stability.
- **Catalog API compatible with 3 Layer Namespace**. 

## Delta 2.4.0

Read the full notes here: [Delta Lake Version 2.4.0](https://github.com/delta-io/delta/releases/tag/v2.4.0)
- Support for **Apache Spark 3.4**
- **Deletion Vectors implementation**. Improve the way UPDATES are handled and recovered, adopting a "Merge On Read" strategy.
- Support for writing and reading with Deletion Vectors and `PURGE` in case we want to deactivate the feature for the table (which will invoke a rewrite of some of the files).
- **Support `REPLACE WHERE` expressions** in SQL to selectively overwrite data.
- **Change on the `DeltaLog` API**: Now `snapshot` is no longer reliable to return the last Snapshot available. Use `DeltaLog.update()` instead. 
- NOTE: This version **does not include the [Iceberg to Delta converter](https://docs.delta.io/2.4.0/delta-utility.html#convert-an-iceberg-table-to-a-delta-table)**