### PR TITLE
QuerySpace creation fix

### DIFF
--- a/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/index/query/QuerySpecBuilder.scala
@@ -5,6 +5,7 @@ package io.qbeast.spark.index.query
 
 import io.qbeast.core.model._
 import org.apache.spark.sql.catalyst.expressions.{
+  Attribute,
   EqualTo,
   Expression,
   GreaterThan,
@@ -56,7 +57,8 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
       conjunctiveSplit.flatMap(transformInExpressions)
 
     // Filter those that involve any Qbeast Indexed Column
-    val queryFilters = transformedFilters.filter(hasQbeastColumnReference(_, indexedColumns))
+    val queryFilters = transformedFilters
+      .filter(hasQbeastColumnReference(_, indexedColumns))
 
     QbeastFilters(weightFilters, queryFilters)
   }
@@ -88,24 +90,24 @@ private[spark] class QuerySpecBuilder(sparkFilters: Seq[Expression])
         // if not found, use the overall coordinates
         val columnFrom = columnFilters
           .collectFirst {
-            case GreaterThan(_, l: Literal) => sparkTypeToCoreType(l)
-            case GreaterThanOrEqual(_, l: Literal) => sparkTypeToCoreType(l)
-            case LessThan(l: Literal, _) => sparkTypeToCoreType(l)
-            case LessThanOrEqual(l: Literal, _) => sparkTypeToCoreType(l)
-            case EqualTo(_, l: Literal) => sparkTypeToCoreType(l)
-            case EqualTo(l: Literal, _) => sparkTypeToCoreType(l)
-            case IsNull(_) => null
+            case GreaterThan(_: Attribute, l: Literal) => sparkTypeToCoreType(l)
+            case GreaterThanOrEqual(_: Attribute, l: Literal) => sparkTypeToCoreType(l)
+            case LessThan(l: Literal, _: Attribute) => sparkTypeToCoreType(l)
+            case LessThanOrEqual(l: Literal, _: Attribute) => sparkTypeToCoreType(l)
+            case EqualTo(_: Attribute, l: Literal) => sparkTypeToCoreType(l)
+            case EqualTo(l: Literal, _: Attribute) => sparkTypeToCoreType(l)
+            case IsNull(_: Attribute) => null
           }
 
         val columnTo = columnFilters
           .collectFirst {
-            case LessThan(_, l: Literal) => sparkTypeToCoreType(l)
-            case LessThanOrEqual(_, l: Literal) => sparkTypeToCoreType(l)
-            case GreaterThan(l: Literal, _) => sparkTypeToCoreType(l)
-            case GreaterThanOrEqual(l: Literal, _) => sparkTypeToCoreType(l)
-            case EqualTo(_, l: Literal) => sparkTypeToCoreType(l)
-            case EqualTo(l: Literal, _) => sparkTypeToCoreType(l)
-            case IsNull(_) => null
+            case LessThan(_: Attribute, l: Literal) => sparkTypeToCoreType(l)
+            case LessThanOrEqual(_: Attribute, l: Literal) => sparkTypeToCoreType(l)
+            case GreaterThan(l: Literal, _: Attribute) => sparkTypeToCoreType(l)
+            case GreaterThanOrEqual(l: Literal, _: Attribute) => sparkTypeToCoreType(l)
+            case EqualTo(_: Attribute, l: Literal) => sparkTypeToCoreType(l)
+            case EqualTo(l: Literal, _: Attribute) => sparkTypeToCoreType(l)
+            case IsNull(_: Attribute) => null
           }
 
         (columnFrom, columnTo)

--- a/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastFilterPushdownTest.scala
@@ -288,14 +288,14 @@ class QbeastFilterPushdownTest extends QbeastIntegrationTestSpec {
       }
   }
 
-  it should "pushdown regex expressions on strings" in withQbeastContextSparkAndTmpDir {
+  it should "NOT pushdown regex expressions on strings" in withQbeastContextSparkAndTmpDir {
     (spark, tmpDir) =>
       {
         val data = loadTestData(spark)
         val columnName = "brand_mod"
         val modifiedData =
           data
-            .withColumn(columnName, regexp_replace(col("brand"), "versace", "prefix_versace"))
+            .withColumn(columnName, regexp_replace(col("brand"), "kipardo", "prefix_kipardo"))
 
         // Index data with the new column
         writeTestData(modifiedData, Seq(columnName), 10000, tmpDir)
@@ -304,14 +304,27 @@ class QbeastFilterPushdownTest extends QbeastIntegrationTestSpec {
 
         val regexExpression = "prefix_(.+)"
         val filter =
-          s"(regexp_extract($columnName, '$regexExpression', 1) = 'versace')"
+          s"(regexp_extract($columnName, '$regexExpression', 1) = 'kipardo')"
         val query = df.filter(filter)
         val originalQuery = modifiedData.filter(filter)
-        val originalQueryWithoutRegex = data.filter("brand = 'versace'")
+        val originalQueryWithoutRegex = data.filter("brand = 'kipardo'")
 
         // OR filters are not split, so we need to match them entirely
         checkLogicalFilterPushdown(Seq(filter), query)
-        checkFileFiltering(query)
+
+        // Check if the files returned from the query are equal as the files existing in the folder
+        query.queryExecution.executedPlan
+          .collectLeaves()
+          .filter(_.isInstanceOf[FileSourceScanExec])
+          .foreach {
+            case f: FileSourceScanExec if f.relation.location.isInstanceOf[OTreeIndex] =>
+              val index = f.relation.location
+              val matchingFiles =
+                index.listFiles(f.partitionFilters, f.dataFilters).flatMap(_.files)
+              val allFiles = index.inputFiles
+              matchingFiles.length shouldBe allFiles.length
+          }
+
         assertSmallDatasetEquality(
           query,
           originalQuery,


### PR DESCRIPTION
## Description

In this PR, we fixed a bug in which the creation of the range filter that creates a QuerySpace wasn't taking into account the possibility of column transformations in Spark. 

For example, imagine that we index the parameter named `column1`. If we filter by:

`regex("prefix", "column1", 1) == "a"`

Instead of filtering by the regex expression, `QuerySpaceBuilder` would understand that we are trying to filter all the values that contain ` column1 == "a"`

## Type of change

Describe the change you're making: how it affects the API, and user experience...

Is a bug fix.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Please describe the tests that you ran to verify your changes.

Change test that (unfortunately) passed because the filter range belonged to the same file (`prefix_versace` and `versace` have very similar values of hash and had been stored together).
Now the test checks if we return the whole dataset in that type of scenarios. 

Later on, we can investigate how to manipulate more complex predicates. But let's start with the basics.

**Test Configuration**:
* Spark Version: 3.2.x
* Hadoop Version: 3.4.x
* Cluster or local? Local