### PR TITLE
Add user metadata option

### DIFF
--- a/src/main/scala/io/qbeast/spark/delta/SparkDeltaMetadataManager.scala
+++ b/src/main/scala/io/qbeast/spark/delta/SparkDeltaMetadataManager.scala
@@ -33,6 +33,9 @@ object SparkDeltaMetadataManager extends MetadataManager[StructType, FileAction,
       deltaOptions += DeltaOptions.TXN_APP_ID -> txnAppId
       deltaOptions += DeltaOptions.TXN_VERSION -> txnVersion
     }
+    if (options.userMetadata.nonEmpty) {
+      deltaOptions += DeltaOptions.USER_METADATA_OPTION -> options.userMetadata.get
+    }
     val metadataWriter = DeltaMetadataWriter(
       tableID,
       mode,

--- a/src/main/scala/io/qbeast/spark/delta/StagingDataManager.scala
+++ b/src/main/scala/io/qbeast/spark/delta/StagingDataManager.scala
@@ -109,6 +109,10 @@ private[spark] class StagingDataManager(tableID: QTableID) extends DeltaStagingU
         .option(DeltaOptions.TXN_VERSION, txnVersion)
         .option(DeltaOptions.TXN_APP_ID, txnAppId)
     }
+    if (options.userMetadata.nonEmpty) {
+      writer = writer
+        .option(DeltaOptions.USER_METADATA_OPTION, options.userMetadata.get)
+    }
     writer.save(tableID.id)
 
     // Convert if the table is not yet qbeast

--- a/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
+++ b/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
@@ -24,25 +24,29 @@ import org.apache.spark.sql.SparkSession
  *   the transaction identifier
  * @param txnAppId
  *   the application identifier
+ * @param userMetadata
+ *   user-provided metadata for each CommitInfo
  */
 case class QbeastOptions(
     columnsToIndex: Seq[String],
     cubeSize: Int,
     stats: Option[DataFrame],
     txnAppId: Option[String],
-    txnVersion: Option[String])
+    txnVersion: Option[String],
+    userMetadata: Option[String])
 
 /**
  * Options available when trying to write in qbeast format
  */
 
 object QbeastOptions {
-  val COLUMNS_TO_INDEX = "columnsToIndex"
-  val CUBE_SIZE = "cubeSize"
-  val PATH = "path"
-  val STATS = "columnStats"
-  val TXN_APP_ID = DeltaOptions.TXN_APP_ID
-  val TXN_VERSION = DeltaOptions.TXN_VERSION
+  val COLUMNS_TO_INDEX: String = "columnsToIndex"
+  val CUBE_SIZE: String = "cubeSize"
+  val PATH: String = "path"
+  val STATS: String = "columnStats"
+  val TXN_APP_ID: String = DeltaOptions.TXN_APP_ID
+  val TXN_VERSION: String = DeltaOptions.TXN_VERSION
+  val USER_METADATA: String = DeltaOptions.USER_METADATA_OPTION
 
   /**
    * Gets the columns to index from the options
@@ -102,6 +106,9 @@ object QbeastOptions {
   private def getTxnVersion(options: Map[String, String]): Option[String] =
     options.get(TXN_VERSION)
 
+  private def getUserMetadata(options: Map[String, String]): Option[String] =
+    options.get(USER_METADATA)
+
   /**
    * Create QbeastOptions object from options map
    * @param options
@@ -115,13 +122,15 @@ object QbeastOptions {
     val stats = getStats(options)
     val txnAppId = getTxnAppId(options)
     val txnVersion = getTxnVersion(options)
-    QbeastOptions(columnsToIndex, desiredCubeSize, stats, txnAppId, txnVersion)
+    val userMetadata = getUserMetadata(options)
+    QbeastOptions(columnsToIndex, desiredCubeSize, stats, txnAppId, txnVersion, userMetadata)
   }
 
   /**
    * The empty options to be used as a placeholder.
    */
-  lazy val empty: QbeastOptions = QbeastOptions(Seq.empty, DEFAULT_CUBE_SIZE, None, None, None)
+  lazy val empty: QbeastOptions =
+    QbeastOptions(Seq.empty, DEFAULT_CUBE_SIZE, None, None, None, None)
 
   def loadTableIDFromParameters(parameters: Map[String, String]): QTableID = {
     new QTableID(

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSparkTxnTest.scala
@@ -48,7 +48,7 @@ class QbeastSparkTxnTest extends QbeastIntegrationTestSpec {
       transaction.version shouldBe 1
   }
 
-  it should "ignore aleady processed transaction while indexing data" in withExtendedSparkAndTmpDir(
+  it should "ignore already processed transaction while indexing data" in withExtendedSparkAndTmpDir(
     sparkConfWithSqlAndCatalog) { (spark, tmpDir) =>
     val data = makeDataFrame(spark)
     data.write


### PR DESCRIPTION
## Description
Add extra write options for `userMetadata`.

```scala
(df
  .write
  .mode("append")
  .option("userMetadata", userMetadataString)
  .format("qbeast")
  .save("/tmp/test/")
)
```

The list of `userMetadata` can be queried as follows:
```scala
import io.delta.tables._

val deltaTable = DeltaTable.forPath(spark, pathToTable)
val fullUserMetadata = deltaTable.history().select("userMetadata")
fullUserMetadata.show()
```

## Type of change
This is a new feature.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [ ] Your branch is updated to the main-1.0.0 branch (dependent changes have been merged).
