### PR TITLE
250 backport the txn app id and txn version support

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
+++ b/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
@@ -6,8 +6,9 @@ import io.qbeast.IISeq
  * Metadata Manager template
  * @tparam DataSchema type of data schema
  * @tparam FileDescriptor type of file descriptor
+ * @tparam QbeastOptions type of Qbeast options
  */
-trait MetadataManager[DataSchema, FileDescriptor] {
+trait MetadataManager[DataSchema, FileDescriptor, QbeastOptions] {
   type Configuration = Map[String, String]
 
   /**
@@ -28,11 +29,15 @@ trait MetadataManager[DataSchema, FileDescriptor] {
    * Writes and updates the metadata by using transaction control
    * @param tableID the QTableID
    * @param schema the schema of the data
+   * @param options the Qbeast options
    * @param append the append flag
    * @param writer the writer code to be executed
    */
-  def updateWithTransaction(tableID: QTableID, schema: DataSchema, append: Boolean)(
-      writer: => (TableChanges, IISeq[FileDescriptor])): Unit
+  def updateWithTransaction(
+      tableID: QTableID,
+      schema: DataSchema,
+      options: QbeastOptions,
+      append: Boolean)(writer: => (TableChanges, IISeq[FileDescriptor])): Unit
 
   /**
    * Updates the table metadata by overwriting the metadata configurations

--- a/core/src/main/scala/io/qbeast/core/model/QbeastCoreContext.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastCoreContext.scala
@@ -9,13 +9,14 @@ import scala.reflect.ClassTag
  * @tparam DATA type of the data
  * @tparam DataSchema type of the data schema
  * @tparam FileDescriptor type of the file descriptor
+ * @tparam QbeastOptions type of Qbeast options
  */
-trait QbeastCoreContext[DATA, DataSchema, FileDescriptor] {
-  def metadataManager: MetadataManager[DataSchema, FileDescriptor]
+trait QbeastCoreContext[DATA, DataSchema, FileDescriptor, QbeastOptions] {
+  def metadataManager: MetadataManager[DataSchema, FileDescriptor, QbeastOptions]
   def dataWriter: DataWriter[DATA, DataSchema, FileDescriptor]
   def indexManager: IndexManager[DATA]
   def queryManager[QUERY: ClassTag]: QueryManager[QUERY, DATA]
-  def revisionBuilder: RevisionFactory[DataSchema]
+  def revisionBuilder: RevisionFactory[DataSchema, QbeastOptions]
   def keeper: Keeper
 
 }
@@ -25,7 +26,7 @@ trait QbeastCoreContext[DATA, DataSchema, FileDescriptor] {
  *
  * @tparam DataSchema type of the data schema
  */
-trait RevisionFactory[DataSchema] {
+trait RevisionFactory[DataSchema, QbeastOptions] {
 
   /**
    * Create a new revision for a table with given parameters
@@ -35,10 +36,7 @@ trait RevisionFactory[DataSchema] {
    * @param options       the options
    * @return
    */
-  def createNewRevision(
-      qtableID: QTableID,
-      schema: DataSchema,
-      options: Map[String, String]): Revision
+  def createNewRevision(qtableID: QTableID, schema: DataSchema, options: QbeastOptions): Revision
 
   /**
    * Create a new revision with given parameters from an old revision
@@ -51,7 +49,7 @@ trait RevisionFactory[DataSchema] {
   def createNextRevision(
       qtableID: QTableID,
       schema: DataSchema,
-      options: Map[String, String],
+      options: QbeastOptions,
       oldRevision: RevisionID): Revision
 
 }

--- a/docs/AdvancedConfiguration.md
+++ b/docs/AdvancedConfiguration.md
@@ -100,6 +100,42 @@ In a `JSON` string, you can pass the **minimum and maximum values of the columns
 }
 ```
 
+## TxnAppId and TxnVersion
+
+These options are used to make the writes idempotent.
+
+The option `txnAppId` identifies an application writing data to the table. It is
+the responsibility of the user to assign unique identifiers to the applications
+writing data to the table.
+
+The option `txnVersion` identifies the transaction issued by the application.
+The value of this option must be a valid string representation of a positive
+long number.
+
+```scala
+df.write.format("qbeast")
+.option("columnsToIndex", "a")
+.option("txnAppId", "ingestionService")
+.option("txnVersion", "1")
+```
+
+If the table already contains the data written by some other transaction with
+the same `txnAppId` and `txnVersion` then the requested write will be ignored.
+
+```scala
+// The data is written
+df.write.format("qbeast")
+.option("columnsToIndex", "a")
+.option("txnAppId", "ingestionService")
+.option("txnVersion", "1")
+...
+// The data is ignored
+df.write.format("qbeast")
+.mode("append")
+.option("txnAppId", "ingestionService")
+.option("txnVersion", "1")
+```
+
 ## Indexing Timestamps with ColumnStats
 
 For indexing `Timestamps` or `Dates` with `columnStats` (min and maximum ranges), notice that **the values need to be formatted in a proper way** (following `"yyyy-MM-dd HH:mm:ss.SSSSSS'Z'"` pattern) for Qbeast to be able to parse it. 

--- a/src/main/scala/io/qbeast/context/QbeastContext.scala
+++ b/src/main/scala/io/qbeast/context/QbeastContext.scala
@@ -16,6 +16,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import scala.reflect.ClassTag
+import io.qbeast.spark.internal.QbeastOptions
 
 /**
  * Qbeast context provides access to internal mechanisms of
@@ -59,7 +60,7 @@ trait QbeastContext {
  */
 object QbeastContext
     extends QbeastContext
-    with QbeastCoreContext[DataFrame, StructType, FileAction] {
+    with QbeastCoreContext[DataFrame, StructType, FileAction, QbeastOptions] {
   private var managedOption: Option[QbeastContext] = None
   private var unmanagedOption: Option[QbeastContext] = None
 
@@ -78,13 +79,13 @@ object QbeastContext
 
   override def indexManager: IndexManager[DataFrame] = SparkOTreeManager
 
-  override def metadataManager: MetadataManager[StructType, FileAction] =
+  override def metadataManager: MetadataManager[StructType, FileAction, QbeastOptions] =
     SparkDeltaMetadataManager
 
   override def dataWriter: DataWriter[DataFrame, StructType, FileAction] =
     SparkDeltaDataWriter
 
-  override def revisionBuilder: RevisionFactory[StructType] =
+  override def revisionBuilder: RevisionFactory[StructType, QbeastOptions] =
     SparkRevisionFactory
 
   /**

--- a/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -66,6 +66,13 @@ private[delta] case class DeltaMetadataWriter(
   }
 
   def writeWithTransaction(writer: => (TableChanges, Seq[FileAction])): Unit = {
+    val oldTransactions = deltaLog.unsafeVolatileSnapshot.setTransactions
+    // If the transaction was completed before then no operation
+    for (txn <- oldTransactions; version <- options.txnVersion; appId <- options.txnAppId) {
+      if (txn.appId == appId && txn.version == version) {
+        return
+      }
+    }
     deltaLog.withNewTransaction { txn =>
       // Register metrics to use in the Commit Info
       val statsTrackers = createStatsTrackers(txn)
@@ -73,9 +80,13 @@ private[delta] case class DeltaMetadataWriter(
       // Execute write
       val (changes, newFiles) = writer
       // Update Qbeast Metadata (replicated set, revision..)
-      val finalActions = updateMetadata(txn, changes, newFiles)
+      var actions = updateMetadata(txn, changes, newFiles)
+      // Set transaction identifier if specified
+      for (txnVersion <- options.txnVersion; txnAppId <- options.txnAppId) {
+        actions +:= SetTransaction(txnAppId, txnVersion, Some(System.currentTimeMillis()))
+      }
       // Commit the information to the DeltaLog
-      txn.commit(finalActions, deltaOperation)
+      txn.commit(actions, deltaOperation)
     }
   }
 

--- a/src/main/scala/io/qbeast/spark/delta/SparkDeltaMetadataManager.scala
+++ b/src/main/scala/io/qbeast/spark/delta/SparkDeltaMetadataManager.scala
@@ -9,20 +9,34 @@ import org.apache.spark.sql.delta.actions.FileAction
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{SaveMode, SparkSession}
+import io.qbeast.spark.internal.QbeastOptions
 
 /**
  * Spark+Delta implementation of the MetadataManager interface
  */
-object SparkDeltaMetadataManager extends MetadataManager[StructType, FileAction] {
+object SparkDeltaMetadataManager extends MetadataManager[StructType, FileAction, QbeastOptions] {
 
-  override def updateWithTransaction(tableID: QTableID, schema: StructType, append: Boolean)(
-      writer: => (TableChanges, IISeq[FileAction])): Unit = {
+  override def updateWithTransaction(
+      tableID: QTableID,
+      schema: StructType,
+      options: QbeastOptions,
+      append: Boolean)(writer: => (TableChanges, IISeq[FileAction])): Unit = {
 
     val deltaLog = loadDeltaQbeastLog(tableID).deltaLog
     val mode = if (append) SaveMode.Append else SaveMode.Overwrite
-    val options =
-      new DeltaOptions(Map("path" -> tableID.id), SparkSession.active.sessionState.conf)
-    val metadataWriter = DeltaMetadataWriter(tableID, mode, deltaLog, options, schema)
+    val conf = SparkSession.active.sessionState.conf
+    val deltaOptions = Map.newBuilder[String, String]
+    deltaOptions += "path" -> tableID.id
+    for (txnAppId <- options.txnAppId; txnVersion <- options.txnVersion) {
+      deltaOptions += DeltaOptions.TXN_APP_ID -> txnAppId
+      deltaOptions += DeltaOptions.TXN_VERSION -> txnVersion
+    }
+    val metadataWriter = DeltaMetadataWriter(
+      tableID,
+      mode,
+      deltaLog,
+      new DeltaOptions(deltaOptions.result(), conf),
+      schema)
     metadataWriter.writeWithTransaction(writer)
   }
 

--- a/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
@@ -14,7 +14,7 @@ import scala.util.matching.Regex
 /**
  * Spark implementation of RevisionBuilder
  */
-object SparkRevisionFactory extends RevisionFactory[StructType] {
+object SparkRevisionFactory extends RevisionFactory[StructType, QbeastOptions] {
 
   val SpecExtractor: Regex = "([^:]+):([A-z]+)".r
 
@@ -25,11 +25,10 @@ object SparkRevisionFactory extends RevisionFactory[StructType] {
   override def createNewRevision(
       qtableID: QTableID,
       schema: StructType,
-      options: Map[String, String]): Revision = {
+      options: QbeastOptions): Revision = {
 
-    val qbeastOptions = QbeastOptions(options)
-    val columnSpecs = qbeastOptions.columnsToIndex
-    val desiredCubeSize = qbeastOptions.cubeSize
+    val columnSpecs = options.columnsToIndex
+    val desiredCubeSize = options.cubeSize
 
     val transformers = columnSpecs.map {
       case SpecExtractor(columnName, transformerType) =>
@@ -40,7 +39,7 @@ object SparkRevisionFactory extends RevisionFactory[StructType] {
 
     }.toVector
 
-    qbeastOptions.stats match {
+    options.stats match {
       case None => Revision.firstRevision(qtableID, desiredCubeSize, transformers)
       case Some(stats) =>
         val columnStats = stats.first()
@@ -78,7 +77,7 @@ object SparkRevisionFactory extends RevisionFactory[StructType] {
   override def createNextRevision(
       qtableID: QTableID,
       schema: StructType,
-      options: Map[String, String],
+      options: QbeastOptions,
       oldRevisionID: RevisionID): Revision = {
     val revision = createNewRevision(qtableID, schema, options)
     revision.copy(revisionID = oldRevisionID + 1)

--- a/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
+++ b/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
@@ -7,13 +7,26 @@ import io.qbeast.core.model.QTableID
 import io.qbeast.spark.index.ColumnsToIndex
 import org.apache.spark.qbeast.config.DEFAULT_CUBE_SIZE
 import org.apache.spark.sql.{AnalysisExceptionFactory, DataFrame, SparkSession}
+import org.apache.spark.sql.delta.DeltaOptions
 
 /**
  * Container for Qbeast options.
+ *
  * @param columnsToIndex value of columnsToIndex option
  * @param cubeSize value of cubeSize option
+ * @param stats
+ *   the stats if available
+ * @param txnVersion
+ *   the transaction identifier
+ * @param txnAppId
+ *   the application identifier
  */
-case class QbeastOptions(columnsToIndex: Seq[String], cubeSize: Int, stats: Option[DataFrame])
+case class QbeastOptions(
+    columnsToIndex: Seq[String],
+    cubeSize: Int,
+    stats: Option[DataFrame],
+    txnAppId: Option[String],
+    txnVersion: Option[String])
 
 /**
  * Options available when trying to write in qbeast format
@@ -24,6 +37,8 @@ object QbeastOptions {
   val CUBE_SIZE = "cubeSize"
   val PATH = "path"
   val STATS = "columnStats"
+  val TXN_APP_ID = DeltaOptions.TXN_APP_ID
+  val TXN_VERSION = DeltaOptions.TXN_VERSION
 
   /**
    * Gets the columns to index from the options
@@ -77,6 +92,11 @@ object QbeastOptions {
     }
   }
 
+  private def getTxnAppId(options: Map[String, String]): Option[String] = options.get(TXN_APP_ID)
+
+  private def getTxnVersion(options: Map[String, String]): Option[String] =
+    options.get(TXN_VERSION)
+
   /**
    * Create QbeastOptions object from options map
    * @param options the options map
@@ -86,8 +106,15 @@ object QbeastOptions {
     val columnsToIndex = getColumnsToIndex(options)
     val desiredCubeSize = getDesiredCubeSize(options)
     val stats = getStats(options)
-    QbeastOptions(columnsToIndex, desiredCubeSize, stats)
+    val txnAppId = getTxnAppId(options)
+    val txnVersion = getTxnVersion(options)
+    QbeastOptions(columnsToIndex, desiredCubeSize, stats, txnAppId, txnVersion)
   }
+
+  /**
+   * The empty options to be used as a placeholder.
+   */
+  lazy val empty: QbeastOptions = QbeastOptions(Seq.empty, DEFAULT_CUBE_SIZE, None, None, None)
 
   def loadTableIDFromParameters(parameters: Map[String, String]): QTableID = {
     new QTableID(

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -102,9 +102,9 @@ trait IndexedTableFactory {
 final class IndexedTableFactoryImpl(
     private val keeper: Keeper,
     private val indexManager: IndexManager[DataFrame],
-    private val metadataManager: MetadataManager[StructType, FileAction],
+    private val metadataManager: MetadataManager[StructType, FileAction, QbeastOptions],
     private val dataWriter: DataWriter[DataFrame, StructType, FileAction],
-    private val revisionBuilder: RevisionFactory[StructType])
+    private val revisionFactory: RevisionFactory[StructType, QbeastOptions])
     extends IndexedTableFactory {
 
   override def getIndexedTable(tableID: QTableID): IndexedTable =
@@ -114,7 +114,7 @@ final class IndexedTableFactoryImpl(
       indexManager,
       metadataManager,
       dataWriter,
-      revisionBuilder)
+      revisionFactory)
 
 }
 
@@ -132,9 +132,9 @@ private[table] class IndexedTableImpl(
     val tableID: QTableID,
     private val keeper: Keeper,
     private val indexManager: IndexManager[DataFrame],
-    private val metadataManager: MetadataManager[StructType, FileAction],
+    private val metadataManager: MetadataManager[StructType, FileAction, QbeastOptions],
     private val dataWriter: DataWriter[DataFrame, StructType, FileAction],
-    private val revisionBuilder: RevisionFactory[StructType])
+    private val revisionFactory: RevisionFactory[StructType, QbeastOptions])
     extends IndexedTable
     with StagingUtils {
   private var snapshotCache: Option[QbeastSnapshot] = None
@@ -180,32 +180,34 @@ private[table] class IndexedTableImpl(
       parameters: Map[String, String]): Map[String, String] = {
     val columnsToIndex = latestRevision.columnTransformers.map(_.columnName).mkString(",")
     val desiredCubeSize = latestRevision.desiredCubeSize.toString
-    (parameters.contains(COLUMNS_TO_INDEX), parameters.contains(CUBE_SIZE)) match {
-      case (true, true) => parameters
-      case (false, false) =>
-        parameters + (COLUMNS_TO_INDEX -> columnsToIndex, CUBE_SIZE -> desiredCubeSize)
-      case (true, false) => parameters + (CUBE_SIZE -> desiredCubeSize)
-      case (false, true) => parameters + (COLUMNS_TO_INDEX -> columnsToIndex)
+    var correctParameters = parameters
+    if (!parameters.contains(COLUMNS_TO_INDEX)) {
+      correctParameters += COLUMNS_TO_INDEX -> columnsToIndex
     }
+    if (!parameters.contains(CUBE_SIZE)) {
+      correctParameters += CUBE_SIZE -> desiredCubeSize
+    }
+    correctParameters
   }
 
   override def save(
       data: DataFrame,
       parameters: Map[String, String],
       append: Boolean): BaseRelation = {
-    val indexStatus =
+    val (indexStatus, options) =
       if (exists && append) {
         // If the table exists and we are appending new data
         // 1. Load existing IndexStatus
         val latestRevision = snapshot.loadLatestRevision
-        val updatedParameters = addRequiredParams(latestRevision, parameters)
+        val options = QbeastOptions(addRequiredParams(latestRevision, parameters))
         if (isStaging(latestRevision)) { // If the existing Revision is Staging
-          IndexStatus(revisionBuilder.createNewRevision(tableID, data.schema, updatedParameters))
+          val revision = revisionFactory.createNewRevision(tableID, data.schema, options)
+          (IndexStatus(revision), options)
         } else {
-          if (isNewRevision(QbeastOptions(updatedParameters), latestRevision)) {
+          if (isNewRevision(options, latestRevision)) {
             // If the new parameters generate a new revision, we need to create another one
-            val newPotentialRevision = revisionBuilder
-              .createNewRevision(tableID, data.schema, updatedParameters)
+            val newPotentialRevision = revisionFactory
+              .createNewRevision(tableID, data.schema, options)
             val newRevisionCubeSize = newPotentialRevision.desiredCubeSize
             // Merge new Revision Transformations with old Revision Transformations
             val newRevisionTransformations =
@@ -224,19 +226,20 @@ private[table] class IndexedTableImpl(
               transformationsChanges = newRevisionTransformations)
 
             // Output the New Revision into the IndexStatus
-            IndexStatus(revisionChanges.createNewRevision)
+            (IndexStatus(revisionChanges.createNewRevision), options)
           } else {
             // If the new parameters does not create a different revision,
             // load the latest IndexStatus
-            snapshot.loadIndexStatus(latestRevision.revisionID)
+            (snapshot.loadIndexStatus(latestRevision.revisionID), options)
           }
         }
       } else {
-        IndexStatus(revisionBuilder.createNewRevision(tableID, data.schema, parameters))
+        val options = QbeastOptions(parameters)
+        val revision = revisionFactory.createNewRevision(tableID, data.schema, options)
+        (IndexStatus(revision), options)
       }
 
-    val relation = write(data, indexStatus, append)
-    relation
+    write(data, indexStatus, options, append)
   }
 
   override def load(): BaseRelation = {
@@ -271,7 +274,11 @@ private[table] class IndexedTableImpl(
     QbeastBaseRelation.forQbeastTable(this)
   }
 
-  private def write(data: DataFrame, indexStatus: IndexStatus, append: Boolean): BaseRelation = {
+  private def write(
+      data: DataFrame,
+      indexStatus: IndexStatus,
+      options: QbeastOptions,
+      append: Boolean): BaseRelation = {
     val revision = indexStatus.revision
     keeper.withWrite(tableID, revision.revisionID) { write =>
       var tries = DEFAULT_NUMBER_OF_RETRIES
@@ -281,7 +288,7 @@ private[table] class IndexedTableImpl(
         val replicatedSet = updatedStatus.replicatedSet
         val revisionID = updatedStatus.revision.revisionID
         try {
-          doWrite(data, updatedStatus, append)
+          doWrite(data, updatedStatus, options, append)
           tries = 0
         } catch {
           case cme: ConcurrentModificationException
@@ -303,15 +310,19 @@ private[table] class IndexedTableImpl(
     createQbeastBaseRelation()
   }
 
-  private def doWrite(data: DataFrame, indexStatus: IndexStatus, append: Boolean): Unit = {
+  private def doWrite(
+      data: DataFrame,
+      indexStatus: IndexStatus,
+      options: QbeastOptions,
+      append: Boolean): Unit = {
     val stagingDataManager: StagingDataManager = new StagingDataManager(tableID)
     stagingDataManager.updateWithStagedData(data) match {
       case r: StagingResolution if r.sendToStaging =>
-        stagingDataManager.stageData(data, indexStatus, append)
+        stagingDataManager.stageData(data, indexStatus, options, append)
 
       case StagingResolution(dataToWrite, removeFiles, false) =>
         val schema = dataToWrite.schema
-        metadataManager.updateWithTransaction(tableID, schema, append) {
+        metadataManager.updateWithTransaction(tableID, schema, options, append) {
           val (qbeastData, tableChanges) = indexManager.index(dataToWrite, indexStatus)
           val fileActions = dataWriter.write(tableID, schema, qbeastData, tableChanges)
           (tableChanges, fileActions ++ removeFiles)
@@ -360,7 +371,7 @@ private[table] class IndexedTableImpl(
       indexStatus: IndexStatus,
       cubesToOptimize: Set[CubeId]): Unit = {
 
-    metadataManager.updateWithTransaction(tableID, schema, append = true) {
+    metadataManager.updateWithTransaction(tableID, schema, QbeastOptions.empty, append = true) {
       val dataToReplicate =
         CubeDataLoader(tableID).loadSetWithCubeColumn(
           cubesToOptimize,
@@ -381,7 +392,7 @@ private[table] class IndexedTableImpl(
     val schema = metadataManager.loadCurrentSchema(tableID)
     val currentIndexStatus = snapshot.loadIndexStatus(revisionID)
 
-    metadataManager.updateWithTransaction(tableID, schema, append = true) {
+    metadataManager.updateWithTransaction(tableID, schema, QbeastOptions.empty, append = true) {
       // There's no affected table changes on compaction, so we send an empty object
       val tableChanges = BroadcastedTableChanges(None, currentIndexStatus, Map.empty)
       val fileActions =

--- a/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/QbeastSnapshotTest.scala
@@ -10,6 +10,7 @@ import io.qbeast.spark.QbeastIntegrationTestSpec
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.{AnalysisException, Dataset, SparkSession}
 import org.scalatest.AppendedClues.convertToClueful
+import io.qbeast.spark.internal.QbeastOptions
 
 class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
 
@@ -64,7 +65,7 @@ class QbeastSnapshotTest extends QbeastIntegrationTestSpec {
         val deltaLog = DeltaLog.forTable(spark, tmpDir)
         val qbeastSnapshot = DeltaQbeastSnapshot(deltaLog.update())
         val columnTransformers = SparkRevisionFactory
-          .createNewRevision(QTableID(tmpDir), df.schema, options)
+          .createNewRevision(QTableID(tmpDir), df.schema, QbeastOptions(options))
           .columnTransformers
 
         val revision = qbeastSnapshot.loadLatestRevision

--- a/src/test/scala/io/qbeast/spark/delta/writer/SparkDeltaDataWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/SparkDeltaDataWriterTest.scala
@@ -12,6 +12,7 @@ import org.apache.spark.qbeast.config.{
 import org.apache.spark.sql.delta.actions.AddFile
 
 import scala.reflect.io.Path
+import io.qbeast.spark.internal.QbeastOptions
 
 class SparkDeltaDataWriterTest extends QbeastIntegrationTestSpec {
 
@@ -28,7 +29,8 @@ class SparkDeltaDataWriterTest extends QbeastIntegrationTestSpec {
       val parameters: Map[String, String] =
         Map("columnsToIndex" -> "age,val2", "cubeSize" -> cubeSize.toString)
       val indexStatus =
-        IndexStatus(SparkRevisionFactory.createNewRevision(tableID, df.schema, parameters))
+        IndexStatus(
+          SparkRevisionFactory.createNewRevision(tableID, df.schema, QbeastOptions(parameters)))
       val (qbeastData, tableChanges) = SparkOTreeManager.index(df, indexStatus)
 
       val fileActions = SparkDeltaDataWriter.write(tableID, df.schema, qbeastData, tableChanges)

--- a/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/WriteTestSpec.scala
@@ -15,6 +15,7 @@ import java.util.UUID
 import scala.collection.immutable
 import scala.collection.immutable.SortedMap
 import scala.util.Random
+import io.qbeast.spark.internal.QbeastOptions
 
 case class WriteTestSpec(numDistinctCubes: Int, spark: SparkSession, tmpDir: String) {
 
@@ -60,7 +61,7 @@ case class WriteTestSpec(numDistinctCubes: Int, spark: SparkSession, tmpDir: Str
     .createNewRevision(
       QTableID("test"),
       data.schema,
-      Map("columnsToIndex" -> "id", "cubeSize" -> "10000"))
+      QbeastOptions(Map("columnsToIndex" -> "id", "cubeSize" -> "10000")))
 
   val cubeStatuses: SortedMap[CubeId, CubeStatus] = {
     val cubeStatusesSeq = weightMap.toIndexedSeq.map {

--- a/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/CubeWeightsIntegrationTest.scala
@@ -7,6 +7,7 @@ import org.apache.spark.qbeast.config.{CUBE_WEIGHTS_BUFFER_CAPACITY, DEFAULT_CUB
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.delta.DeltaLog
 import org.scalatest.PrivateMethodTester
+import io.qbeast.spark.internal.QbeastOptions
 
 class CubeWeightsIntegrationTest extends QbeastIntegrationTestSpec with PrivateMethodTester {
 
@@ -31,7 +32,8 @@ class CubeWeightsIntegrationTest extends QbeastIntegrationTestSpec with PrivateM
               .createNewRevision(
                 QTableID("test"),
                 df.schema,
-                Map("columnsToIndex" -> names.mkString(","), "cubeSize" -> "10000")))
+                QbeastOptions(
+                  Map("columnsToIndex" -> names.mkString(","), "cubeSize" -> "10000"))))
           val (_, tc) = oTreeAlgorithm.index(df.toDF(), indexStatus)
           df.write
             .format("qbeast")

--- a/src/test/scala/io/qbeast/spark/index/IndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/IndexTest.scala
@@ -12,6 +12,7 @@ import org.apache.spark.sql.types.{IntegerType, LongType}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import io.qbeast.spark.internal.QbeastOptions
 
 class IndexTest
     extends AnyFlatSpec
@@ -21,6 +22,7 @@ class IndexTest
 
   // TEST CONFIGURATIONS
   private val options = Map("columnsToIndex" -> "age,val2", "cubeSize" -> "10000")
+  private val qbeastOptions = QbeastOptions(options)
 
   private def createDF(): DataFrame = {
     val spark = SparkSession.active
@@ -39,7 +41,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (indexed, _) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -52,7 +55,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (_, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -65,7 +69,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (_, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -78,7 +83,8 @@ class IndexTest
     withOTreeAlgorithm { oTreeAlgorithm =>
       {
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
 
         val (indexed, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
@@ -102,7 +108,7 @@ class IndexTest
         val rev = SparkRevisionFactory.createNewRevision(
           QTableID("test"),
           df.schema,
-          Map("columnsToIndex" -> "user_id,product_id", "cubeSize" -> "10000"))
+          QbeastOptions(Map("columnsToIndex" -> "user_id,product_id", "cubeSize" -> "10000")))
         val (indexed, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
         val weightMap = tc.cubeWeights.value
 
@@ -179,7 +185,8 @@ class IndexTest
     withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
       withOTreeAlgorithm { oTreeAlgorithm =>
         val df = createDF()
-        val rev = SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, options)
+        val rev =
+          SparkRevisionFactory.createNewRevision(QTableID("test"), df.schema, qbeastOptions)
         val (_, tc) = oTreeAlgorithm.index(df, IndexStatus(rev))
 
         df.write
@@ -217,7 +224,7 @@ class IndexTest
       val rev = SparkRevisionFactory.createNewRevision(
         QTableID("test"),
         df.schema,
-        Map("columnsToIndex" -> "age,val2", "cubeSize" -> smallCubeSize.toString))
+        QbeastOptions(Map("columnsToIndex" -> "age,val2", "cubeSize" -> smallCubeSize.toString)))
 
       val (indexed, tc: BroadcastedTableChanges) = oTreeAlgorithm.index(df, IndexStatus(rev))
       val weightMap = tc.cubeWeights.value

--- a/src/test/scala/io/qbeast/spark/index/OTreeAlgorithmTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/OTreeAlgorithmTest.scala
@@ -9,6 +9,7 @@ import io.qbeast.spark.index.QbeastColumns._
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
+import io.qbeast.spark.internal.QbeastOptions
 
 class OTreeAlgorithmTest extends QbeastIntegrationTestSpec {
 
@@ -81,7 +82,7 @@ class OTreeAlgorithmTest extends QbeastIntegrationTestSpec {
       val rev = SparkRevisionFactory.createNewRevision(
         QTableID("test"),
         df.schema,
-        Map("columnsToIndex" -> df.columns.mkString(","), "cubeSize" -> "10000"))
+        QbeastOptions(Map("columnsToIndex" -> df.columns.mkString(","), "cubeSize" -> "10000")))
 
       val newDf = df.transform(DoublePassOTreeDataAnalyzer.addRandomWeight(rev))
       /* With less than 10k rows the probability of a collision is approximately 0.3%,

--- a/src/test/scala/io/qbeast/spark/index/SparkPointWeightIndexerTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkPointWeightIndexerTest.scala
@@ -24,7 +24,7 @@ class SparkPointWeightIndexerTest extends QbeastIntegrationTestSpec {
     val rev = SparkRevisionFactory.createNewRevision(
       qid,
       df.schema,
-      Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c"))
+      QbeastOptions(Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c")))
 
     val indexStatus = IndexStatus(rev)
     val tableChanges = BroadcastedTableChanges(None, indexStatus, Map.empty)
@@ -47,7 +47,7 @@ class SparkPointWeightIndexerTest extends QbeastIntegrationTestSpec {
     val rev = SparkRevisionFactory.createNewRevision(
       qid,
       df.schema,
-      Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c"))
+      QbeastOptions(Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c")))
     val indexStatus = IndexStatus(rev)
 
     val revisionChange =
@@ -81,7 +81,7 @@ class SparkPointWeightIndexerTest extends QbeastIntegrationTestSpec {
     val rev = SparkRevisionFactory.createNewRevision(
       qid,
       df.schema,
-      Map(QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing"))
+      QbeastOptions(Map(QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing")))
     val indexStatus = IndexStatus(rev)
 
     val revisionChange =

--- a/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
@@ -54,7 +54,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(QbeastOptions.COLUMNS_TO_INDEX -> "a", QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(QbeastOptions.COLUMNS_TO_INDEX -> "a", QbeastOptions.CUBE_SIZE -> "10")))
 
     revision.tableID shouldBe qid
     revision.revisionID shouldBe 0
@@ -71,7 +72,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c,d", QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(QbeastOptions.COLUMNS_TO_INDEX -> "a,b,c,d", QbeastOptions.CUBE_SIZE -> "10")))
 
     revision.tableID shouldBe qid
     revision.revisionID shouldBe 0
@@ -87,9 +89,10 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(
-          QbeastOptions.COLUMNS_TO_INDEX -> "a:linear,b:linear,c:hashing,d:linear",
-          QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(
+            QbeastOptions.COLUMNS_TO_INDEX -> "a:linear,b:linear,c:hashing,d:linear",
+            QbeastOptions.CUBE_SIZE -> "10")))
 
     revisionExplicit.copy(timestamp = 0) shouldBe revision.copy(timestamp = 0)
   })
@@ -102,10 +105,11 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(
-          QbeastOptions.COLUMNS_TO_INDEX -> "a",
-          QbeastOptions.CUBE_SIZE -> "10",
-          QbeastOptions.STATS -> """{ "a_min": 0, "a_max": 10 }"""))
+        QbeastOptions(
+          Map(
+            QbeastOptions.COLUMNS_TO_INDEX -> "a",
+            QbeastOptions.CUBE_SIZE -> "10",
+            QbeastOptions.STATS -> """{ "a_min": 0, "a_max": 10 }""")))
 
     revision.tableID shouldBe qid
     // the reason while it's 1 is because columnStats are provided here
@@ -213,7 +217,8 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(QbeastOptions.COLUMNS_TO_INDEX -> "date", QbeastOptions.STATS -> columnStats))
+        QbeastOptions(
+          Map(QbeastOptions.COLUMNS_TO_INDEX -> "date", QbeastOptions.STATS -> columnStats)))
 
     val transformation = revision.transformations.head
     transformation should not be null
@@ -232,11 +237,12 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
         SparkRevisionFactory.createNewRevision(
           qid,
           schema,
-          Map(
-            QbeastOptions.COLUMNS_TO_INDEX -> "a,b",
-            QbeastOptions.CUBE_SIZE -> "10",
-            QbeastOptions.STATS ->
-              """{ "a_min": 0, "a_max": 10, "b_min": 10.0, "b_max": 20.0}""".stripMargin))
+          QbeastOptions(
+            Map(
+              QbeastOptions.COLUMNS_TO_INDEX -> "a,b",
+              QbeastOptions.CUBE_SIZE -> "10",
+              QbeastOptions.STATS ->
+                """{ "a_min": 0, "a_max": 10, "b_min": 10.0, "b_max": 20.0}""".stripMargin)))
 
       revision.tableID shouldBe qid
       // the reason while it's 1 is because columnStats are provided here
@@ -269,9 +275,10 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
       SparkRevisionFactory.createNewRevision(
         qid,
         schema,
-        Map(
-          QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing,d:hashing",
-          QbeastOptions.CUBE_SIZE -> "10"))
+        QbeastOptions(
+          Map(
+            QbeastOptions.COLUMNS_TO_INDEX -> "a:hashing,b:hashing,c:hashing,d:hashing",
+            QbeastOptions.CUBE_SIZE -> "10")))
 
     revision.tableID shouldBe qid
     revision.revisionID shouldBe 0

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
@@ -1,0 +1,212 @@
+package io.qbeast.spark.utils
+
+import io.qbeast.spark.internal.QbeastOptions
+import io.qbeast.spark.QbeastIntegrationTestSpec
+import io.qbeast.TestClasses.Student
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
+
+import scala.util.Random
+
+/**
+ * Integration test to check the correctness of the transactions identified by user.
+ */
+class QbeastSparkTxnTest extends QbeastIntegrationTestSpec {
+
+  "QbeastSpark" should "save SetTransaction action in the log while indexing data" in
+    withExtendedSparkAndTmpDir(sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      val transaction =
+        DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.setTransactions.head
+      transaction.appId shouldBe "test"
+      transaction.version shouldBe 1
+    }
+
+  it should "save SetTransaction action in the log while staging data" in
+    withExtendedSparkAndTmpDir(
+      sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+      (spark, tmpDir) =>
+        val data = makeDataFrame(spark)
+        data.write
+          .format("qbeast")
+          .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+          .option(QbeastOptions.CUBE_SIZE, 1)
+          .option(QbeastOptions.TXN_APP_ID, "test")
+          .option(QbeastOptions.TXN_VERSION, "1")
+          .save(tmpDir)
+        val transaction =
+          DeltaLog.forTable(spark, tmpDir).unsafeVolatileSnapshot.setTransactions.head
+        transaction.appId shouldBe "test"
+        transaction.version shouldBe 1
+    }
+
+  it should "ignore aleady processed transaction while indexing data" in
+    withExtendedSparkAndTmpDir(sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count()
+    }
+
+  it should "ignore already processed transaction while staging data" in
+    withExtendedSparkAndTmpDir(
+      sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+      (spark, tmpDir) =>
+        val data = makeDataFrame(spark)
+        data.write
+          .format("qbeast")
+          .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+          .option(QbeastOptions.CUBE_SIZE, 1)
+          .option(QbeastOptions.TXN_APP_ID, "test")
+          .option(QbeastOptions.TXN_VERSION, "1")
+          .save(tmpDir)
+        data.write
+          .format("qbeast")
+          .option(QbeastOptions.TXN_APP_ID, "test")
+          .option(QbeastOptions.TXN_VERSION, "1")
+          .mode(SaveMode.Append)
+          .save(tmpDir)
+        spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count()
+    }
+
+  it should "process transaction with different appId while indexing data" in
+    withExtendedSparkAndTmpDir(sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.TXN_APP_ID, "test2")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+    }
+
+  it should "process transaction with different version while indexing data" in
+    withExtendedSparkAndTmpDir(sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "2")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+    }
+
+  it should "process transaction with different appId while staging data" in
+    withExtendedSparkAndTmpDir(
+      sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+      (spark, tmpDir) =>
+        val data = makeDataFrame(spark)
+        data.write
+          .format("qbeast")
+          .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+          .option(QbeastOptions.CUBE_SIZE, 1)
+          .option(QbeastOptions.TXN_APP_ID, "test")
+          .option(QbeastOptions.TXN_VERSION, "1")
+          .save(tmpDir)
+        data.write
+          .format("qbeast")
+          .option(QbeastOptions.TXN_APP_ID, "test2")
+          .option(QbeastOptions.TXN_VERSION, "1")
+          .mode(SaveMode.Append)
+          .save(tmpDir)
+        spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+    }
+
+  it should "process transaction with different version while staging data" in
+    withExtendedSparkAndTmpDir(
+      sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+      (spark, tmpDir) =>
+        val data = makeDataFrame(spark)
+        data.write
+          .format("qbeast")
+          .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+          .option(QbeastOptions.CUBE_SIZE, 1)
+          .option(QbeastOptions.TXN_APP_ID, "test")
+          .option(QbeastOptions.TXN_VERSION, "1")
+          .save(tmpDir)
+        data.write
+          .format("qbeast")
+          .option(QbeastOptions.TXN_APP_ID, "test")
+          .option(QbeastOptions.TXN_VERSION, "2")
+          .mode(SaveMode.Append)
+          .save(tmpDir)
+        spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+    }
+
+  it should "process implicit transaction while indexing data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
+    val data = makeDataFrame(spark)
+    data.write
+      .format("qbeast")
+      .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+      .option(QbeastOptions.CUBE_SIZE, 1)
+      .option(QbeastOptions.TXN_APP_ID, "test")
+      .option(QbeastOptions.TXN_VERSION, "1")
+      .save(tmpDir)
+    data.write
+      .format("qbeast")
+      .mode(SaveMode.Append)
+      .save(tmpDir)
+    spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  it should "process implicit transaction while staging data" in withExtendedSparkAndTmpDir(
+    sparkConfWithSqlAndCatalog.set("spark.qbeast.index.stagingSizeInBytes", "1000000")) {
+    (spark, tmpDir) =>
+      val data = makeDataFrame(spark)
+      data.write
+        .format("qbeast")
+        .option(QbeastOptions.COLUMNS_TO_INDEX, "id")
+        .option(QbeastOptions.CUBE_SIZE, 1)
+        .option(QbeastOptions.TXN_APP_ID, "test")
+        .option(QbeastOptions.TXN_VERSION, "1")
+        .save(tmpDir)
+      data.write
+        .format("qbeast")
+        .mode(SaveMode.Append)
+        .save(tmpDir)
+      spark.read.format("qbeast").load(tmpDir).count() shouldBe data.count() * 2
+  }
+
+  private def makeDataFrame(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    (1 to 3).map(i => Student(i, i.toString(), Random.nextInt)).toDF()
+  }
+
+}


### PR DESCRIPTION
## Description

This is a backport of txnAppId and txnVersion support from the main-1.0.0 branch. 

## Type of change

This is a new feature for implementing idempotent writes backported from main-1.0.0, so it is an extension which does not introduce any changes in the data format, and it is backward compatible. The documentation is updated to provide information about the use and semantics of the txnAppId and txnVersion options.

## Checklist:

- [ x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ x] Add comments to the code (make it easier for the community!).
- [ x] Change the documentation.
- [ x] Add tests.
- [ x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

- Test io.qbeast.spark.utils.QbeastSparkTxnTest is added to test idempotent writes based on the added options