### PR TITLE
Issue 315: Correct cube element counts for rollup during optimization

### DIFF
--- a/src/test/scala/io/qbeast/spark/delta/writer/RollupDataWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/writer/RollupDataWriterTest.scala
@@ -15,17 +15,22 @@
  */
 package io.qbeast.spark.delta.writer
 
+import io.qbeast.core.model.CubeId
 import io.qbeast.core.model.IndexStatus
 import io.qbeast.core.model.QTableID
+import io.qbeast.core.model.Revision
+import io.qbeast.core.transform.EmptyTransformer
+import io.qbeast.spark.index.QbeastColumns
 import io.qbeast.spark.index.SparkOTreeManager
 import io.qbeast.spark.index.SparkRevisionFactory
 import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.TestClasses._
+import org.scalatest.PrivateMethodTester
 
 import scala.reflect.io.Path
 
-class RollupDataWriterTest extends QbeastIntegrationTestSpec {
+class RollupDataWriterTest extends QbeastIntegrationTestSpec with PrivateMethodTester {
 
   "RollupDataWriter" should "write the data correctly" in
     withSparkAndTmpDir { (spark, tmpDir) =>
@@ -50,6 +55,26 @@ class RollupDataWriterTest extends QbeastIntegrationTestSpec {
         Path(tmpDir + "/" + fa.path).exists shouldBe true
         fa.dataChange shouldBe true
       }
+    }
+
+  it should "compute rollup correctly when optimizing" in
+    withSparkAndTmpDir { (spark, tmpDir) =>
+      import spark.implicits._
+
+      val computeRollup = PrivateMethod[Map[CubeId, CubeId]]('computeRollup)
+      val revision =
+        Revision(1L, 0, QTableID(tmpDir), 20, Vector(EmptyTransformer("col_1")), Vector.empty)
+
+      val root = revision.createCubeIdRoot()
+      val c1 = root.children.next()
+      val c2 = c1.nextSibling.get
+      val extendedData = Seq(
+        (1 to 20).map(_ => ("root", root.bytes)),
+        (1 to 1).map(_ => ("c1", c1.bytes)),
+        (1 to 20).map(_ => ("c2", c2.bytes))).flatten.toDF("id", QbeastColumns.cubeColumnName)
+
+      val rollup = RollupDataWriter invokePrivate computeRollup(revision, extendedData)
+      rollup shouldBe Map(root -> root, c1 -> root, c2 -> c2)
     }
 
 }


### PR DESCRIPTION
## Description

Fixes #315 

Instead of ignoring offsets, cube element counts are computed from the extended data.

## Type of change

It is a bug fix: #315

## Checklist:

- [x] New feature/bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)
Test correct rollup result: `RollupDataWriterTest`
