### PR TITLE
Schema cast for appends using INSERT INTO

### DIFF
--- a/src/main/scala/io/qbeast/spark/internal/rules/QbeastAnalysis.scala
+++ b/src/main/scala/io/qbeast/spark/internal/rules/QbeastAnalysis.scala
@@ -31,8 +31,6 @@ class QbeastAnalysis(spark: SparkSession) extends Rule[LogicalPlan] with QbeastA
 
   }
 
-  // private val deltaAnalysis = new DeltaAnalysis(spark)
-
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     // This rule is a hack to return a V1 relation for reading
     // Because we didn't implemented SupportsRead on QbeastTableImpl yet
@@ -54,23 +52,6 @@ class QbeastAnalysis(spark: SparkSession) extends Rule[LogicalPlan] with QbeastA
         appendData.copy(query = projection)
       } else {
         appendData
-      }
-
-    /**
-     * Appending data by Name
-     * INSERT INTO tbl(col1, col2, col3) VALUES (...)
-     */
-
-    case appendDataByName @ AppendQbeastTable(relation, table)
-        if appendDataByName.isByName && relation.origin.sqlText.nonEmpty && needSchemaAdjustment(
-          table.name(),
-          appendDataByName.query,
-          relation.schema) =>
-      val projection = resolveQueryColumnsByName(appendDataByName.query, relation.output, table)
-      if (projection != appendDataByName.query) {
-        appendDataByName.copy(query = projection)
-      } else {
-        appendDataByName
       }
   }
 

--- a/src/main/scala/io/qbeast/spark/internal/rules/QbeastAnalysisUtils.scala
+++ b/src/main/scala/io/qbeast/spark/internal/rules/QbeastAnalysisUtils.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
 package io.qbeast.spark.internal.rules
 
 import org.apache.spark.sql.{AnalysisExceptionFactory, SchemaUtils}

--- a/src/main/scala/io/qbeast/spark/internal/rules/QbeastAnalysisUtils.scala
+++ b/src/main/scala/io/qbeast/spark/internal/rules/QbeastAnalysisUtils.scala
@@ -1,0 +1,222 @@
+package io.qbeast.spark.internal.rules
+
+import io.qbeast.spark.internal.sources.v2.QbeastTableImpl
+import org.apache.spark.sql.{AnalysisExceptionFactory, SchemaUtils, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{
+  Alias,
+  AnsiCast,
+  ArrayTransform,
+  Attribute,
+  Cast,
+  CreateStruct,
+  Expression,
+  GetArrayItem,
+  GetStructField,
+  LambdaFunction,
+  NamedExpression,
+  NamedLambdaVariable,
+  UpCast
+}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaErrors, DeltaLog}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{ArrayType, DataType, IntegerType, StructField, StructType}
+
+trait QbeastAnalysisUtils {
+
+  private lazy val session = SparkSession.active
+
+  /**
+   * Checks if the schema of the Table corresponds to the schema of the Query
+   * From Delta Lake OSS Project code in DeltaAnalysis
+   *
+   * @param tableName
+   * @param query
+   * @param schema
+   * @return
+   */
+  protected def needSchemaAdjustment(
+      tableName: String,
+      query: LogicalPlan,
+      schema: StructType): Boolean = {
+    val output = query.output
+    if (output.length < schema.length) {
+      throw AnalysisExceptionFactory.create(
+        s"The number of colums to write does not correspond " +
+          s"to the number of columns of the Table $tableName")
+    }
+    // Now we should try our best to match everything that already exists, and leave the rest
+    // for schema evolution
+    val existingSchemaOutput = output.take(schema.length)
+
+    existingSchemaOutput.map(_.name) != schema.map(_.name) ||
+    !SchemaUtils.isReadCompatible(
+      SchemaUtils.schemaAsNullable(schema),
+      existingSchemaOutput.toStructType)
+  }
+
+  def insertIntoByNameMissingColumn(
+      query: LogicalPlan,
+      targetAttrs: Seq[Attribute],
+      qbeastTable: QbeastTableImpl): Unit = {
+
+    val deltaLog = DeltaLog.forTable(session, qbeastTable.v1Table.location.toString)
+    val deltaLogProtocol = deltaLog.update().protocol
+    if (query.output.length < targetAttrs.length) {
+      // Some columns are not specified. We don't allow schema evolution in INSERT INTO BY NAME, so
+      // we need to ensure the missing columns must be generated columns.
+      val userSpecifiedNames = if (session.sessionState.conf.caseSensitiveAnalysis) {
+        query.output.map(a => (a.name, a)).toMap
+      } else {
+        CaseInsensitiveMap(query.output.map(a => (a.name, a)).toMap)
+      }
+      val tableSchema = qbeastTable.schema()
+      if (tableSchema.length != targetAttrs.length) {
+        // The target attributes may contain the metadata columns by design. Throwing an exception
+        // here in case target attributes may have the metadata columns for Delta in future.
+        throw DeltaErrors.schemaNotConsistentWithTarget(s"$tableSchema", s"$targetAttrs")
+      }
+      qbeastTable.schema().foreach { col =>
+        if (!userSpecifiedNames.contains(col.name) &&
+          !ColumnWithDefaultExprUtils.columnHasDefaultExpr(deltaLogProtocol, col)) {
+          throw DeltaErrors.missingColumnsInInsertInto(col.name)
+        }
+      }
+    }
+  }
+
+  protected def resolveQueryColumnsByName(
+      query: LogicalPlan,
+      targetAttrs: Seq[Attribute],
+      qbeastTable: QbeastTableImpl): LogicalPlan = {
+    insertIntoByNameMissingColumn(query, targetAttrs, qbeastTable)
+    // Spark will resolve columns to make sure specified columns are in the table schema and don't
+    // have duplicates. This is just a sanity check.
+    assert(
+      query.output.length <= targetAttrs.length,
+      s"Too many specified columns ${query.output.map(_.name).mkString(", ")}. " +
+        s"Table columns: ${targetAttrs.map(_.name).mkString(", ")}")
+
+    val project = query.output.map { attr =>
+      val targetAttr = targetAttrs
+        .find(t => session.sessionState.conf.resolver(t.name, attr.name))
+        .getOrElse {
+          // This is a sanity check. Spark should have done the check.
+          throw AnalysisExceptionFactory.create("Missing column")
+        }
+      addCastToColumn(attr, targetAttr, qbeastTable.name())
+    }
+    Project(project, query)
+  }
+
+  protected def resolveQueryColumnsByOrdinal(
+      query: LogicalPlan,
+      targetAttrs: Seq[Attribute],
+      tblName: String): LogicalPlan = {
+    // always add a Cast. it will be removed in the optimizer if it is unnecessary.
+    val project = query.output.zipWithIndex.map { case (attr, i) =>
+      if (i < targetAttrs.length) {
+        val targetAttr = targetAttrs(i)
+        addCastToColumn(attr, targetAttr, tblName)
+      } else {
+        attr
+      }
+    }
+    Project(project, query)
+  }
+
+  type CastFunction = (Expression, DataType) => Expression
+
+  protected def getCastFunction: CastFunction = {
+    val conf = SQLConf.get
+    val timeZone = conf.sessionLocalTimeZone
+    conf.storeAssignmentPolicy match {
+      case SQLConf.StoreAssignmentPolicy.LEGACY =>
+        Cast(_, _, Option(timeZone), ansiEnabled = false)
+      case SQLConf.StoreAssignmentPolicy.ANSI =>
+        (input: Expression, dt: DataType) => {
+          AnsiCast(input, dt, Option(timeZone))
+        }
+      case SQLConf.StoreAssignmentPolicy.STRICT => UpCast(_, _)
+    }
+  }
+
+  def addCastsToStructs(
+      tableName: String,
+      parent: NamedExpression,
+      source: StructType,
+      target: StructType): NamedExpression = {
+    if (source.length < target.length) {
+      throw DeltaErrors.notEnoughColumnsInInsert(
+        tableName,
+        source.length,
+        target.length,
+        Some(parent.qualifiedName))
+    }
+    val fields = source.zipWithIndex.map {
+      case (StructField(name, nested: StructType, _, metadata), i) if i < target.length =>
+        target(i).dataType match {
+          case t: StructType =>
+            val subField =
+              Alias(GetStructField(parent, i, Option(name)), target(i).name)(explicitMetadata =
+                Option(metadata))
+            addCastsToStructs(tableName, subField, nested, t)
+          case o =>
+            val field = parent.qualifiedName + "." + name
+            val targetName = parent.qualifiedName + "." + target(i).name
+            throw DeltaErrors.cannotInsertIntoColumn(tableName, field, targetName, o.simpleString)
+        }
+      case (other, i) if i < target.length =>
+        val targetAttr = target(i)
+        Alias(
+          getCastFunction(GetStructField(parent, i, Option(other.name)), targetAttr.dataType),
+          targetAttr.name)(explicitMetadata = Option(targetAttr.metadata))
+
+      case (other, i) =>
+        // This is a new column, so leave to schema evolution as is. Do not lose it's name so
+        // wrap with an alias
+        Alias(GetStructField(parent, i, Option(other.name)), other.name)(explicitMetadata =
+          Option(other.metadata))
+    }
+    Alias(CreateStruct(fields), parent.name)(
+      parent.exprId,
+      parent.qualifier,
+      Option(parent.metadata))
+  }
+
+  private def addCastsToArrayStructs(
+      tableName: String,
+      parent: NamedExpression,
+      source: StructType,
+      target: StructType,
+      sourceNullable: Boolean): Expression = {
+    val structConverter: (Expression, Expression) => Expression = (_, i) =>
+      addCastsToStructs(tableName, Alias(GetArrayItem(parent, i), i.toString)(), source, target)
+    val transformLambdaFunc = {
+      val elementVar = NamedLambdaVariable("elementVar", source, sourceNullable)
+      val indexVar = NamedLambdaVariable("indexVar", IntegerType, false)
+      LambdaFunction(structConverter(elementVar, indexVar), Seq(elementVar, indexVar))
+    }
+    ArrayTransform(parent, transformLambdaFunc)
+  }
+
+  protected def addCastToColumn(
+      attr: Attribute,
+      targetAttr: Attribute,
+      tblName: String): NamedExpression = {
+    val expr = (attr.dataType, targetAttr.dataType) match {
+      case (s, t) if s == t =>
+        attr
+      case (s: StructType, t: StructType) if s != t =>
+        addCastsToStructs(tblName, attr, s, t)
+      case (ArrayType(s: StructType, sNull: Boolean), ArrayType(t: StructType, tNull: Boolean))
+          if s != t && sNull == tNull =>
+        addCastsToArrayStructs(tblName, attr, s, t, sNull)
+      case _ =>
+        getCastFunction(attr, targetAttr.dataType)
+    }
+    Alias(expr, targetAttr.name)(explicitMetadata = Option(targetAttr.metadata))
+  }
+
+}

--- a/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastWriteBuilder.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastWriteBuilder.scala
@@ -3,6 +3,7 @@
  */
 package io.qbeast.spark.internal.sources.v2
 
+import io.qbeast.spark.internal.sources.QbeastBaseRelation
 import io.qbeast.spark.table.IndexedTable
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.connector.write.{
@@ -12,6 +13,7 @@ import org.apache.spark.sql.connector.write.{
   V1Write,
   WriteBuilder
 }
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.sources.{Filter, InsertableRelation}
 
 import scala.collection.convert.ImplicitConversions.`map AsScala`
@@ -54,12 +56,21 @@ class QbeastWriteBuilder(
 
       new InsertableRelation {
         def insert(data: DataFrame, overwrite: Boolean): Unit = {
+          val session = data.sparkSession
           val append = if (forceOverwrite) false else !overwrite
 
           // Passing the options in the query plan plus the properties
           // because columnsToIndex needs to be included in the contract
           val writeOptions = info.options().toMap ++ properties
           indexedTable.save(data, writeOptions, append)
+
+          // TODO: Push this to Apache Spark
+          // Re-cache all cached plans(including this relation itself, if it's cached) that refer
+          // to this data source relation. This is the behavior for InsertInto
+          session.sharedState.cacheManager.recacheByPlan(
+            session,
+            LogicalRelation(
+              QbeastBaseRelation.createRelation(session.sqlContext, indexedTable, writeOptions)))
         }
       }
     }

--- a/src/main/scala/org/apache/spark/sql/SchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/SchemaUtils.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ */
 package org.apache.spark.sql
 
 import org.apache.spark.sql.types.StructType

--- a/src/main/scala/org/apache/spark/sql/SchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/SchemaUtils.scala
@@ -1,0 +1,26 @@
+package org.apache.spark.sql
+
+import org.apache.spark.sql.types.StructType
+
+object SchemaUtils {
+
+  /**
+   * Sets all the fields from the Schema to nullable
+   * @param schema the schema to change
+   * @return
+   */
+  def schemaAsNullable(schema: StructType): StructType = {
+    schema.asNullable
+  }
+
+  /**
+   * Whether the newSchema is read compatible with the currentSchema or not
+   * @param newSchema the schema to test
+   * @param currentSchema the current schema of the table
+   * @return
+   */
+  def isReadCompatible(newSchema: StructType, currentSchema: StructType): Boolean = {
+    org.apache.spark.sql.delta.schema.SchemaUtils.isReadCompatible(newSchema, currentSchema)
+  }
+
+}

--- a/src/test/scala/io/qbeast/spark/utils/QbeastInsertToTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastInsertToTest.scala
@@ -1,6 +1,7 @@
 package io.qbeast.spark.utils
 
 import io.qbeast.spark.QbeastIntegrationTestSpec
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
 
 class QbeastInsertToTest extends QbeastIntegrationTestSpec {
@@ -186,6 +187,19 @@ class QbeastInsertToTest extends QbeastIntegrationTestSpec {
           ignoreNullable = true)
       }
   }
+
+  it should "insert into table with no schema" in
+    withQbeastContextSparkAndTmpWarehouse((spark, tmpWarehouse) => {
+
+      spark.sql(
+        s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+          "OPTIONS ('columnsToIndex'='id')")
+
+      spark.sql("INSERT INTO student VALUES (1, 'John', 10)")
+
+      spark.table("student").count() shouldBe 1
+      spark.table("student").head() shouldBe Row(1, "John", 10)
+    })
 
   it should "support INSERT OVERWRITE using a VALUE clause" in withQbeastContextSparkAndTmpDir {
     (spark, tmpDir) =>

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSchemaTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSchemaTest.scala
@@ -1,0 +1,102 @@
+package io.qbeast.spark.utils
+
+import io.qbeast.spark.QbeastIntegrationTestSpec
+import org.apache.spark.sql.{AnalysisException, Row}
+
+/**
+ * Test for checking the correctness of the output schemas
+ * when Appending Data through INSERT INTO
+ */
+class QbeastSchemaTest extends QbeastIntegrationTestSpec {
+
+  "Qbeast" should "detect when schemas does not match on INSERT INTO" in
+    withQbeastContextSparkAndTmpWarehouse((spark, _) => {
+
+      spark.sql(
+        s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+          "OPTIONS ('columnsToIndex'='id')")
+
+      an[AnalysisException] shouldBe thrownBy(spark.sql("INSERT INTO student VALUES (1, 'John')"))
+
+    })
+
+  it should "replace schemas by ordinal" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
+
+    spark.sql(
+      s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+        "OPTIONS ('columnsToIndex'='id')")
+
+    spark.sql("INSERT INTO student VALUES (1, 'John', 10)")
+
+    spark.table("student").head() shouldBe Row(1, "John", 10)
+
+  })
+
+  it should "replace schemas by name" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
+
+    spark.sql(
+      s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+        "OPTIONS ('columnsToIndex'='id')")
+
+    spark.sql("INSERT INTO student(id, name, age) VALUES (1, 'John', 10)")
+
+    spark.table("student").head() shouldBe Row(1, "John", 10)
+  })
+
+  it should "detect schema mismatch" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
+
+    spark.sql(
+      s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+        "OPTIONS ('columnsToIndex'='id')")
+
+    an[AnalysisException] shouldBe thrownBy(
+      spark.sql("INSERT INTO student(id1, name2, age3) VALUES (1, 'John', 10)"))
+
+    spark.table("student").head() shouldBe Row(1, "John", 10)
+  })
+
+  it should "fail when types does not match" in withQbeastContextSparkAndTmpWarehouse(
+    (spark, _) => {
+
+      spark.sql(
+        s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+          "OPTIONS ('columnsToIndex'='id')")
+
+      an[Exception] shouldBe thrownBy(spark.sql("INSERT INTO student VALUES ('John', 10, 1)"))
+
+    })
+
+  it should "replace schemas from other table" in withQbeastContextSparkAndTmpWarehouse(
+    (spark, _) => {
+
+      spark.sql(
+        s"CREATE TABLE student_parquet (id_parquet INT, name_parquet STRING, age_parquet INT) " +
+          s"USING parquet")
+      spark.sql("INSERT INTO student_parquet VALUES (1, 'John', 10)")
+
+      spark.sql(
+        s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+          "OPTIONS ('columnsToIndex'='id')")
+
+      spark.sql("INSERT INTO student SELECT * FROM student_parquet")
+
+      spark.table("student").head() shouldBe Row(1, "John", 10)
+    })
+
+  it should "not replace schemas from other table if they do not match" in
+    withQbeastContextSparkAndTmpWarehouse((spark, _) => {
+
+      spark.sql(
+        s"CREATE TABLE student_parquet (id_parquet INT, name_parquet STRING) " +
+          s"USING parquet")
+      spark.sql("INSERT INTO student_parquet VALUES (1, 'John')")
+
+      spark.sql(
+        s"CREATE TABLE student (id INT, name STRING, age INT) USING qbeast " +
+          "OPTIONS ('columnsToIndex'='id')")
+
+      an[AnalysisException] shouldBe thrownBy(
+        spark.sql("INSERT INTO student SELECT * FROM student_parquet"))
+
+    })
+}


### PR DESCRIPTION
## Description

Fixes #213 

## Type of change

Describe the change you're making: how it affects the API, user experience...

It is a bug fix for INSERT INTO statement when no schema is provided. 

The code searches the Spark Logical Plan for an `AppendData` operation to a `QbeastTableImpl` and applies the required casts to the input query in order to match the Schema of the Table.

NOTE: This code is retrieved from DeltaAnalysis in https://github.com/delta-io/delta/blob/512562dbd43b03bd3debcebd059ed2a36577d140/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala#L4 

Since all the methods were private, there was not easy way of avoiding duplication. Sorry for the inconvenience. 

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Please describe the tests that you ran to verify your changes.

Test referred to this particular problem/other issues regarding Schema can be found in `QbeastSchemaTest` under `src/test/io/qbeast/utils`.

**Test Configuration**:
* Spark Version: 3.2.1
* Hadoop Version: 3.4.x
* Cluster or local? Local