### PR TITLE
243 investigate streaming options

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
+++ b/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
@@ -8,8 +8,10 @@ import io.qbeast.IISeq
  *   type of data schema
  * @tparam FileDescriptor
  *   type of file descriptor
+ * @tparam QbeastOptions
+ *   type of the Qbeast options
  */
-trait MetadataManager[DataSchema, FileDescriptor] {
+trait MetadataManager[DataSchema, FileDescriptor, QbeastOptions] {
   type Configuration = Map[String, String]
 
   /**
@@ -36,13 +38,16 @@ trait MetadataManager[DataSchema, FileDescriptor] {
    *   the QTableID
    * @param schema
    *   the schema of the data
+   * @param options
+   *   the update options
    * @param append
    *   the append flag
-   * @param writer
-   *   the writer code to be executed
    */
-  def updateWithTransaction(tableID: QTableID, schema: DataSchema, append: Boolean)(
-      writer: => (TableChanges, IISeq[FileDescriptor])): Unit
+  def updateWithTransaction(
+      tableID: QTableID,
+      schema: DataSchema,
+      options: QbeastOptions,
+      append: Boolean)(writer: => (TableChanges, IISeq[FileDescriptor])): Unit
 
   /**
    * Updates the table metadata by overwriting the metadata configurations with the provided

--- a/core/src/main/scala/io/qbeast/core/model/QbeastCoreContext.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastCoreContext.scala
@@ -10,15 +10,17 @@ import scala.reflect.ClassTag
  *   type of the data
  * @tparam DataSchema
  *   type of the data schema
+ * @tparam QbeastOptions
+ *   type of the Qbeast options
  * @tparam FileDescriptor
  *   type of the file descriptor
  */
-trait QbeastCoreContext[DATA, DataSchema, FileDescriptor] {
-  def metadataManager: MetadataManager[DataSchema, FileDescriptor]
+trait QbeastCoreContext[DATA, DataSchema, QbeastOptions, FileDescriptor] {
+  def metadataManager: MetadataManager[DataSchema, FileDescriptor, QbeastOptions]
   def dataWriter: DataWriter[DATA, DataSchema, FileDescriptor]
   def indexManager: IndexManager[DATA]
   def queryManager[QUERY: ClassTag]: QueryManager[QUERY, DATA]
-  def revisionBuilder: RevisionFactory[DataSchema]
+  def revisionBuilder: RevisionFactory[DataSchema, QbeastOptions]
   def keeper: Keeper
 
 }
@@ -28,8 +30,10 @@ trait QbeastCoreContext[DATA, DataSchema, FileDescriptor] {
  *
  * @tparam DataSchema
  *   type of the data schema
+ * @tparam QbeastOptions
+ *   type of the Qbeast options
  */
-trait RevisionFactory[DataSchema] {
+trait RevisionFactory[DataSchema, QbeastOptions] {
 
   /**
    * Create a new revision for a table with given parameters
@@ -42,10 +46,7 @@ trait RevisionFactory[DataSchema] {
    *   the options
    * @return
    */
-  def createNewRevision(
-      qtableID: QTableID,
-      schema: DataSchema,
-      options: Map[String, String]): Revision
+  def createNewRevision(qtableID: QTableID, schema: DataSchema, options: QbeastOptions): Revision
 
   /**
    * Create a new revision with given parameters from an old revision
@@ -62,7 +63,7 @@ trait RevisionFactory[DataSchema] {
   def createNextRevision(
       qtableID: QTableID,
       schema: DataSchema,
-      options: Map[String, String],
+      options: QbeastOptions,
       oldRevision: RevisionID): Revision
 
 }

--- a/docs/AdvancedConfiguration.md
+++ b/docs/AdvancedConfiguration.md
@@ -100,6 +100,42 @@ In a `JSON` string, you can pass the **minimum and maximum values of the columns
 }
 ```
 
+## TxnAppId and TxnVersion
+
+These options are used to make the writes idempotent.
+
+The option `txnAppId` identifies an application writing data to the table. It is
+the responsibility of the user to assign unique identifiers to the applications
+writing data to the table.
+
+The option `txnVersion` identifies the transaction issued by the application.
+The value of this option must be a valid string representation of a positive
+long number.
+
+```scala
+df.write.format("qbeast")
+.option("columnsToIndex", "a")
+.option("txnAppId", "ingestionService")
+.option("txnVersion", "1")
+```
+
+If the table already contains the data written by some other transaction with
+the same `txnAppId` and `txnVersion` then the requested write will be ignored.
+
+```scala
+// The data is written
+df.write.format("qbeast")
+.option("columnsToIndex", "a")
+.option("txnAppId", "ingestionService")
+.option("txnVersion", "1")
+...
+// The data is ignored
+df.write.format("qbeast")
+.mode("append")
+.option("txnAppId", "ingestionService")
+.option("txnVersion", "1")
+```
+
 ## Indexing Timestamps with ColumnStats
 
 For indexing `Timestamps` or `Dates` with `columnStats` (min and maximum ranges), notice that **the values need to be formatted in a proper way** (following `"yyyy-MM-dd HH:mm:ss.SSSSSS'Z'"` pattern) for Qbeast to be able to parse it. 

--- a/src/main/scala/io/qbeast/context/QbeastContext.scala
+++ b/src/main/scala/io/qbeast/context/QbeastContext.scala
@@ -10,6 +10,7 @@ import io.qbeast.spark.delta.writer.RollupDataWriter
 import io.qbeast.spark.delta.SparkDeltaMetadataManager
 import io.qbeast.spark.index.SparkOTreeManager
 import io.qbeast.spark.index.SparkRevisionFactory
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.table.IndexedTableFactory
 import io.qbeast.spark.table.IndexedTableFactoryImpl
 import org.apache.spark.scheduler.SparkListener
@@ -63,7 +64,7 @@ trait QbeastContext {
  */
 object QbeastContext
     extends QbeastContext
-    with QbeastCoreContext[DataFrame, StructType, FileAction] {
+    with QbeastCoreContext[DataFrame, StructType, QbeastOptions, FileAction] {
   private var managedOption: Option[QbeastContext] = None
   private var unmanagedOption: Option[QbeastContext] = None
 
@@ -82,13 +83,13 @@ object QbeastContext
 
   override def indexManager: IndexManager[DataFrame] = SparkOTreeManager
 
-  override def metadataManager: MetadataManager[StructType, FileAction] =
+  override def metadataManager: MetadataManager[StructType, FileAction, QbeastOptions] =
     SparkDeltaMetadataManager
 
   override def dataWriter: DataWriter[DataFrame, StructType, FileAction] =
     RollupDataWriter
 
-  override def revisionBuilder: RevisionFactory[StructType] =
+  override def revisionBuilder: RevisionFactory[StructType, QbeastOptions] =
     SparkRevisionFactory
 
   /**

--- a/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -76,6 +76,13 @@ private[delta] case class DeltaMetadataWriter(
   }
 
   def writeWithTransaction(writer: => (TableChanges, Seq[FileAction])): Unit = {
+    val oldTransactions = deltaLog.unsafeVolatileSnapshot.setTransactions
+    // If the transaction was completed before then no operation
+    for (txn <- oldTransactions; version <- options.txnVersion; appId <- options.txnAppId) {
+      if (txn.appId == appId && txn.version == version) {
+        return
+      }
+    }
     deltaLog.withNewTransaction { txn =>
       // Register metrics to use in the Commit Info
       val statsTrackers = createStatsTrackers(txn)
@@ -83,9 +90,13 @@ private[delta] case class DeltaMetadataWriter(
       // Execute write
       val (changes, newFiles) = writer
       // Update Qbeast Metadata (replicated set, revision..)
-      val finalActions = updateMetadata(txn, changes, newFiles)
+      var actions = updateMetadata(txn, changes, newFiles)
+      // Set transaction identifier if specified
+      for (txnVersion <- options.txnVersion; txnAppId <- options.txnAppId) {
+        actions +:= SetTransaction(txnAppId, txnVersion, Some(System.currentTimeMillis()))
+      }
       // Commit the information to the DeltaLog
-      txn.commit(finalActions, deltaOperation)
+      txn.commit(actions, deltaOperation)
     }
   }
 

--- a/src/main/scala/io/qbeast/spark/delta/StagingDataManager.scala
+++ b/src/main/scala/io/qbeast/spark/delta/StagingDataManager.scala
@@ -6,11 +6,13 @@ package io.qbeast.spark.delta
 import io.qbeast.core.model.IndexStatus
 import io.qbeast.core.model.QTableID
 import io.qbeast.spark.internal.commands.ConvertToQbeastCommand
+import io.qbeast.spark.internal.QbeastOptions
 import org.apache.hadoop.fs.Path
 import org.apache.spark.qbeast.config.STAGING_SIZE_IN_BYTES
 import org.apache.spark.sql.delta.actions.FileAction
 import org.apache.spark.sql.delta.actions.RemoveFile
 import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaOptions
 import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
@@ -83,13 +85,31 @@ private[spark] class StagingDataManager(tableID: QTableID) extends DeltaStagingU
   /**
    * Stage the data without indexing by writing it in the delta format. If the table is not yet a
    * qbeast table, use ConvertToQbeastCommand for conversion after the write.
+   *
+   * @param data
+   *   the data to stage
+   * @param indexStatus
+   *   the index status
+   * @param options
+   *   the options
+   * @param append
+   *   the operation appends data
    */
-  def stageData(data: DataFrame, indexStatus: IndexStatus, append: Boolean): Unit = {
+  def stageData(
+      data: DataFrame,
+      indexStatus: IndexStatus,
+      options: QbeastOptions,
+      append: Boolean): Unit = {
     // Write data to the staging area in the delta format
-    data.write
+    var writer = data.write
       .format("delta")
       .mode(if (append) SaveMode.Append else SaveMode.Overwrite)
-      .save(tableID.id)
+    for (txnVersion <- options.txnVersion; txnAppId <- options.txnAppId) {
+      writer = writer
+        .option(DeltaOptions.TXN_VERSION, txnVersion)
+        .option(DeltaOptions.TXN_APP_ID, txnAppId)
+    }
+    writer.save(tableID.id)
 
     // Convert if the table is not yet qbeast
     if (isInitial) {

--- a/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
@@ -6,6 +6,7 @@ package io.qbeast.spark.delta
 import io.qbeast.core.model.CubeStatus
 import io.qbeast.core.model.QTableID
 import io.qbeast.spark.index.SparkRevisionFactory
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.TestClasses.Client3
 import org.apache.spark.sql.delta.DeltaLog
@@ -67,7 +68,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
         val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
         val columnTransformers = SparkRevisionFactory
-          .createNewRevision(QTableID(tmpDir), df.schema, options)
+          .createNewRevision(QTableID(tmpDir), df.schema, QbeastOptions(options))
           .columnTransformers
 
         val revision = qbeastSnapshot.loadLatestRevision

--- a/src/test/scala/io/qbeast/spark/delta/writer/RollupDataWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/RollupDataWriterTest.scala
@@ -4,6 +4,7 @@ import io.qbeast.core.model.IndexStatus
 import io.qbeast.core.model.QTableID
 import io.qbeast.spark.index.SparkOTreeManager
 import io.qbeast.spark.index.SparkRevisionFactory
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.TestClasses._
 
@@ -23,8 +24,9 @@ class RollupDataWriterTest extends QbeastIntegrationTestSpec {
       val tableID = QTableID(tmpDir)
       val parameters: Map[String, String] =
         Map("columnsToIndex" -> "age,val2", "cubeSize" -> cubeSize.toString)
-      val indexStatus =
-        IndexStatus(SparkRevisionFactory.createNewRevision(tableID, df.schema, parameters))
+      val revision =
+        SparkRevisionFactory.createNewRevision(tableID, df.schema, QbeastOptions(parameters))
+      val indexStatus = IndexStatus(revision)
       val (qbeastData, tableChanges) = SparkOTreeManager.index(df, indexStatus)
 
       val fileActions = RollupDataWriter.write(tableID, df.schema, qbeastData, tableChanges)

--- a/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
@@ -5,6 +5,7 @@ import io.qbeast.spark.index.NormalizedWeight
 import io.qbeast.spark.index.QbeastColumns
 import io.qbeast.spark.index.QbeastColumns._
 import io.qbeast.spark.index.SparkRevisionFactory
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.TestClasses.IndexData
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.rdd.RDD
@@ -63,7 +64,7 @@ case class WriteTestSpec(numDistinctCubes: Int, spark: SparkSession, tmpDir: Str
     .createNewRevision(
       QTableID("test"),
       data.schema,
-      Map("columnsToIndex" -> "id", "cubeSize" -> "10000"))
+      QbeastOptions(Map("columnsToIndex" -> "id", "cubeSize" -> "10000")))
 
   val cubeStatuses: SortedMap[CubeId, CubeStatus] = {
     val cubeStatusesSeq = weightMap.toIndexedSeq.map {

--- a/src/test/scala/io/qbeast/spark/index/CubeDomainsIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/CubeDomainsIntegrationTest.scala
@@ -6,6 +6,7 @@ import io.qbeast.core.model.IndexStatus
 import io.qbeast.core.model.QTableID
 import io.qbeast.core.model.Weight
 import io.qbeast.spark.delta
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.TestClasses.Client3
 import org.apache.spark.qbeast.config.CUBE_WEIGHTS_BUFFER_CAPACITY
@@ -38,7 +39,8 @@ class CubeDomainsIntegrationTest extends QbeastIntegrationTestSpec with PrivateM
               .createNewRevision(
                 QTableID("test"),
                 df.schema,
-                Map("columnsToIndex" -> names.mkString(","), "cubeSize" -> "10000")))
+                QbeastOptions(
+                  Map("columnsToIndex" -> names.mkString(","), "cubeSize" -> "10000"))))
           val (_, tc) = oTreeAlgorithm.index(df.toDF(), indexStatus)
           df.write
             .format("qbeast")

--- a/src/test/scala/io/qbeast/spark/index/IndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/IndexTest.scala
@@ -6,6 +6,7 @@ package io.qbeast.spark.index
 import io.qbeast.core.model._
 import io.qbeast.core.model.BroadcastedTableChanges
 import io.qbeast.spark.delta
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.TestClasses.Client3
 import io.qbeast.TestClasses.Client4
@@ -26,6 +27,7 @@ class IndexTest
 
   // TEST CONFIGURATIONS
   private val options = Map("columnsToIndex" -> "age,val2", "cubeSize" -> "10000")
+  private val qbeastOptions = QbeastOptions(options)
 
   private def createDF(): DataFrame = {
     val spark = SparkSession.active
@@ -44,7 +46,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (indexed, _) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -57,7 +60,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (_, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -70,7 +74,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (_, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -83,7 +88,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (indexed, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -107,7 +113,7 @@ class IndexTest
         val rev = SparkRevisionFactory.createNewRevision(
           QTableID("test"),
           df.schema,
-          Map("columnsToIndex" -> "user_id,product_id", "cubeSize" -> "10000"))
+          QbeastOptions(Map("columnsToIndex" -> "user_id,product_id", "cubeSize" -> "10000")))
         val (indexed, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
         val weightMap = tc.cubeWeightsBroadcast.value
 
@@ -184,7 +190,8 @@ class IndexTest
     withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
       withOTreeAlgorithm { oTreeAlgorithm =>
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
         val (_, tc) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
         df.write
@@ -224,7 +231,7 @@ class IndexTest
       val rev = SparkRevisionFactory.createNewRevision(
         QTableID("test"),
         df.schema,
-        Map("columnsToIndex" -> "age,val2", "cubeSize" -> smallCubeSize.toString))
+        QbeastOptions(Map("columnsToIndex" -> "age,val2", "cubeSize" -> smallCubeSize.toString)))
 
       val (indexed, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
       val weightMap = tc.cubeWeightsBroadcast.value

--- a/src/test/scala/io/qbeast/spark/index/OTreeAlgorithmTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/OTreeAlgorithmTest.scala
@@ -5,6 +5,7 @@ package io.qbeast.spark.index
 
 import io.qbeast.core.model.QTableID
 import io.qbeast.spark.index.QbeastColumns._
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.TestClasses._
 import org.apache.spark.sql.functions._
@@ -81,7 +82,7 @@ class OTreeAlgorithmTest extends QbeastIntegrationTestSpec {
       val rev = SparkRevisionFactory.createNewRevision(
         QTableID("test"),
         df.schema,
-        Map("columnsToIndex" -> df.columns.mkString(","), "cubeSize" -> "10000"))
+        QbeastOptions(Map("columnsToIndex" -> df.columns.mkString(","), "cubeSize" -> "10000")))
 
       val newDf = df.transform(DoublePassOTreeDataAnalyzer.addRandomWeight(rev))
       /* With less than 10k rows the probability of a collision is approximately 0.3%,

--- a/src/test/scala/io/qbeast/spark/index/SparkPointWeightIndexerTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkPointWeightIndexerTest.scala
@@ -27,7 +27,7 @@ class SparkPointWeightIndexerTest extends QbeastIntegrationTestSpec {
     val rev = SparkRevisionFactory.createNewRevision(
       qid,
       df.schema,
-      Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c"))
+      QbeastOptions(Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c")))
 
     val indexStatus = IndexStatus(rev)
     val tableChanges = BroadcastedTableChanges(None, indexStatus, Map.empty, Map.empty)
@@ -50,7 +50,7 @@ class SparkPointWeightIndexerTest extends QbeastIntegrationTestSpec {
     val rev = SparkRevisionFactory.createNewRevision(
       qid,
       df.schema,
-      Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c"))
+      QbeastOptions(Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c")))
     val indexStatus = IndexStatus(rev)
 
     val revisionChange =
@@ -84,7 +84,7 @@ class SparkPointWeightIndexerTest extends QbeastIntegrationTestSpec {
     val rev = SparkRevisionFactory.createNewRevision(
       qid,
       df.schema,
-      Map(QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing"))
+      QbeastOptions(Map(QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing")))
     val indexStatus = IndexStatus(rev)
 
     val revisionChange =

--- a/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
@@ -56,7 +56,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(QbeastOptions.COLUMNS_TO_INDEX -> "a", QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(QbeastOptions.COLUMNS_TO_INDEX -> "a", QbeastOptions.CUBE_SIZE -> "10")))
 
     revision.tableID shouldBe qid
     revision.revisionID shouldBe 0
@@ -74,7 +75,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c,d", QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c,d", QbeastOptions.CUBE_SIZE -> "10")))
 
     revision.tableID shouldBe qid
     revision.revisionID shouldBe 0
@@ -90,9 +92,10 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(
-          QbeastOptions.COLUMNS_TO_INDEX -> "a:linear,b:linear,c:hashing,d:linear",
-          QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(
+            QbeastOptions.COLUMNS_TO_INDEX -> "a:linear,b:linear,c:hashing,d:linear",
+            QbeastOptions.CUBE_SIZE -> "10")))
 
     revisionExplicit.copy(timestamp = 0) shouldBe revision.copy(timestamp = 0)
   })
@@ -105,10 +108,11 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(
-          QbeastOptions.COLUMNS_TO_INDEX -> "a",
-          QbeastOptions.CUBE_SIZE -> "10",
-          QbeastOptions.STATS -> """{ "a_min": 0, "a_max": 10 }"""))
+        QbeastOptions(
+          Map(
+            QbeastOptions.COLUMNS_TO_INDEX -> "a",
+            QbeastOptions.CUBE_SIZE -> "10",
+            QbeastOptions.STATS -> """{ "a_min": 0, "a_max": 10 }""")))
 
     revision.tableID shouldBe qid
     // the reason while it's 1 is because columnStats are provided here
@@ -216,7 +220,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(QbeastOptions.COLUMNS_TO_INDEX -> "date", QbeastOptions.STATS -> columnStats))
+        QbeastOptions(
+          Map(QbeastOptions.COLUMNS_TO_INDEX -> "date", QbeastOptions.STATS -> columnStats)))
 
     val transformation = revision.transformations.head
     transformation should not be null
@@ -235,11 +240,12 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
         SparkRevisionFactory.createNewRevision(
           qid,
           schema,
-          Map(
-            QbeastOptions.COLUMNS_TO_INDEX -> "a,b",
-            QbeastOptions.CUBE_SIZE -> "10",
-            QbeastOptions.STATS ->
-              """{ "a_min": 0, "a_max": 10, "b_min": 10.0, "b_max": 20.0}""".stripMargin))
+          QbeastOptions(
+            Map(
+              QbeastOptions.COLUMNS_TO_INDEX -> "a,b",
+              QbeastOptions.CUBE_SIZE -> "10",
+              QbeastOptions.STATS ->
+                """{ "a_min": 0, "a_max": 10, "b_min": 10.0, "b_max": 20.0}""".stripMargin)))
 
       revision.tableID shouldBe qid
       // the reason while it's 1 is because columnStats are provided here
@@ -272,9 +278,10 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(
-          QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing,d:hashing",
-          QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(
+            QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing,d:hashing",
+            QbeastOptions.CUBE_SIZE -> "10")))
 
     revision.tableID shouldBe qid
     revision.revisionID shouldBe 0

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
@@ -1,0 +1,173 @@
+package io.qbeast.spark.utils
+
+import io.qbeast.spark.internal.QbeastOptions
+import io.qbeast.spark.QbeastIntegrationTestSpec
+import io.qbeast.TestClasses.Student
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
+
+import scala.util.Random
+
+/**
+ * Integration test to check the correctness of the transactions identified by user.
+ */
+class QbeastSparkTxnTest extends QbeastIntegrationTestSpec {
+
+  "QbeastSpark" should "save SetTransaction action in the log while indexing data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+    val data = makeDataFrame(spark)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+      .option(QbeastOptions.CUBE_SIZE, 1)
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .save(tmpDir)
+    val transaction =
+      DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.setTransactions.head
+    transaction.appId shouldBe "test"
+    transaction.version shouldBe 1
+  }
+
+  it should "save SetTransaction action in the log while staging data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+    (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      val transaction =
+        DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.setTransactions.head
+      transaction.appId shouldBe "test"
+      transaction.version shouldBe 1
+  }
+
+  it should "ignore aleady processed transaction while indexing data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+    val data = makeDataFrame(spark)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+      .option(QbeastOptions.CUBE_SIZE, 1)
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .save(tmpDir)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .mode(SaveMode.Append)
+      .save(tmpDir)
+    spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count()
+  }
+
+  it should "ignore already processed transaction while staging data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+    (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count()
+  }
+
+  it should "process transaction with different appId while indexing data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+    val data = makeDataFrame(spark)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+      .option(QbeastOptions.CUBE_SIZE, 1)
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .save(tmpDir)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.TXN_APP_ID, "test2")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .mode(SaveMode.Append)
+      .save(tmpDir)
+    spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  it should "process transaction with different version while indexing data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+    val data = makeDataFrame(spark)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+      .option(QbeastOptions.CUBE_SIZE, 1)
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .save(tmpDir)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "2")
+      .mode(SaveMode.Append)
+      .save(tmpDir)
+    spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  it should "process transaction with different appId  while staging data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+    (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.TXN_APP_ID, "test2")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  it should "process transaction with different version  while staging data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+    (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "2")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  private def makeDataFrame(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    (1 to 3).map(i => Student(i, i.toString(), Random.nextInt)).toDF()
+  }
+
+}

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
@@ -125,7 +125,7 @@ class QbeastSparkTxnTest extends QbeastIntegrationTestSpec {
     spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
   }
 
-  it should "process transaction with different appId  while staging data" in withExtendedSparkAndTmpDir(
+  it should "process transaction with different appId while staging data" in withExtendedSparkAndTmpDir(
     sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
     (spark, tmpDir) =>
       val data = makeDataFrame(spark)
@@ -145,7 +145,7 @@ class QbeastSparkTxnTest extends QbeastIntegrationTestSpec {
       spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
   }
 
-  it should "process transaction with different version  while staging data" in withExtendedSparkAndTmpDir(
+  it should "process transaction with different version while staging data" in withExtendedSparkAndTmpDir(
     sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
     (spark, tmpDir) =>
       val data = makeDataFrame(spark)
@@ -160,6 +160,41 @@ class QbeastSparkTxnTest extends QbeastIntegrationTestSpec {
         .format("qbeast")
         .option(QbeastOptions.TXN_APP_ID, "test")
         .option(QbeastOptions.TXN_VERSION, "2")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  it should "process implicit transaction while indexing data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+    val data = makeDataFrame(spark)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+      .option(QbeastOptions.CUBE_SIZE, 1)
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .save(tmpDir)
+    data.write
+      .format("qbeast")
+      .mode(SaveMode.Append)
+      .save(tmpDir)
+    spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  it should "process implicit transaction while staging data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+    (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
         .mode(SaveMode.Append)
         .save(tmpDir)
       spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2


### PR DESCRIPTION
## Description

The set of supported options is extended to let the user to control the transaction identity and thus to make the writes idempotent.

## Type of change

This is a new feature borrowed from Delta which adds two supported options `txnAppId` and `txnVersion` to be used to identify the write transaction. Once committed any other transaction with the same properties will be ignored as already committed. This feature allows to make the writes idempotent.

No breaking changes have been introduced.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)
A new integration test `io.qbeast.spark.utils.QbeastSparkTxnTest` is added to check the transaction handling.