### PR TITLE
Add Google Colab support to the Qbeast notebook demo 

### DIFF
--- a/docs/sample_pushdown_demo.ipynb
+++ b/docs/sample_pushdown_demo.ipynb
@@ -98,7 +98,7 @@
    "outputs": [],
    "source": [
     "!conda install pyspark=3.1.1 -y\n",
-    "#!pip install pyspark==3.1.1 # Google Colab compatibility"
+    "#!pip install pyspark==3.1.1 # Google Colab compatibility. Please comment previous line if you're using pip"
    ]
   },
   {

--- a/docs/sample_pushdown_demo.ipynb
+++ b/docs/sample_pushdown_demo.ipynb
@@ -97,7 +97,8 @@
    },
    "outputs": [],
    "source": [
-    "!conda install pyspark=3.1.1 -y"
+    "!conda install pyspark=3.1.1 -y\n",
+    "#!pip install pyspark==3.1.1 # Google Colab compatibility"
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR adds Google Colab support to the Qbeast notebook demo, by adding the required pip command line.
The notebook is now working on Colab.