### PR TITLE
Issue 297: Reduce overhead for CubeDomainsBuilder instantiation

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/CubeDomainsBuilder.scala
+++ b/core/src/main/scala/io/qbeast/core/model/CubeDomainsBuilder.scala
@@ -209,14 +209,26 @@ class CubeDomainsBuilder protected (
  */
 private class WeightAndCountFactory(existingCubeWeights: Map[CubeId, Weight]) {
 
+  /**
+   * Create an instance of WeightAndCount for a given cube depending on its status in the existing
+   * index
+   * @param cubeId
+   *   CubeId to create a WeightAndCount for
+   * @return
+   *   WeightAndCount
+   */
   def create(cubeId: CubeId): WeightAndCount =
     existingCubeWeights.get(cubeId) match {
       case Some(w: Weight) if NormalizedWeight(w) < 1.0 =>
+        // cubeId present in the existing index as an inner cube
         new InnerCubeWeightAndCount(w)
       case Some(_: Weight) =>
+        // cubeId present in the existing index as a leaf cube
         val leafSize = 0
         new LeafCubeWeightAndCount(leafSize)
-      case None => new WeightAndCount(MaxValue, 0)
+      case None =>
+        // cubeId not present in the existing index
+        new WeightAndCount(MaxValue, 0)
     }
 
 }

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -145,13 +145,21 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable {
       val numPartitions: Int = weightedDataFrame.rdd.getNumPartitions
       val bufferCapacity: Long = CUBE_WEIGHTS_BUFFER_CAPACITY
 
+      // Broadcast large objects for CubeDomainsBuilder
+      val broadcastExistingCubeWeights = SparkSession.active.sparkContext.broadcast(
+        indexStatus.cubesStatuses.mapValues(_.maxWeight).map(identity))
+      val broadcastReplicatedOrAnnouncedSet =
+        SparkSession.active.sparkContext.broadcast(indexStatus.replicatedOrAnnouncedSet)
+
       val selected = weightedDataFrame.select(cols.map(col): _*)
       val weightIndex = selected.schema.fieldIndex(weightColumnName)
 
       selected
         .mapPartitions(rows => {
           val domains = CubeDomainsBuilder(
-            indexStatus = indexStatus,
+            existingCubeWeights = broadcastExistingCubeWeights.value,
+            replicatedOrAnnouncedSet = broadcastReplicatedOrAnnouncedSet.value,
+            desiredCubeSize = revision.desiredCubeSize,
             numPartitions = numPartitions,
             numElements = numElements,
             bufferCapacity = bufferCapacity)

--- a/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
+++ b/src/main/scala/io/qbeast/spark/index/OTreeDataAnalyzer.scala
@@ -146,10 +146,11 @@ object DoublePassOTreeDataAnalyzer extends OTreeDataAnalyzer with Serializable {
       val bufferCapacity: Long = CUBE_WEIGHTS_BUFFER_CAPACITY
 
       // Broadcast large objects for CubeDomainsBuilder
-      val broadcastExistingCubeWeights = SparkSession.active.sparkContext.broadcast(
-        indexStatus.cubesStatuses.mapValues(_.maxWeight).map(identity))
+      val broadcastExistingCubeWeights =
+        spark.sparkContext.broadcast(
+          indexStatus.cubesStatuses.mapValues(_.maxWeight).map(identity))
       val broadcastReplicatedOrAnnouncedSet =
-        SparkSession.active.sparkContext.broadcast(indexStatus.replicatedOrAnnouncedSet)
+        spark.sparkContext.broadcast(indexStatus.replicatedOrAnnouncedSet)
 
       val selected = weightedDataFrame.select(cols.map(col): _*)
       val weightIndex = selected.schema.fieldIndex(weightColumnName)


### PR DESCRIPTION
This PR Fixes #297 by

1. As the overhead comes from `CubeStatus`, we pass the required objects directly instead of `IndexStatus`
2. Use `Broadcast` so they persist in each worker so we don't have to pass them for each task
