### PR TITLE
Issue 299: Check columnsToIndex depending on user input

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
+++ b/core/src/main/scala/io/qbeast/core/model/RevisionClasses.scala
@@ -152,7 +152,15 @@ final case class Revision(
    *   true if the revision indexes all and only the provided columns.
    */
   def matchColumns(columnsToIndex: Seq[String]): Boolean = {
-    columnsToIndex.toSet == columnTransformers.map(_.columnName).toSet
+    columnsToIndex.size == columnTransformers.size && columnsToIndex
+      .zip(columnTransformers)
+      .forall { case (columnToIndex, t) =>
+        if (columnToIndex.contains(":")) {
+          columnToIndex == t.spec
+        } else {
+          columnToIndex == t.columnName
+        }
+      }
   }
 
   /**

--- a/core/src/test/scala/io/qbeast/core/model/RevisionTest.scala
+++ b/core/src/test/scala/io/qbeast/core/model/RevisionTest.scala
@@ -1,0 +1,26 @@
+package io.qbeast.core.model
+
+import io.qbeast.core.transform.LinearTransformer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RevisionTest extends AnyFlatSpec with Matchers {
+
+  "Revision" should "check indexing columns correctly" in {
+    val revision = Revision(
+      1L,
+      1L,
+      QTableID(""),
+      1,
+      Vector(LinearTransformer("col_1", IntegerDataType)),
+      Vector.empty)
+
+    revision.matchColumns(Seq("col_1")) shouldBe true
+    revision.matchColumns(Seq("col_1:linear")) shouldBe true
+
+    revision.matchColumns(Seq("col_2")) shouldBe false
+    revision.matchColumns(Seq("col_1", "col_2")) shouldBe false
+    revision.matchColumns(Seq("col_1:histogram")) shouldBe false
+  }
+
+}


### PR DESCRIPTION
## Description
Fixes #299. It compares the `columnsToIndex` to `Transformer` `columnName` or `spec` depending on user input.

## Type of change

Bug Fix

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Test `columnsToIndex` comparison
