### PR TITLE
#228 Implementation of equals/hashCode of CubeId is fixed

### DIFF
--- a/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
@@ -28,6 +28,10 @@ class CubeIdTest extends AnyFlatSpec with Matchers {
     val id7 =
       CubeId(2, "wQwwwQwwQwwQwwwwwQwQwwwQQwwwwQQwQwwwQwwQwwQwwwwwQwwQQQQQQQQQQQQQ")
     id6 == id7 shouldBe true
+    val id8 =
+      CubeId(1, 4, Array(9L)).parent.get.parent.get.parent.get
+    val id9 = CubeId(1, 1, Array(1L))
+    id8 == id9 shouldBe true
   }
 
   it should "implement hashCode correctly" in {

--- a/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
@@ -157,6 +157,13 @@ class CubeIdTest extends AnyFlatSpec with Matchers {
     id4.nextSibling shouldBe None
   }
 
+  it should "implement children iterator throwing NoSuchElementException after last child" in {
+    val children = CubeId.root(1).children
+    children.next() shouldBe CubeId.root(1).firstChild
+    children.next() shouldBe CubeId.root(1).firstChild.nextSibling.get
+    assertThrows[NoSuchElementException](children.next())
+  }
+
   it should "return a correct container with specified depth" in {
     val point = Point(0.66, 0.83)
     val id = CubeId.container(point, 2)

--- a/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
+++ b/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
@@ -1,6 +1,11 @@
 package io.qbeast.core.model
 
-import io.qbeast.core.transform.{HashTransformation, LinearTransformation, Transformation, Transformer}
+import io.qbeast.core.transform.{
+  HashTransformation,
+  LinearTransformation,
+  Transformation,
+  Transformer
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 


### PR DESCRIPTION
## Description

This PR fixes the implementation of `equals/hashCode` of the class `CubeId` and closes #228.

## Type of change
This is a fix of internal implementation, so neither public API, nor serialization format are affected.

## How Has This Been Tested? (Optional)
The corner cases mentioned in the bug #228 are added to the `CubeIdTest` class.