### PR TITLE
Backport string hist encoding to main

### DIFF
--- a/core/src/main/scala/io/qbeast/core/transform/HashTransformation.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/HashTransformation.scala
@@ -30,4 +30,5 @@ case class HashTransformation(nullValue: Any = Random.nextInt()) extends Transfo
   override def isSupersededBy(newTransformation: Transformation): Boolean = false
 
   override def merge(other: Transformation): Transformation = this
+
 }

--- a/core/src/main/scala/io/qbeast/core/transform/HistogramTransformation.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/HistogramTransformation.scala
@@ -1,0 +1,29 @@
+package io.qbeast.core.transform
+
+import io.qbeast.core.model.QDataType
+
+trait HistogramTransformation extends Transformation {
+
+  /**
+   * QDataType for the associated column.
+   */
+  def dataType: QDataType
+
+  /**
+   * Histogram of the associated column that reflects the distribution of the column values.
+   * @return
+   */
+  def histogram: IndexedSeq[Any]
+
+  /**
+   * Determines whether the associated histogram is the default one
+   * @return
+   */
+  def isDefault: Boolean
+
+  override def transform(value: Any): Double
+
+  override def isSupersededBy(newTransformation: Transformation): Boolean
+
+  override def merge(other: Transformation): Transformation
+}

--- a/core/src/main/scala/io/qbeast/core/transform/HistogramTransformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/HistogramTransformer.scala
@@ -1,0 +1,43 @@
+package io.qbeast.core.transform
+
+import io.qbeast.core.model.{QDataType, StringDataType}
+
+object HistogramTransformer extends TransformerType {
+  override def transformerSimpleName: String = "histogram"
+
+  override def apply(columnName: String, dataType: QDataType): Transformer = dataType match {
+    case StringDataType => StringHistogramTransformer(columnName, dataType)
+    case dt => throw new Exception(s"DataType not supported for HistogramTransformers: $dt")
+  }
+
+  // "a" to "z"
+  def defaultStringHistogram: IndexedSeq[String] = (97 to 122).map(_.toChar.toString)
+}
+
+trait HistogramTransformer extends Transformer {
+
+  override protected def transformerType: TransformerType = HistogramTransformer
+
+  /**
+   * Returns the name of the column
+   *
+   * @return
+   */
+  override def columnName: String
+
+  /**
+   * Returns the stats
+   *
+   * @return
+   */
+  override def stats: ColumnStats
+
+  /**
+   * Returns the Transformation given a row representation of the values
+   *
+   * @param row the values
+   * @return the transformation
+   */
+  override def makeTransformation(row: String => Any): Transformation
+
+}

--- a/core/src/main/scala/io/qbeast/core/transform/LinearTransformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/LinearTransformer.scala
@@ -49,7 +49,7 @@ case class LinearTransformer(columnName: String, dataType: QDataType) extends Tr
     } else if (minAux == maxAux) {
       // If both values are equal we return an IdentityTransformation
       IdentityToZeroTransformation(minAux)
-    } else { // otherwhise we pick the min and max
+    } else { // otherwise we pick the min and max
       val min = getValue(minAux)
       val max = getValue(maxAux)
       dataType match {

--- a/core/src/main/scala/io/qbeast/core/transform/StringHistogramTransformation.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/StringHistogramTransformation.scala
@@ -1,0 +1,130 @@
+package io.qbeast.core.transform
+
+import com.fasterxml.jackson.core.{JsonFactory, JsonGenerator, JsonParser, TreeNode}
+import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.fasterxml.jackson.databind.{DeserializationContext, SerializerProvider}
+import io.qbeast.core.model.{QDataType, StringDataType}
+import io.qbeast.core.transform.HistogramTransformer.defaultStringHistogram
+
+import scala.collection.Searching._
+
+@JsonSerialize(using = classOf[StringHistogramTransformationSerializer])
+@JsonDeserialize(using = classOf[StringHistogramTransformationDeserializer])
+case class StringHistogramTransformation(histogram: IndexedSeq[String])
+    extends HistogramTransformation {
+  require(histogram.length > 1, s"Histogram length has to be > 1: ${histogram.length}")
+
+  override val dataType: QDataType = StringDataType
+
+  override def isDefault: Boolean = histogram == defaultStringHistogram
+
+  /**
+   * Converts a real number to a normalized value.
+   *
+   * @param value a real number to convert
+   * @return a real number between 0 and 1
+   */
+  override def transform(value: Any): Double = {
+    val v: String = value match {
+      case s: String => s
+      case null => "null"
+      case _ => value.toString
+    }
+
+    histogram.search(v) match {
+      case Found(foundIndex) => foundIndex.toDouble / (histogram.length - 1)
+      case InsertionPoint(insertionPoint) =>
+        if (insertionPoint == 0) 0d
+        else if (insertionPoint == histogram.length + 1) 1d
+        else (insertionPoint - 1).toDouble / (histogram.length - 1)
+    }
+  }
+
+  /**
+   * This method should determine if the new data will cause the creation of a new revision.
+   *
+   * @param newTransformation the new transformation created with statistics over the new data
+   * @return true if the domain of the newTransformation is not fully contained in this one.
+   */
+  override def isSupersededBy(newTransformation: Transformation): Boolean =
+    newTransformation match {
+      case nt @ StringHistogramTransformation(hist) =>
+        if (isDefault) !nt.isDefault
+        else if (nt.isDefault) false
+        else !(histogram == hist)
+      case _ => false
+    }
+
+  /**
+   * Merges two transformations. The domain of the resulting transformation is the union of this
+   *
+   * @param other Transformation
+   * @return a new Transformation that contains both this and other.
+   */
+  override def merge(other: Transformation): Transformation = other match {
+    case _: StringHistogramTransformation => other
+    case _ => this
+  }
+
+}
+
+class StringHistogramTransformationSerializer
+    extends StdSerializer[StringHistogramTransformation](classOf[StringHistogramTransformation]) {
+  val jsonFactory = new JsonFactory()
+
+  override def serializeWithType(
+      value: StringHistogramTransformation,
+      gen: JsonGenerator,
+      serializers: SerializerProvider,
+      typeSer: TypeSerializer): Unit = {
+    gen.writeStartObject()
+    typeSer.getPropertyName
+    gen.writeStringField(typeSer.getPropertyName, typeSer.getTypeIdResolver.idFromValue(value))
+
+    gen.writeFieldName("histogram")
+    gen.writeStartArray()
+    value.histogram.foreach(gen.writeString)
+    gen.writeEndArray()
+
+    gen.writeEndObject()
+  }
+
+  override def serialize(
+      value: StringHistogramTransformation,
+      gen: JsonGenerator,
+      provider: SerializerProvider): Unit = {
+    gen.writeStartObject()
+
+    gen.writeFieldName("histogram")
+    gen.writeStartArray()
+    value.histogram.foreach(gen.writeString)
+    gen.writeEndArray()
+
+    gen.writeEndObject()
+  }
+
+}
+
+class StringHistogramTransformationDeserializer
+    extends StdDeserializer[StringHistogramTransformation](
+      classOf[StringHistogramTransformation]) {
+
+  override def deserialize(
+      p: JsonParser,
+      ctxt: DeserializationContext): StringHistogramTransformation = {
+    val histogramBuilder = IndexedSeq.newBuilder[String]
+
+    val tree: TreeNode = p.getCodec.readTree(p)
+    tree.get("histogram") match {
+      case an: ArrayNode =>
+        (0 until an.size()).foreach(i => histogramBuilder += an.get(i).asText())
+    }
+
+    StringHistogramTransformation(histogramBuilder.result())
+  }
+
+}

--- a/core/src/main/scala/io/qbeast/core/transform/StringHistogramTransformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/StringHistogramTransformer.scala
@@ -1,0 +1,37 @@
+package io.qbeast.core.transform
+
+import io.qbeast.core.model.QDataType
+import io.qbeast.core.transform.HistogramTransformer.defaultStringHistogram
+
+case class StringHistogramTransformer(columnName: String, dataType: QDataType)
+    extends HistogramTransformer {
+  private val columnHistogram = s"${columnName}_histogram"
+
+  /**
+   * Returns the stats
+   *
+   * @return
+   */
+  override def stats: ColumnStats = {
+    val defaultHistString = defaultStringHistogram.mkString("Array('", "', '", "')")
+    ColumnStats(
+      statsNames = columnHistogram :: Nil,
+      statsSqlPredicates = s"$defaultHistString AS $columnHistogram" :: Nil)
+  }
+
+  /**
+   * Returns the Transformation given a row representation of the values
+   *
+   * @param row the values
+   * @return the transformation
+   */
+  override def makeTransformation(row: String => Any): Transformation = {
+    val hist = row(columnHistogram) match {
+      case h: Seq[_] => h.map(_.toString).toIndexedSeq
+      case _ => defaultStringHistogram
+    }
+
+    StringHistogramTransformation(hist)
+  }
+
+}

--- a/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
+++ b/core/src/main/scala/io/qbeast/core/transform/Transformer.scala
@@ -14,7 +14,9 @@ import java.util.Locale
 object Transformer {
 
   private val transformersRegistry: Map[String, TransformerType] =
-    Seq(LinearTransformer, HashTransformer).map(a => (a.transformerSimpleName, a)).toMap
+    Seq(LinearTransformer, HashTransformer, HistogramTransformer)
+      .map(a => (a.transformerSimpleName, a))
+      .toMap
 
   /**
    * Returns the transformer for the given column and type of transformer

--- a/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/CubeIdTest.scala
@@ -28,6 +28,10 @@ class CubeIdTest extends AnyFlatSpec with Matchers {
     val id7 =
       CubeId(2, "wQwwwQwwQwwQwwwwwQwQwwwQQwwwwQQwQwwwQwwQwwQwwwwwQwwQQQQQQQQQQQQQ")
     id6 == id7 shouldBe true
+    val id8 =
+      CubeId(1, 4, Array(9L)).parent.get.parent.get.parent.get
+    val id9 = CubeId(1, 1, Array(1L))
+    id8 == id9 shouldBe true
   }
 
   it should "implement hashCode correctly" in {
@@ -151,6 +155,13 @@ class CubeIdTest extends AnyFlatSpec with Matchers {
     id2.nextSibling shouldBe Some(id3)
     id3.nextSibling shouldBe Some(id4)
     id4.nextSibling shouldBe None
+  }
+
+  it should "implement children iterator throwing NoSuchElementException after last child" in {
+    val children = CubeId.root(1).children
+    children.next() shouldBe CubeId.root(1).firstChild
+    children.next() shouldBe CubeId.root(1).firstChild.nextSibling.get
+    assertThrows[NoSuchElementException](children.next())
   }
 
   it should "return a correct container with specified depth" in {

--- a/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
+++ b/core/src/test/scala/io/qbeast/core/model/JSONSerializationTests.scala
@@ -1,6 +1,11 @@
 package io.qbeast.core.model
 
-import io.qbeast.core.transform.{HashTransformation, LinearTransformation, Transformation, Transformer}
+import io.qbeast.core.transform.{
+  HashTransformation,
+  LinearTransformation,
+  Transformation,
+  Transformer
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/core/src/test/scala/io/qbeast/core/transform/EmptyTransformationTest.scala
+++ b/core/src/test/scala/io/qbeast/core/transform/EmptyTransformationTest.scala
@@ -1,6 +1,7 @@
 package io.qbeast.core.transform
 
 import io.qbeast.core.model.DoubleDataType
+import io.qbeast.core.transform.HistogramTransformer.defaultStringHistogram
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -19,17 +20,21 @@ class EmptyTransformationTest extends AnyFlatSpec with Matchers {
     val et = EmptyTransformation()
     val ht = HashTransformation()
     val lt = LinearTransformation(1d, 1.1, DoubleDataType)
+    val sht = StringHistogramTransformation(defaultStringHistogram)
 
     et.isSupersededBy(ht) shouldBe true
     et.isSupersededBy(lt) shouldBe true
+    et.isSupersededBy(sht) shouldBe true
   }
 
   it should "return the other Transformation when merging" in {
     val et = EmptyTransformation()
     val ht = HashTransformation()
     val lt = LinearTransformation(1d, 1.1, DoubleDataType)
+    val sht = StringHistogramTransformation(defaultStringHistogram)
 
     et.merge(ht) shouldBe ht
     et.merge(lt) shouldBe lt
+    et.merge(sht) shouldBe sht
   }
 }

--- a/core/src/test/scala/io/qbeast/core/transform/StringHistogramTransformationTest.scala
+++ b/core/src/test/scala/io/qbeast/core/transform/StringHistogramTransformationTest.scala
@@ -1,0 +1,77 @@
+package io.qbeast.core.transform
+
+import io.qbeast.core.transform.HistogramTransformer.defaultStringHistogram
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Random
+
+class StringHistogramTransformationTest extends AnyFlatSpec with Matchers {
+
+  "A StringHistogramTransformation" should "map values to [0d, 1d]" in {
+    val attempts = 10
+    val sht = StringHistogramTransformation(defaultStringHistogram)
+    val minAsciiEnc = 32 // SPACE
+    val maxAsciiEnc = 126 // ~
+    (1 to attempts).foreach { _ =>
+      val inputStr = (1 to 5)
+        .map { _ =>
+          val asciiEnc = minAsciiEnc + Random.nextInt(maxAsciiEnc - minAsciiEnc)
+          asciiEnc.toChar.toString
+        }
+        .mkString("")
+      val v = sht.transform(inputStr)
+
+      v should be <= 1d
+      v should be >= 0d
+    }
+  }
+
+  it should "properly handle null" in {
+    val sht = StringHistogramTransformation(defaultStringHistogram)
+    val v = sht.transform(null)
+    v should be <= 1d
+    v should be >= 0d
+  }
+
+  it should "map existing values correctly" in {
+    val hist = Array(0.0, 0.25, 0.5, 0.75, 1.0).map(_.toString)
+    val sht = StringHistogramTransformation(hist)
+    hist.foreach(s => sht.transform(s) shouldBe s.toDouble)
+  }
+
+  it should "map non-existing values correctly" in {
+    val hist = Array(0.0, 0.25, 0.5, 0.75, 1.0).map(_.toString)
+    val sht = StringHistogramTransformation(hist)
+    sht.transform((hist.head.toDouble - 1).toString) shouldBe 0d
+    sht.transform((hist.last.toDouble + 1).toString) shouldBe 1d
+
+    hist.foreach { s =>
+      val v = (s.toDouble + 0.1).toString
+      sht.transform(v) shouldBe s.toDouble
+    }
+  }
+
+  it should "supersede correctly" in {
+    val defaultT = StringHistogramTransformation(defaultStringHistogram)
+    val customT_1 =
+      StringHistogramTransformation(Array("brand_A", "brand_B", "brand_C"))
+    val customT_2 =
+      StringHistogramTransformation(Array("brand_A", "brand_B", "brand_D"))
+
+    defaultT.isSupersededBy(customT_1) shouldBe true
+    defaultT.isSupersededBy(defaultT) shouldBe false
+
+    customT_1.isSupersededBy(defaultT) shouldBe false
+    customT_1.isSupersededBy(customT_1) shouldBe false
+    customT_1.isSupersededBy(customT_2) shouldBe true
+  }
+
+  it should "have histograms with length > 1" in {
+    an[IllegalArgumentException] should be thrownBy
+      StringHistogramTransformation(Array.empty[String])
+
+    an[IllegalArgumentException] should be thrownBy
+      StringHistogramTransformation(Array("a"))
+  }
+}

--- a/core/src/test/scala/io/qbeast/core/transform/TransformerTest.scala
+++ b/core/src/test/scala/io/qbeast/core/transform/TransformerTest.scala
@@ -23,6 +23,9 @@ class TransformerTest extends AnyFlatSpec with Matchers {
     Transformer(columnName, dataType).spec shouldBe "a:linear"
     Transformer("linear", columnName, dataType).spec shouldBe "a:linear"
     Transformer("hashing", columnName, dataType).spec shouldBe "a:hashing"
+
+    an[Exception] should be thrownBy Transformer("histogram", columnName, dataType).spec
+
     an[NoSuchElementException] should be thrownBy Transformer(
       "another",
       columnName,
@@ -75,6 +78,22 @@ class TransformerTest extends AnyFlatSpec with Matchers {
     resTransformation.minNumber shouldBe minTimestamp.getTime
     resTransformation.maxNumber shouldBe maxTimestamp.getTime
     resTransformation.orderedDataType shouldBe DateDataType
+
+  }
+
+  it should "makeTransformation with String histograms" in {
+    val columnName = "s"
+    val dataType = StringDataType
+    val transformer = Transformer("histogram", columnName, dataType)
+    transformer shouldBe a[StringHistogramTransformer]
+
+    val hist = Seq("str_1", "str_2", "str_3", "str_4", "str_5", "str_6")
+    val transformation = Map(s"${columnName}_histogram" -> hist)
+    transformer.makeTransformation(transformation) match {
+      case _ @StringHistogramTransformation(histogram) =>
+        histogram == hist shouldBe true
+      case _ => fail("should always be StringHistogramTransformation")
+    }
 
   }
 

--- a/docs/AdvancedConfiguration.md
+++ b/docs/AdvancedConfiguration.md
@@ -115,6 +115,58 @@ val columnStats =
      |"date_max":"${formatter.format(maxTimestamp)}" }""".stripMargin
 ```
 
+## String indexing via Histograms
+
+The default **String** column transformation (`HashTransformation`) has limited range query supports since the lexicographic ordering of the String values are not preserved.
+
+This can be addressed by introducing a custom **String** histogram in the form of sorted `Seq[String]`, and can lead to several improvements including:
+1. more efficient file-pruning because of its reduced file-level column min/max
+2. support for range queries on String columns
+3. improved overall query speed
+
+The following code snippet demonstrates the extraction of a **String** histogram from the source data:
+```scala
+ import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions
+ import org.apache.spark.sql.DataFrame
+ import org.apache.spark.sql.functions.{col, min}
+
+ def getStringHistogramStr(columnName: String, numBins: Int, df: DataFrame): String = {
+   val binStarts = "__bin_starts"
+   val stringPartitionColumn =
+     MultiDimClusteringFunctions.range_partition_id(col(columnName), numBins)
+   df
+     .select(columnName)
+     .distinct()
+     .na.drop()
+     .groupBy(stringPartitionColumn)
+     .agg(min(columnName).alias(binStarts))
+     .select(binStarts)
+     .orderBy(binStarts)
+     .collect()
+     .map { r =>
+       val s = r.getAs[String](0)
+       s"'$s'"
+     }
+     .mkString("[", ",", "]")
+ }
+
+val brandStats = getStringHistogramStr("brand", 50, df)
+val statsStr = s"""{"brand_histogram":$brandStats}"""
+
+(df
+  .write
+  .mode("overwrite")
+  .format("qbeast")
+  .option("columnsToIndex", "brand:histogram")
+  .option("columnStats", statsStr)
+  .save(targetPath))
+```
+This is only necessary for the first write, if not otherwise made explicit, all subsequent appends will reuse the same histogram.
+Any new custom histogram provided during `appends` forces the creation of a new `Revision`.
+
+A default **String** histogram("a" t0 "z") will be used if the use of histogram is stated(`stringColName:string_hist`) with no histogram in `columnStats`.
+The default histogram can not supersede an existing `StringHashTransformation`.
+
 ## DefaultCubeSize
 
 If you don't specify the cubeSize at DataFrame level, the default value is used. This is set to 5M, so if you want to change it

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -9,6 +9,7 @@ import io.qbeast.core.transform.Transformer
 import io.qbeast.spark.index.QbeastColumns.{cubeToReplicateColumnName, weightColumnName}
 import io.qbeast.spark.internal.QbeastFunctions.qbeastHash
 import org.apache.spark.qbeast.config.CUBE_WEIGHTS_BUFFER_CAPACITY
+
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 
@@ -246,7 +247,7 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable {
     }
 
     val spaceChanges =
-      if (isReplication) None
+      if (isReplication) None // IF is replication
       else calculateRevisionChanges(dataFrameStats, indexStatus.revision)
 
     // The revision to use

--- a/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
@@ -153,6 +153,40 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
 
   })
 
+  it should "createNewRevision with columnStats " +
+    "even on APPEND mode" in withSparkAndTmpDir((spark, tmpDir) => {
+      import spark.implicits._
+      val df = 0.to(10).map(i => T3(i, i * 2.0, s"$i", i * 1.2f)).toDF()
+      val columnStats = """{ "a_min": 0, "a_max": 20 }"""
+
+      // On append mode, it already expects a RevisionChange,
+      // but in this case the change is defined by the user
+      // instead of triggered by the data
+
+      // TODO: very special case
+      // TODO: a cleaner solution would be to change the API for IndexManager
+      //  and allow to send a set of options
+      //  with user-specific configurations to Index
+
+      df.write
+        .mode("append")
+        .format("qbeast")
+        .option("columnsToIndex", "a")
+        .option("columnStats", columnStats)
+        .save(tmpDir)
+
+      val qbeastSnapshot =
+        DeltaQbeastSnapshot(DeltaLog.forTable(spark, tmpDir).update())
+      val latestRevision = qbeastSnapshot.loadLatestRevision
+      val transformation = latestRevision.transformations.head
+
+      transformation should not be null
+      transformation shouldBe a[LinearTransformation]
+      transformation.asInstanceOf[LinearTransformation].minNumber shouldBe 0
+      transformation.asInstanceOf[LinearTransformation].maxNumber shouldBe 20
+
+    })
+
   it should "createNewRevision with min max timestamp" in withSpark(spark => {
     import spark.implicits._
     val data = Seq(

--- a/src/test/scala/io/qbeast/spark/index/TransformerIndexingTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/TransformerIndexingTest.scala
@@ -2,14 +2,85 @@ package io.qbeast.spark.index
 
 import io.qbeast.TestClasses._
 import io.qbeast.spark.QbeastIntegrationTestSpec
-import org.apache.spark.sql.functions.{to_date, to_timestamp}
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.functions.{
+  to_date,
+  to_timestamp,
+  col,
+  min,
+  substring,
+  abs,
+  sum,
+  ascii
+}
+import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions
+import org.apache.spark.sql.{Dataset, DataFrame, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.delta.DeltaLog
 
 import scala.util.Random
 
 class TransformerIndexingTest extends AnyFlatSpec with Matchers with QbeastIntegrationTestSpec {
+
+  /**
+   * Compute String column histogram.
+   * @param columnName String column name
+   * @param numBins number of bins for the histogram
+   * @param df DataFrame
+   * @return Sorted String histogram as a String
+   */
+  def getStringHistogramStr(columnName: String, numBins: Int, df: DataFrame): String = {
+    val binStarts = "__bin_starts"
+    val stringPartitionColumn =
+      MultiDimClusteringFunctions.range_partition_id(col(columnName), numBins)
+
+    df
+      .select(columnName)
+      .distinct()
+      .groupBy(stringPartitionColumn)
+      .agg(min(columnName).alias(binStarts))
+      .select(binStarts)
+      .orderBy(binStarts)
+      .collect()
+      .map(r => s"'${r.getAs[String](0)}'")
+      .mkString("[", ",", "]")
+  }
+
+  /**
+   * Compute weighted encoding distance for files:
+   * (ascii(string_col_max.head) - ascii(string_col_min.head)) * numRecords
+   */
+  def computeColumnEncodingDist(
+      spark: SparkSession,
+      tablePath: String,
+      columnName: String): Long = {
+    import spark.implicits._
+
+    val dl = DeltaLog.forTable(spark, tablePath)
+    val js = dl
+      .update()
+      .allFiles
+      .select("stats")
+      .collect()
+      .map(r => r.getAs[String](0))
+      .mkString("[", ",", "]")
+    val stats = spark.read.json(Seq(js).toDS())
+
+    stats
+      .select(
+        col(s"maxValues.$columnName").alias("__max"),
+        col(s"minValues.$columnName").alias("__min"),
+        col("numRecords"))
+      .withColumn("__max_start", substring(col("__max"), 0, 1))
+      .withColumn("__min_start", substring(col("__min"), 0, 1))
+      .withColumn("__max_ascii", ascii(col("__max_start")))
+      .withColumn("__min_ascii", ascii(col("__min_start")))
+      .withColumn("dist", abs(col("__max_ascii") - col("__min_ascii")) * col("numRecords"))
+      .select("dist")
+      .agg(sum("dist"))
+      .first()
+      .getAs[Long](0)
+  }
 
   // Write source data indexing all columns and read it back
   private def writeAndReadDF(source: Dataset[_], tmpDir: String, spark: SparkSession) = {
@@ -349,5 +420,36 @@ class TransformerIndexingTest extends AnyFlatSpec with Matchers with QbeastInteg
         indexed.where(filter).count() shouldBe source.where(filter).count()
       })
 
+    })
+
+  it should "create better file-level min-max with a String histogram" in withSparkAndTmpDir(
+    (spark, tmpDir) => {
+      val histPath = tmpDir + "/string_hist/"
+      val hashPath = tmpDir + "/string_hash/"
+      val colName = "brand"
+
+      val df = loadTestData(spark)
+
+      val colHistStr = getStringHistogramStr(colName, 50, df)
+      val statsStr = s"""{"${colName}_histogram":$colHistStr}"""
+
+      df.write
+        .mode("overwrite")
+        .format("qbeast")
+        .option("cubeSize", "30000")
+        .option("columnsToIndex", s"$colName:histogram")
+        .option("columnStats", statsStr)
+        .save(histPath)
+      val histDist = computeColumnEncodingDist(spark, histPath, colName)
+
+      df.write
+        .mode("overwrite")
+        .format("qbeast")
+        .option("columnsToIndex", colName)
+        .option("cubeSize", "30000")
+        .save(hashPath)
+      val hashDist = computeColumnEncodingDist(spark, hashPath, colName)
+
+      histDist should be < hashDist
     })
 }


### PR DESCRIPTION
## Description
This PR introduces a new **String** `Transformation` that uses String histograms for value mapping.

(Backport the feature from `main-1.0.0`)

### How does it work?
A sorted sequence of distinct string values should be provided to map String values to the space.

The sequence is treated as an equal-width histogram for the column to index.

To transforma a given **String** value, we look for its **insertion position** within the sequence using binary search:
```scala
val hist = ["a", "b", "c", "d", "e"]
val coordinate = hist.search("b").insertionPoint.toDouble / (hist.length - 1) // 0.25
```

Values that are not contained within the limits of the histogram are mapped to their corresponding extremes, i.e. `0.0` or `1.0`. 

### How to use?
To use the feature, we build the histogram and provide it as part of `columnStats` when writing.

`:histogram` should also be specified for the String column to index.

1. Compute the histogram:
- Use all distinct String values:
```scala
import org.apache.spark.sql.DataFrame
import org.apache.spark.sql.functions.col

def getAllString(df: DataFrame, columnName: String): String = {	
  df
  .select(columnName)
  .distinct()
  .na.drop
  .orderBy(col(columnName).asc)
  .collect()
  .map { r => 
    val s = r.getAs[String](0)
    s"'$s'"
  }
  .mkString("[", ",", "]")
}

val histogram = getAllString(df, "test_col_name")
```

- Use a reduced number of String values:
```scala
import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions
import org.apache.spark.sql.DataFrame
import org.apache.spark.sql.functions.{col, min}

def getStringHistogramStr(df: DataFrame, columnName: String, numBins: Int): String = {
  val binStarts = "__bin_starts"
  val stringPartitionColumn = MultiDimClusteringFunctions.range_partition_id(col(columnName), numBins)
	
  df
  .select(columnName)
  .distinct()
  .na.drop
  .groupBy(stringPartitionColumn)
  .agg(min(columnName).alias(binStarts))
  .select(binStarts)
  .orderBy(binStarts)
  .collect()
  .map { r => 
    val s = r.getAs[String](0)
    s"'$s'"
  }
  .mkString("[", ",", "]")
}

val histogram = getStringHistogramStr(df, "test_col_name", 100)
```

2. Index the data as follows:
```scala
val columnStats = s"""{"test_col_name_histogram":$histogram}"""

df
  .write
  .format("qbeast")
  .option("columnsToIndex", s"test_col_name:histogram")
  .option("columnStats", columnStats)
  .save(targetPath)
```

If no histogram is provided in `columnStats` during the first write, a default histogram("a" to "z") will be used. Subsequent `appends` will reuse the same histogram.

A new revision will be created when a different custom histogram is provided as "columnStats".

Note: It also fixes the bug where the first write has to have `overwrite` write mode.

## Checklist:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Branch is updated to the main branch.
