### PR TITLE
#228 Implementation of equals/hashCode of CubeId is reworked

### DIFF
--- a/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
@@ -28,6 +28,10 @@ class CubeIdTest extends AnyFlatSpec with Matchers {
     val id7 =
       CubeId(2, "wQwwwQwwQwwQwwwwwQwQwwwQQwwwwQQwQwwwQwwQwwQwwwwwQwwQQQQQQQQQQQQQ")
     id6 == id7 shouldBe true
+    val id8 =
+      CubeId(1, 4, Array(9L)).parent.get.parent.get.parent.get
+    val id9 = CubeId(1, 1, Array(1L))
+    id8 == id9 shouldBe true
   }
 
   it should "implement hashCode correctly" in {

--- a/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
+++ b/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
@@ -1,6 +1,11 @@
 package io.qbeast.core.model
 
-import io.qbeast.core.transform.{HashTransformation, LinearTransformation, Transformation, Transformer}
+import io.qbeast.core.transform.{
+  HashTransformation,
+  LinearTransformation,
+  Transformation,
+  Transformer
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 


### PR DESCRIPTION
## Description

Fix for the #228.

## Type of change

Internal implementation of CubeId is fixed, no changes in API or serialization format have been introduced

## How Has This Been Tested? (Optional)

CubeIdTest is extended to include the scenarios what failed before the fix.