### PR TITLE
267 Remove redundant metadata creations

### DIFF
--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
@@ -185,6 +185,8 @@ private[delta] class QbeastMetadataOperation extends ImplicitMetadataOperation w
       }
       errorBuilder.finalizeAndThrow(spark.sessionState.conf)
     } else if (hasRevisionUpdate) {
+      // Aside from rewrites and schema changes, we will update the metadata only
+      // when there's a Revision update. Metadata entries interrupt concurrent writes.
       txn.updateMetadata(txn.metadata.copy(configuration = configuration))
     }
   }

--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
@@ -143,7 +143,7 @@ private[delta] class QbeastMetadataOperation extends ImplicitMetadataOperation w
 
     // Qbeast configuration metadata
     val (configuration, hasRevisionUpdate) =
-      if (isNewRevision || isOverwriteMode)
+      if (isNewRevision || isOverwriteMode || tableChanges.isOptimizeOperation)
         (updateQbeastRevision(baseConfiguration, latestRevision), true)
       else (baseConfiguration, false)
 

--- a/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
+++ b/src/main/scala/io/qbeast/spark/delta/QbeastMetadataOperation.scala
@@ -142,10 +142,10 @@ private[delta] class QbeastMetadataOperation extends ImplicitMetadataOperation w
       else txn.metadata.configuration
 
     // Qbeast configuration metadata
-    val configuration =
-      if (isNewRevision || isOverwriteMode) {
-        updateQbeastRevision(baseConfiguration, latestRevision)
-      } else baseConfiguration
+    val (configuration, hasRevisionUpdate) =
+      if (isNewRevision || isOverwriteMode)
+        (updateQbeastRevision(baseConfiguration, latestRevision), true)
+      else (baseConfiguration, false)
 
     if (txn.readVersion == -1) {
       super.updateMetadata(
@@ -165,8 +165,7 @@ private[delta] class QbeastMetadataOperation extends ImplicitMetadataOperation w
       recordDeltaEvent(txn.deltaLog, "delta.ddl.overwriteSchema")
       if (rearrangeOnly) {
         throw DeltaErrors.unexpectedDataChangeException(
-          "Overwrite the Delta table schema or " +
-            "change the partition schema")
+          "Overwrite the Delta table schema or change the partition schema")
       }
       txn.updateMetadata(newMetadata)
     } else if (isNewSchema && canMergeSchema) {
@@ -185,7 +184,9 @@ private[delta] class QbeastMetadataOperation extends ImplicitMetadataOperation w
         errorBuilder.addSchemaMismatch(txn.metadata.schema, dataSchema, txn.metadata.id)
       }
       errorBuilder.finalizeAndThrow(spark.sessionState.conf)
-    } else txn.updateMetadata(txn.metadata.copy(configuration = configuration))
+    } else if (hasRevisionUpdate) {
+      txn.updateMetadata(txn.metadata.copy(configuration = configuration))
+    }
   }
 
   override protected val canMergeSchema: Boolean = true

--- a/src/test/scala/io/qbeast/spark/keeper/ProtocolMockTest.scala
+++ b/src/test/scala/io/qbeast/spark/keeper/ProtocolMockTest.scala
@@ -106,7 +106,7 @@ class ProtocolMockTest extends ProtocolMockTestSpec {
   }
 
   "A write timout" should
-    "not cause inconsistency when a a timeout may interfere with an optimization" in withContext(
+    "not cause inconsistency when a timeout may interfere with an optimization" in withContext(
       LocalKeeper) { context =>
       implicit val keeper = LocalKeeper
       val initProcess = new InitProcess(context)


### PR DESCRIPTION
## Description
Fixes #267

We make no metadata updates unless a write involves revision change or replication.
An appends that's unaware of the Replication that happened after its own write started will cause inconsistencies.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested?
- An Append that neither changes the schema nor updates the Revision should not create metadata log entry.
