### PR TITLE
#256 backport to main publishing to local Ivy and Maven turned on

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,21 @@ $SPARK_HOME/bin/spark-shell \
 --conf spark.sql.extensions=io.qbeast.spark.internal.QbeastSparkSessionExtension
 ```
 
+### 4. Publishing artefacts in the local repository
+Sometimes it is convenient to have custom versions of the library to be
+published in the local repository like IVy or Maven. For local Ivy (`~/.ivy2`)
+use
+
+```bash
+sbt publishLocal
+```
+
+For local Maven (~/.m2) use
+
+```bash
+sbt publishM2
+```
+
 <br/>
 
 # Community Values

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,7 @@ lazy val qbeastSpark = (project in file("."))
       hadoopAws % Test),
     Test / parallelExecution := false,
     assembly / test := {},
-    assembly / assemblyOption := (assembly / assemblyOption).value.copy(includeScala = false),
-    publish / skip := true)
+    assembly / assemblyOption := (assembly / assemblyOption).value.copy(includeScala = false))
   .settings(noWarningInConsole)
 
 qbeastSpark / Compile / doc / scalacOptions ++= Seq(


### PR DESCRIPTION
## Description

This is a change in the build script that allows to publish build snapshots in the local repos. It does not affect the client code at all.

## Type of change

This is an enhancement that simplifies the developing applications on the top of qbeast-spark. Neither client API nor storage format are affected.

## Checklist:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [ ] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Manual testing is the only available, because it is a change in the project infrastructure.