### PR TITLE
Issue 288: Add log messages

### DIFF
--- a/src/main/scala/io/qbeast/spark/delta/writer/BlockWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/BlockWriter.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapred.TaskAttemptContextImpl
 import org.apache.hadoop.mapred.TaskAttemptID
 import org.apache.hadoop.mapreduce.TaskType
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.execution.datasources.OutputWriter
@@ -67,7 +68,8 @@ case class BlockWriter(
     statsTrackers: Seq[WriteJobStatsTracker],
     qbeastColumns: QbeastColumns,
     tableChanges: TableChanges)
-    extends Serializable {
+    extends Serializable
+    with Logging {
 
   /**
    * Writes rows in corresponding files
@@ -131,6 +133,8 @@ case class BlockWriter(
         .setModificationTime(fileStatus.getModificationTime())
         .setRevisionId(revision.revisionID)
         .result()
+
+      logInfo(s"Qbeast: Adding file $file")
       val addFile = IndexFiles.toAddFile()(file)
 
       (addFile, taskStats)

--- a/src/main/scala/io/qbeast/spark/delta/writer/BlockWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/BlockWriter.scala
@@ -136,10 +136,10 @@ case class BlockWriter(
 
       logInfo(s"Adding file ${file.path}")
       logDebug(s"""Additional file information:
-              | path=${file.path},
-              | size=${file.size},
-              | modificationTime=${file.modificationTime},
-              | revision=${file.revisionId}""".stripMargin)
+              |path=${file.path},
+              |size=${file.size},
+              |modificationTime=${file.modificationTime},
+              |revision=${file.revisionId}""".stripMargin.replaceAll("\n", " "))
       val addFile = IndexFiles.toAddFile()(file)
 
       (addFile, taskStats)

--- a/src/main/scala/io/qbeast/spark/delta/writer/BlockWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/BlockWriter.scala
@@ -134,7 +134,12 @@ case class BlockWriter(
         .setRevisionId(revision.revisionID)
         .result()
 
-      logInfo(s"Qbeast: Adding file $file")
+      logInfo(s"Adding file ${file.path}")
+      logDebug(s"""Additional file information:
+              | path=${file.path},
+              | size=${file.size},
+              | modificationTime=${file.modificationTime},
+              | revision=${file.revisionId}""".stripMargin)
       val addFile = IndexFiles.toAddFile()(file)
 
       (addFile, taskStats)

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -326,7 +326,9 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
       dataFrame: DataFrame,
       indexStatus: IndexStatus,
       isReplication: Boolean): (DataFrame, TableChanges) = {
-    logTrace(s"Begin: analyze for index ${indexStatus.revision}")
+    // For logging purposes
+    val indexStatusRevision = indexStatus.revision
+    logTrace(s"Begin: analyze for index with revision=$indexStatusRevision and isReplication=$isReplication")
 
     // Compute the statistics for the indexedColumns
     val columnTransformers = indexStatus.revision.columnTransformers
@@ -358,7 +360,7 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
           computePartitionCubeDomains(numElements, newRevision, indexStatus, isReplication))
 
     // Compute global cube domains for the current write
-    logDebug(s"Computing global cube domains for index ${indexStatus.revision}")
+    logDebug(s"Computing global cube domains for index $indexStatusRevision")
     val globalCubeDomains: Map[CubeId, Double] =
       partitionCubeDomains
         .transform(computeGlobalCubeDomains(newRevision))
@@ -366,11 +368,11 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
         .toMap
 
     // Merge globalCubeDomain with the existing cube domains
-    logDebug(s"Merging global cube domains for index ${indexStatus.revision}")
+    logDebug(s"Merging global cube domains for index $indexStatusRevision")
     val mergedCubeDomains: Map[CubeId, Double] = mergeCubeDomains(globalCubeDomains, indexStatus)
 
     // Populate NormalizedWeight level-wise from top to bottom
-    logDebug(s"Estimating cube weights for index ${indexStatus.revision}, ${isReplication}")
+    logDebug(s"Estimating cube weights for index $indexStatusRevision")
     val estimatedCubeWeights: Map[CubeId, NormalizedWeight] =
       estimateCubeWeights(mergedCubeDomains.toSeq, indexStatus, isReplication)
 
@@ -384,7 +386,7 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
       else Set.empty[CubeId])
 
     val result = (weightedDataFrame, tableChanges)
-    logTrace(s"End: analyze for index ${indexStatus.revision}")
+    logTrace(s"End: analyze for index $indexStatusRevision")
     result
   }
 

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -328,9 +328,9 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
       isReplication: Boolean): (DataFrame, TableChanges) = {
     // For logging purposes
     val indexStatusRevision = indexStatus.revision
-    logTrace(s"""Begin: analyze for index with
-              | revision=$indexStatusRevision
-              | and isReplication=$isReplication""".stripMargin)
+    logTrace(s"""Begin: Analyze for index with
+              |revision=$indexStatusRevision
+              |isReplication=$isReplication""".stripMargin.replaceAll("\n", " "))
 
     // Compute the statistics for the indexedColumns
     val columnTransformers = indexStatus.revision.columnTransformers

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -328,8 +328,9 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
       isReplication: Boolean): (DataFrame, TableChanges) = {
     // For logging purposes
     val indexStatusRevision = indexStatus.revision
-    logTrace(
-      s"Begin: analyze for index with revision=$indexStatusRevision and isReplication=$isReplication")
+    logTrace(s"""Begin: analyze for index with
+              | revision=$indexStatusRevision
+              | and isReplication=$isReplication""".stripMargin)
 
     // Compute the statistics for the indexedColumns
     val columnTransformers = indexStatus.revision.columnTransformers

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -350,6 +350,7 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
       case None => indexStatus.revision
       case Some(revisionChange) => revisionChange.createNewRevision
     }
+    logDebug(s"newRevision=$newRevision")
 
     // Add a random weight column
     val weightedDataFrame = dataFrame.transform(addRandomWeight(newRevision))
@@ -361,7 +362,7 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
           computePartitionCubeDomains(numElements, newRevision, indexStatus, isReplication))
 
     // Compute global cube domains for the current write
-    logDebug(s"Computing global cube domains for index $indexStatusRevision")
+    logDebug(s"Computing global cube domains for index revision $indexStatusRevision")
     val globalCubeDomains: Map[CubeId, Double] =
       partitionCubeDomains
         .transform(computeGlobalCubeDomains(newRevision))
@@ -369,11 +370,11 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
         .toMap
 
     // Merge globalCubeDomain with the existing cube domains
-    logDebug(s"Merging global cube domains for index $indexStatusRevision")
+    logDebug(s"Merging global cube domains for index revision $indexStatusRevision")
     val mergedCubeDomains: Map[CubeId, Double] = mergeCubeDomains(globalCubeDomains, indexStatus)
 
     // Populate NormalizedWeight level-wise from top to bottom
-    logDebug(s"Estimating cube weights for index $indexStatusRevision")
+    logDebug(s"Estimating cube weights for index revision $indexStatusRevision")
     val estimatedCubeWeights: Map[CubeId, NormalizedWeight] =
       estimateCubeWeights(mergedCubeDomains.toSeq, indexStatus, isReplication)
 
@@ -387,7 +388,7 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
       else Set.empty[CubeId])
 
     val result = (weightedDataFrame, tableChanges)
-    logTrace(s"End: analyze for index $indexStatusRevision")
+    logTrace(s"End: analyze for index with revision $indexStatusRevision")
     result
   }
 

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -328,7 +328,8 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable w
       isReplication: Boolean): (DataFrame, TableChanges) = {
     // For logging purposes
     val indexStatusRevision = indexStatus.revision
-    logTrace(s"Begin: analyze for index with revision=$indexStatusRevision and isReplication=$isReplication")
+    logTrace(
+      s"Begin: analyze for index with revision=$indexStatusRevision and isReplication=$isReplication")
 
     // Compute the statistics for the indexedColumns
     val columnTransformers = indexStatus.revision.columnTransformers

--- a/src/main/scala/io/qbeast/spark/index/SparkOTreeManager.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkOTreeManager.scala
@@ -17,12 +17,13 @@ package io.qbeast.spark.index
 
 import io.qbeast.core.model._
 import io.qbeast.IISeq
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.DataFrame
 
 /**
  * Implementation of OTreeAlgorithm.
  */
-object SparkOTreeManager extends IndexManager[DataFrame] with Serializable {
+object SparkOTreeManager extends IndexManager[DataFrame] with Serializable with Logging {
 
   /**
    * Builds an OTree index.
@@ -82,6 +83,7 @@ object SparkOTreeManager extends IndexManager[DataFrame] with Serializable {
       dataFrame: DataFrame,
       indexStatus: IndexStatus,
       isReplication: Boolean): (DataFrame, TableChanges) = {
+    logTrace(s"Begin: index with revision ${indexStatus.revision}")
     // Analyze the data and compute weight and estimated weight map of the result
     val (weightedDataFrame, tc) =
       DoublePassOTreeDataAnalyzer.analyze(dataFrame, indexStatus, isReplication)
@@ -92,7 +94,9 @@ object SparkOTreeManager extends IndexManager[DataFrame] with Serializable {
     val indexedDataFrame =
       weightedDataFrame.transform(pointWeightIndexer.buildIndex)
 
-    (indexedDataFrame, tc)
+    val result = (indexedDataFrame, tc)
+    logTrace(s"End: index with revision ${indexStatus.revision}")
+    result
   }
 
 }

--- a/src/main/scala/io/qbeast/spark/index/SparkOTreeManager.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkOTreeManager.scala
@@ -83,7 +83,7 @@ object SparkOTreeManager extends IndexManager[DataFrame] with Serializable with 
       dataFrame: DataFrame,
       indexStatus: IndexStatus,
       isReplication: Boolean): (DataFrame, TableChanges) = {
-    logTrace(s"Begin: index with revision ${indexStatus.revision}")
+    logTrace(s"Begin: Index with revision ${indexStatus.revision}")
     // Analyze the data and compute weight and estimated weight map of the result
     val (weightedDataFrame, tc) =
       DoublePassOTreeDataAnalyzer.analyze(dataFrame, indexStatus, isReplication)

--- a/src/main/scala/io/qbeast/spark/index/SparkOTreeManager.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkOTreeManager.scala
@@ -95,7 +95,7 @@ object SparkOTreeManager extends IndexManager[DataFrame] with Serializable with 
       weightedDataFrame.transform(pointWeightIndexer.buildIndex)
 
     val result = (indexedDataFrame, tc)
-    logTrace(s"End: index with revision ${indexStatus.revision}")
+    logTrace(s"End: Index with revision ${indexStatus.revision}")
     result
   }
 

--- a/src/main/scala/io/qbeast/spark/internal/sources/QbeastDataSource.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/QbeastDataSource.scala
@@ -76,6 +76,7 @@ class QbeastDataSource private[sources] (private val tableFactory: IndexedTableF
         "columnsToIndex" -> currentRevision.columnTransformers.map(_.columnName).mkString(","),
         "cubeSize" -> currentRevision.desiredCubeSize.toString)
       val tableProperties = properties.asScala.toMap ++ indexProperties
+      logDebug(s"Table ${tableId} properties: ${tableProperties}")
       new QbeastTableImpl(
         TableIdentifier(tableId.id),
         new Path(tableId.id),

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -25,6 +25,7 @@ import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.internal.QbeastOptions.checkQbeastProperties
 import io.qbeast.spark.internal.QbeastOptions.COLUMNS_TO_INDEX
 import io.qbeast.spark.internal.QbeastOptions.CUBE_SIZE
+import org.apache.spark.internal.Logging
 import org.apache.spark.qbeast.config.COLUMN_SELECTOR_ENABLED
 import org.apache.spark.qbeast.config.DEFAULT_NUMBER_OF_RETRIES
 import org.apache.spark.sql.delta.actions.FileAction
@@ -214,7 +215,8 @@ private[table] class IndexedTableImpl(
     private val revisionFactory: RevisionFactory[StructType, QbeastOptions],
     private val columnSelector: ColumnsToIndexSelector[DataFrame])
     extends IndexedTable
-    with StagingUtils {
+    with StagingUtils
+    with Logging {
   private var snapshotCache: Option[QbeastSnapshot] = None
 
   /**
@@ -325,11 +327,13 @@ private[table] class IndexedTableImpl(
       data: DataFrame,
       parameters: Map[String, String],
       append: Boolean): BaseRelation = {
+    logTrace(s"Begin: save table ${tableID}")
     val (indexStatus, options) =
       if (exists && append) {
         // If the table exists and we are appending new data
         // 1. Load existing IndexStatus
         val options = QbeastOptions(verifyAndMergeProperties(parameters))
+        logDebug(s"Appending data to table ${tableID}, ${latestRevision.revisionID}")
         if (isStaging(latestRevision)) { // If the existing Revision is Staging
           val revision = revisionFactory.createNewRevision(tableID, data.schema, options)
           (IndexStatus(revision), options)
@@ -340,6 +344,8 @@ private[table] class IndexedTableImpl(
               .createNewRevision(tableID, data.schema, options)
             val newRevisionCubeSize = newPotentialRevision.desiredCubeSize
             // Merge new Revision Transformations with old Revision Transformations
+            logDebug(
+              s"Merging transformations for table ${tableID}, with cube size ${newRevisionCubeSize}")
             val newRevisionTransformations =
               latestRevision.transformations.zip(newPotentialRevision.transformations).map {
                 case (oldTransformation, newTransformation)
@@ -354,12 +360,15 @@ private[table] class IndexedTableImpl(
               timestamp = System.currentTimeMillis(),
               desiredCubeSizeChange = Some(newRevisionCubeSize),
               transformationsChanges = newRevisionTransformations)
+            logDebug(s"Creating new revision changes for table ${tableID}, ${revisionChanges})")
 
             // Output the New Revision into the IndexStatus
             (IndexStatus(revisionChanges.createNewRevision), options)
           } else {
             // If the new parameters does not create a different revision,
             // load the latest IndexStatus
+            logDebug(
+              s"Loading latest revision for table ${tableID}, with revision ${latestRevision.revisionID}")
             (snapshot.loadIndexStatus(latestRevision.revisionID), options)
           }
         }
@@ -370,7 +379,9 @@ private[table] class IndexedTableImpl(
         val revision = revisionFactory.createNewRevision(tableID, data.schema, options)
         (IndexStatus(revision), options)
       }
-    write(data, indexStatus, options, append)
+    val result = write(data, indexStatus, options, append)
+    logTrace(s"End: save table ${tableID}")
+    result
   }
 
   override def load(): BaseRelation = {
@@ -403,7 +414,9 @@ private[table] class IndexedTableImpl(
       indexStatus: IndexStatus,
       options: QbeastOptions,
       append: Boolean): BaseRelation = {
+    logTrace(s"Begin: Writing data to table ${tableID}")
     val revision = indexStatus.revision
+    logDebug(s"Writing data to table ${tableID}, with revision ${revision.revisionID}")
     keeper.withWrite(tableID, revision.revisionID) { write =>
       var tries = DEFAULT_NUMBER_OF_RETRIES
       while (tries > 0) {
@@ -431,7 +444,9 @@ private[table] class IndexedTableImpl(
       }
     }
     clearCaches()
-    createQbeastBaseRelation()
+    val result = createQbeastBaseRelation()
+    logTrace(s"End: Done writing data to table ${tableID}")
+    result
   }
 
   private def doWrite(
@@ -439,6 +454,7 @@ private[table] class IndexedTableImpl(
       indexStatus: IndexStatus,
       options: QbeastOptions,
       append: Boolean): Unit = {
+    logTrace(s"Begin: Writing data to table ${tableID}")
     val stagingDataManager: StagingDataManager = new StagingDataManager(tableID)
     stagingDataManager.updateWithStagedData(data) match {
       case r: StagingResolution if r.sendToStaging =>
@@ -452,6 +468,7 @@ private[table] class IndexedTableImpl(
           (tableChanges, fileActions ++ removeFiles)
         }
     }
+    logTrace(s"End: Writing data to table ${tableID}")
   }
 
   override def analyze(revisionID: RevisionID): Seq[String] = {

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -381,7 +381,7 @@ private[table] class IndexedTableImpl(
         (IndexStatus(revision), options)
       }
     val result = write(data, indexStatus, options, append)
-    logTrace(s"End: save table ${tableID}")
+    logTrace(s"End: Save table ${tableID}")
     result
   }
 

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -360,7 +360,8 @@ private[table] class IndexedTableImpl(
               timestamp = System.currentTimeMillis(),
               desiredCubeSizeChange = Some(newRevisionCubeSize),
               transformationsChanges = newRevisionTransformations)
-            logDebug(s"Creating new revision changes for table ${tableID} with revisionChanges=${revisionChanges})")
+            logDebug(
+              s"Creating new revision changes for table ${tableID} with revisionChanges=${revisionChanges})")
 
             // Output the New Revision into the IndexStatus
             (IndexStatus(revisionChanges.createNewRevision), options)

--- a/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/spark/table/IndexedTable.scala
@@ -333,7 +333,7 @@ private[table] class IndexedTableImpl(
         // If the table exists and we are appending new data
         // 1. Load existing IndexStatus
         val options = QbeastOptions(verifyAndMergeProperties(parameters))
-        logDebug(s"Appending data to table ${tableID}, ${latestRevision.revisionID}")
+        logDebug(s"Appending data to table ${tableID} with revision=${latestRevision.revisionID}")
         if (isStaging(latestRevision)) { // If the existing Revision is Staging
           val revision = revisionFactory.createNewRevision(tableID, data.schema, options)
           (IndexStatus(revision), options)
@@ -345,7 +345,7 @@ private[table] class IndexedTableImpl(
             val newRevisionCubeSize = newPotentialRevision.desiredCubeSize
             // Merge new Revision Transformations with old Revision Transformations
             logDebug(
-              s"Merging transformations for table ${tableID}, with cube size ${newRevisionCubeSize}")
+              s"Merging transformations for table ${tableID} with cubeSize=${newRevisionCubeSize}")
             val newRevisionTransformations =
               latestRevision.transformations.zip(newPotentialRevision.transformations).map {
                 case (oldTransformation, newTransformation)
@@ -360,7 +360,7 @@ private[table] class IndexedTableImpl(
               timestamp = System.currentTimeMillis(),
               desiredCubeSizeChange = Some(newRevisionCubeSize),
               transformationsChanges = newRevisionTransformations)
-            logDebug(s"Creating new revision changes for table ${tableID}, ${revisionChanges})")
+            logDebug(s"Creating new revision changes for table ${tableID} with revisionChanges=${revisionChanges})")
 
             // Output the New Revision into the IndexStatus
             (IndexStatus(revisionChanges.createNewRevision), options)
@@ -368,7 +368,7 @@ private[table] class IndexedTableImpl(
             // If the new parameters does not create a different revision,
             // load the latest IndexStatus
             logDebug(
-              s"Loading latest revision for table ${tableID}, with revision ${latestRevision.revisionID}")
+              s"Loading latest revision for table ${tableID} with revision=${latestRevision.revisionID}")
             (snapshot.loadIndexStatus(latestRevision.revisionID), options)
           }
         }
@@ -416,7 +416,7 @@ private[table] class IndexedTableImpl(
       append: Boolean): BaseRelation = {
     logTrace(s"Begin: Writing data to table ${tableID}")
     val revision = indexStatus.revision
-    logDebug(s"Writing data to table ${tableID}, with revision ${revision.revisionID}")
+    logDebug(s"Writing data to table ${tableID} with revision ${revision.revisionID}")
     keeper.withWrite(tableID, revision.revisionID) { write =>
       var tries = DEFAULT_NUMBER_OF_RETRIES
       while (tries > 0) {


### PR DESCRIPTION
## Description
It adds log messages to be able to trace activity when executing such as the following:

```
spark_data.write.format("qbeast")
            .mode("append")
            .options(**qbeast_options)
            .save(output_path)
```

The code at the moment is very scarce on log messages, in factr, I couldn't find any in the part of the code I was inspecting. It is going to take multiple PRs to populate the code base with logging messages appropriately.

Fixes #288

## Type of change
It is adding log messages using the spark internal logging trait. As such, we have to add a line to specific classes to have them using `org.apache.spark.internal.Logging`. 

In the log messages I added so far, I have prefixed it with `Qbeast: ` to make it easier to locate the messages among all INFO messages that Spark generated. That's not ideal, and I'd much rather have the logs printing the fully-qualified class name. We might want to change it before merging.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)
I have validated locally with `spark-shell` that the messages are printing.   

**Test Configuration**:
* Spark Version: 3.5.0
* Hadoop Version:
* Cluster or local? Local