### PR TITLE
Issue 317: Reduce optimization overhead

### DIFF
--- a/src/main/scala/io/qbeast/spark/delta/writer/RollupDataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/RollupDataWriter.scala
@@ -293,7 +293,10 @@ object RollupDataWriter
       indexStatus: IndexStatus): DataFrame = {
     val spark = extendedData.sparkSession
     val cubeMaxWeightsBroadcast =
-      spark.sparkContext.broadcast(indexStatus.cubesStatuses.mapValues(_.maxWeight))
+      spark.sparkContext.broadcast(
+        indexStatus.cubesStatuses
+          .mapValues(_.maxWeight)
+          .map(identity))
     val columns = revision.columnTransformers.map(_.columnName)
     extendedData
       .withColumn(

--- a/src/main/scala/io/qbeast/spark/delta/writer/RollupDataWriter.scala
+++ b/src/main/scala/io/qbeast/spark/delta/writer/RollupDataWriter.scala
@@ -291,21 +291,26 @@ object RollupDataWriter
       extendedData: DataFrame,
       revision: Revision,
       indexStatus: IndexStatus): DataFrame = {
+    val spark = extendedData.sparkSession
+    val cubeMaxWeightsBroadcast =
+      spark.sparkContext.broadcast(indexStatus.cubesStatuses.mapValues(_.maxWeight))
     val columns = revision.columnTransformers.map(_.columnName)
     extendedData
       .withColumn(
         QbeastColumns.cubeColumnName,
-        getCubeIdUDF(revision, indexStatus)(
+        getCubeIdUDF(revision, cubeMaxWeightsBroadcast.value)(
           struct(columns.map(col): _*),
           col(QbeastColumns.weightColumnName)))
   }
 
-  private def getCubeIdUDF(revision: Revision, indexStatus: IndexStatus): UserDefinedFunction =
+  private def getCubeIdUDF(
+      revision: Revision,
+      cubeMaxWeights: Map[CubeId, Weight]): UserDefinedFunction =
     udf { (row: Row, weight: Int) =>
       val point = RowUtils.rowValuesToPoint(row, revision)
       val cubeId = CubeId.containers(point).find { cubeId =>
-        indexStatus.cubesStatuses.get(cubeId) match {
-          case Some(status) => weight <= status.maxWeight.value
+        cubeMaxWeights.get(cubeId) match {
+          case Some(maxWeight) => weight <= maxWeight.value
           case None => true
         }
       }
@@ -315,10 +320,11 @@ object RollupDataWriter
   private def extendDataWithCubeToRollup(
       extendedData: DataFrame,
       revision: Revision): DataFrame = {
-    val rollup = computeRollup(revision, extendedData)
+    val spark = extendedData.sparkSession
+    val rollupBroadcast = spark.sparkContext.broadcast(computeRollup(revision, extendedData))
     extendedData.withColumn(
       QbeastColumns.cubeToRollupColumnName,
-      getRollupCubeIdUDF(revision, rollup)(col(QbeastColumns.cubeColumnName)))
+      getRollupCubeIdUDF(revision, rollupBroadcast.value)(col(QbeastColumns.cubeColumnName)))
   }
 
   private def computeRollup(revision: Revision, extendedData: DataFrame): Map[CubeId, CubeId] = {


### PR DESCRIPTION
## Description

Fixes #317 through broadcasting rollup map and cube max Weights.

## Type of change

This is a bug fix - #317 

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature/bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [ ] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).