### PR TITLE
Issue 193: Update Index Metrics

### DIFF
--- a/docs/QbeastTable.md
+++ b/docs/QbeastTable.md
@@ -43,11 +43,10 @@ qbeastTable.optimize(Seq("file1", "file2")) // Optimizes the specific files
 
 ## Index Metrics
 
-`IndexMetrics` aims to provide an overview for a given revision of the index.
+`IndexMetrics` provides an overview of a given revision of the index.
 
-You can use it during development to compare different indexes built using different indexing parameters such as the `desiredCubeSize` and `columnsToIndex`.
+You can use it during development to compare indexes built using different indexing parameters such as the `desiredCubeSize` and `columnsToIndex.`
 
-This is meant to be used as an easy access point to analyze the resulting index, which should come handy for comparing different index parameters or even implementations.
 
 ```scala
 val metrics = qbeastTable.getIndexMetrics()
@@ -57,57 +56,98 @@ println(metrics)
 
 ```
 // EXAMPLE OUTPUT
-
 OTree Index Metrics:
+revisionId: 1
+elementCount: 309008
 dimensionCount: 2
-elementCount: 2879966589
-depth: 9
-cubeCount: 13141
-desiredCubeSize: 500000
-indexingColumns: ss_sold_date_sk,ss_item_sk
-avgFanout: 4.0
-depthOnBalance: 1.3567716601745503
+desiredCubeSize: 3000
+indexingColumns: price:linear,user_id:linear
+height: 8 (4)
+avgFanout: 3.94 (4.0)
+cubeCount: 230
+blockCount: 848
+fileCount: 61
+bytes: 11605372
 
-Stats on cube sizes:
-Quartiles:
-- min: 456367
-- 1stQ: 498510
-- 2ndQ: 499954
-- 3rdQ: 501410
-- max: 536430
-Stats:
-- count: 3285
-- l1_dev: 0.00449603896499239
-- l2_dev: 1.3487574366807247E-4
-Level-wise stats:
-level, avgCubeSize, stdCubeSize, cubeCount, avgWeight:
-- 0:	497810,		0,		1,	1.7361319627929786E-4
-- 1:	494798,		3550,		4,	8.689350799817908E-4
-- 2:	499781,		3488,		16,	0.003668841950401859
-- 3:	500516,		4292,		64,	0.015534089088738918
-- 4:	500289,		3967,		256,	0.06698862054431544
-- 5:	499966,		3530,		1024,	0.287867372830027
-- 6:	499962,		3040,		1792,	0.6729941083529944
-- 7:	500142,		10508,		128,	0.7959112180321912
+Multi-block files stats:
+cubeElementCountStats: (count: 230, avg: 1343, std: 1186, quartiles: (1,292,858,2966,3215))
+blockElementCountStats: (count: 848, avg: 364, std: 829, quartiles: (1,6,21,42,3120))
+fileBytesStats: (count: 61, avg: 190252, std: 57583, quartiles: (113168,139261,182180,215136,332851))
+blockCountPerCubeStats: (count: 230, avg: 3, std: 1, quartiles: (1,4,4,4,4))
+blockCountPerFileStats: (count: 61, avg: 13, std: 43, quartiles: (1,3,5,5,207))
+
+Inner cubes depth-wise stats:
+cubeElementCountStats: (count: 58, avg: 3069, std: 58, quartiles: (2942,3026,3070,3109,3215))
+blockElementCountStats: (count: 232, avg: 767, std: 1278, quartiles: (14,26,33,2859,3120))
+depth avgCubeElementCount cubeCount blockCount cubeElementCountStd cubeElementCountQuartiles  avgWeight           
+0     3026                1         4          0                   (3026,3026,3026,3026,3026) 0.009708486732493268
+1     3120                2         8          72                  (3048,3048,3193,3193,3193) 0.1777036037942636  
+2     3088                3         12         91                  (3003,3003,3048,3215,3215) 0.29339823296605566 
+3     3078                7         28         45                  (3016,3046,3070,3110,3168) 0.3028351948969015  
+4     3075                12        48         80                  (2942,3027,3084,3148,3214) 0.3853194593029685  
+5     3056                21        84         45                  (2975,3016,3066,3090,3127) 0.557916611995329   
+6     3071                12        48         37                  (2999,3055,3084,3111,3115) 0.71568557500894    
+
+Leaf cubes depth-wise stats:
+cubeElementCountStats: (count: 172, avg: 761, std: 733, quartiles: (1,163,584,1159,2966))
+blockElementCountStats: (count: 616, avg: 212, std: 498, quartiles: (1,4,10,36,2877))
+depth avgCubeElementCount cubeCount blockCount cubeElementCountStd cubeElementCountQuartiles avgWeight         
+1     47                  2         4          46                  (1,1,94,94,94)            1515.9574468085107
+2     358                 4         12         389                 (4,36,424,970,970)        210.8753971341503 
+3     1010                5         20         994                 (314,330,677,767,2966)    5.5998339972396405
+4     836                 14        45         951                 (4,38,315,1612,2552)      106.06026824809581
+5     978                 27        103        827                 (63,299,616,1681,2666)    8.58027316980015  
+6     811                 72        267        686                 (7,280,626,1253,2889)     21.17595889195726 
+7     580                 48        165        590                 (3,143,515,779,2246)      76.10800345961682  
 ```
 
 ## Metrics
 ### 1. General index metadata:
 
-- **dimensionCount**: the number of dimensions (indexed columns) in the index
+
+- **revisionId**: the identifier for the index revision
 - **elementCount**: the number of records for this revision
-- **desiredCubeSize**: the desired cube size chosen at the moment of indexing
-- **Number of cubes**: the number of nodes in the index tree
-- **depth**: the number of levels in the tree
-- **avgFanOut**: the average number of children per non-leaf cube. The max value for this metrics is `2 ^ dimensionCount`
-- **depthOnBalance**: how far the depth of the tree is from the theoretical value, assuming all inner cubes have max fan out
-- **indexingColumns**: the indexing column names
+- **dimensionCount**: the number of dimensions in the index
+- **desiredCubeSize**: the target number of elements per cube
+- **indexingColumns**: the columns that are indexed. The format is `column1:type,column2:type,...` where `type` is the transformation type applied to the column
+- **height**: the height of the tree. In parentheses, we have the theoretical height if the index is perfectly balanced
+- **avgFanOut**: the average number of children per non-leaf cube. In parentheses, we have the max value for this metric, which is equal to `2 ^ dimensionCount`
+- **cubeCount**: the total number of nodes in the index tree
+- **blockCount**: the number of blocks in the index tree
+- **fileCount**: the number of files in the index tree
+- **bytes**: the total size of the index tree in bytes
 
-### 2. Cube sizes stats:
-Meant to describe the distribution of cube sizes:
-- `metrics.innerCubeSizeMetrics` for inner cubes. `metrics.leafCubeSizeMetrics` for leaf cubes
-- **min**, **max**, **quartiles**, and how far the cube sizes are from the `desiredCubeSize`(**l1 and l2 error**).
-- The average normalizedWeight, cube size, count, and standard deviation per level.
+### 2. Multi-block files stats::
+The following metrics describe the distribution of the cubes, blocks, and files in the index tree:
+- **cubeElementCountStats**: the statistics of the number of elements per cube
+- **blockElementCountStats**: the statistics of the number of elements per block
+- **fileBytesStats**: the statistics of the size of the files
+- **blockCountPerCubeStats**: the statistics of the number of blocks per cube
+- **blockCountPerFileStats**: the statistics of the number of blocks per file
 
-### 3. `Map[CubeId, CubeStatus]`
+For example, `cubeElementCountStats: (count: 230, avg: 1343, std: 1186, quartiles: (1,292,858,2966,3215))` means that
+- there are`230` cubes
+- the average number of elements per cube is `1343`
+- the standard deviation is `1186`
+- the quartiles are `(min:1, 1stQ:292, 2ndQ:858, 3rdQ:2966, max:3215)`
+
+### 3. Depth-wise cube statistics:
+The following metrics describe the distribution of the cubes in the index tree based on their depth, specifically for the inner cubes:
+```bash
+Inner cubes depth-wise stats:
+cubeElementCountStats: (count: 58, avg: 3069, std: 58, quartiles: (2942,3026,3070,3109,3215))
+blockElementCountStats: (count: 232, avg: 767, std: 1278, quartiles: (14,26,33,2859,3120))
+depth avgCubeElementCount cubeCount blockCount cubeElementCountStd cubeElementCountQuartiles  avgWeight           
+0     3026                1         4          0                   (3026,3026,3026,3026,3026) 0.009708486732493268
+1     3120                2         8          72                  (3048,3048,3193,3193,3193) 0.1777036037942636  
+2     3088                3         12         91                  (3003,3003,3048,3215,3215) 0.29339823296605566 
+3     3078                7         28         45                  (3016,3046,3070,3110,3168) 0.3028351948969015  
+4     3075                12        48         80                  (2942,3027,3084,3148,3214) 0.3853194593029685  
+5     3056                21        84         45                  (2975,3016,3066,3090,3127) 0.557916611995329   
+6     3071                12        48         37                  (2999,3055,3084,3111,3115) 0.71568557500894    
+```
+
+`cubeElementCountStats` and `blockElementCountStats` are the same as in the previous section. The same metrics are displayed for each level of the index tree.
+
+### 4. `Map[CubeId, CubeStatus]`
 - More information can be extracted from the index tree through `metrics.cubeStatuses`

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -167,7 +167,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
 
       // The tree has only one cube
       metrics.height shouldBe 1
-      metrics.avgFanout.isNaN shouldBe true
+      metrics.avgFanout shouldBe 0d
 
       // There is no inner cube
       val blocks = metrics.cubeStatuses.values.toSeq.flatMap(_.blocks)
@@ -200,7 +200,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       metrics.desiredCubeSize shouldBe 100
       metrics.indexingColumns shouldBe "age:empty,val2:empty"
       metrics.height shouldBe 1
-      metrics.avgFanout.isNaN shouldBe true
+      metrics.avgFanout shouldBe 0d
 
       metrics.cubeElementCountStats.count shouldBe 1
       metrics.blockElementCountStats.count shouldBe numFiles
@@ -223,10 +223,14 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       val metrics = IndexMetrics(qs.loadLatestRevision, SortedMap.empty[CubeId, CubeStatus])
 
       metrics.cubeStatuses.isEmpty shouldBe true
+
       metrics.revisionId shouldBe 0L
-      metrics.height shouldBe -1
       metrics.elementCount shouldBe 0
+      metrics.dimensionCount shouldBe 2
+      metrics.desiredCubeSize shouldBe 100
       metrics.indexingColumns shouldBe "age:empty,val2:empty"
+      metrics.height shouldBe -1
+      metrics.avgFanout shouldBe 0d
 
       metrics.cubeElementCountStats.count shouldBe 0
       metrics.blockElementCountStats.count shouldBe 0

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -15,11 +15,17 @@
  */
 package io.qbeast.spark.utils
 
+import io.qbeast.core.model.CubeId
+import io.qbeast.core.model.CubeStatus
+import io.qbeast.spark.delta.DeltaQbeastSnapshot
+import io.qbeast.spark.internal.commands.ConvertToQbeastCommand
 import io.qbeast.spark.QbeastIntegrationTestSpec
 import io.qbeast.spark.QbeastTable
 import io.qbeast.TestClasses.Client3
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.SparkSession
+
+import scala.collection.immutable.SortedMap
 
 class QbeastTableTest extends QbeastIntegrationTestSpec {
 
@@ -122,103 +128,113 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
         val cubeSize = 100
         writeTestData(data, columnsToIndex, cubeSize, tmpDir)
 
-        val metrics = QbeastTable.forPath(spark, tmpDir).getIndexMetrics()
+        val metrics = QbeastTable.forPath(spark, tmpDir).getIndexMetrics(Some(1L))
+
+        metrics.revisionId shouldBe 1L
         metrics.elementCount shouldBe 1001
         metrics.dimensionCount shouldBe columnsToIndex.size
         metrics.desiredCubeSize shouldBe cubeSize
+        metrics.indexingColumns shouldBe "age:linear,val2:linear"
+        metrics.height shouldBe >(1)
+
         // If the tree has any inner node, avgFanout cannot be < 1.0
-        metrics.avgFanout shouldBe >=(1.0)
-        metrics.indexingColumns shouldBe columnsToIndex.mkString(",")
+        metrics.avgFanout shouldBe >=(1d)
+        metrics.depthOnBalance shouldBe >(0d)
 
-        val innerCsMetrics = metrics.innerCubeSizeMetrics
-        innerCsMetrics.min shouldBe <=(innerCsMetrics.firstQuartile)
-        innerCsMetrics.firstQuartile shouldBe <=(innerCsMetrics.secondQuartile)
-        innerCsMetrics.secondQuartile shouldBe <=(innerCsMetrics.thirdQuartile)
-        innerCsMetrics.thirdQuartile shouldBe <=(innerCsMetrics.max)
+        val blocks = metrics.cubeStatuses.values.toSeq.flatMap(_.blocks)
 
-        val leafCsMetrics = metrics.leafCubeSizeMetrics
-        innerCsMetrics.count + leafCsMetrics.count shouldBe metrics.cubeCount
+        metrics.cubeElementCountStats.count shouldBe metrics.cubeStatuses.size
+        metrics.blockElementCountStats.count shouldBe blocks.size
+        metrics.fileBytesStats.count shouldBe blocks.map(_.file).distinct.size
+        metrics.blockCountPerCubeStats.count shouldBe metrics.cubeStatuses.size
+        metrics.blockCountPerFileStats.count shouldBe metrics.fileBytesStats.count
 
-        // Cube size std for the root
-        val rootSizeStd =
-          metrics.innerCubeSizeMetrics.levelStats
-            .split("\n")(1)
-            .split(" +")(3)
-
-        rootSizeStd shouldBe "0"
       }
   }
 
-  it should "return proper metrics string formats" in withQbeastContextSparkAndTmpDir {
+  it should "handle single cube index correctly" in withQbeastContextSparkAndTmpDir {
     (spark, tmpDir) =>
-      {
-        val data = createDF(spark)
-        val columnsToIndex = Seq("age", "val2")
-        val cubeSize = 100
-        writeTestData(data, columnsToIndex, cubeSize, tmpDir)
+      val data = createDF(spark)
+      val columnsToIndex = Seq("age", "val2")
+      val cubeSize = 5000 // large cube size to make sure all elements are stored in the root
+      writeTestData(data, columnsToIndex, cubeSize, tmpDir)
 
-        val metrics = QbeastTable.forPath(spark, tmpDir).getIndexMetrics()
+      val metrics = QbeastTable.forPath(spark, tmpDir).getIndexMetrics(Some(1L))
+      metrics.revisionId shouldBe 1L
+      metrics.elementCount shouldBe 1001
+      metrics.dimensionCount shouldBe columnsToIndex.size
+      metrics.desiredCubeSize shouldBe cubeSize
+      metrics.indexingColumns shouldBe "age:linear,val2:linear"
 
-        val metricsStringLines = metrics.toString.split("\n")
-        val innerCsMetricsStringLines = metrics.innerCubeSizeMetrics.toString.split("\n")
-        val leafCsMetricsStringLines = metrics.leafCubeSizeMetrics.toString.split("\n")
+      // The tree has only one cube
+      metrics.height shouldBe 1
+      metrics.avgFanout.isNaN shouldBe true
 
-        val metricsAttributes = Seq(
-          "OTree Index Metrics",
-          "dimensionCount",
-          "elementCount",
-          "depth:",
-          "cubeCount",
-          "desiredCubeSize",
-          "indexingColumns",
-          "avgFanout",
-          "depthOnBalance")
+      // There is no inner cube
+      val blocks = metrics.cubeStatuses.values.toSeq.flatMap(_.blocks)
 
-        val csMetricsAttributes = Seq(
-          "Stats on cube sizes",
-          "Quartiles",
-          "- min",
-          "- 1stQ",
-          "- 2ndQ",
-          "- 3rdQ",
-          "- max",
-          "Stats:",
-          "- count",
-          "- l1_dev",
-          "- l2_dev",
-          "Level-wise stats")
-        metricsAttributes.foreach(attr => metricsStringLines.count(_.startsWith(attr)) shouldBe 1)
+      metrics.cubeElementCountStats.count shouldBe metrics.cubeStatuses.size
+      metrics.blockElementCountStats.count shouldBe blocks.size
+      metrics.fileBytesStats.count shouldBe blocks.map(_.file).distinct.size
+      metrics.blockCountPerCubeStats.count shouldBe metrics.cubeStatuses.size
+      metrics.blockCountPerFileStats.count shouldBe metrics.fileBytesStats.count
 
-        csMetricsAttributes.foreach(attr => {
-          innerCsMetricsStringLines.count(_.startsWith(attr)) shouldBe 1
-          leafCsMetricsStringLines.count(_.startsWith(attr)) shouldBe 1
-        })
-      }
   }
 
-  it should "handle single cube index correctly" in
-    withQbeastContextSparkAndTmpDir { (spark, tmpDir) =>
-      {
-        val data = createDF(spark)
-        val columnsToIndex = Seq("age", "val2")
-        val cubeSize = 5000 // large cube size to make sure all elements are stored in the root
-        writeTestData(data, columnsToIndex, cubeSize, tmpDir)
+  it should "handle the staging revision correctly" in withQbeastContextSparkAndTmpDir {
+    (spark, tmpDir) =>
+      val data = createDF(spark)
+      val columnsToIndex = Seq("age", "val2")
+      val cubeSize = 100
+      val numFiles = 10
 
-        val qbeastTable = QbeastTable.forPath(spark, tmpDir)
-        val metrics = qbeastTable.getIndexMetrics(Some(1L))
+      // Add 10 file to the staging revision
+      data.repartition(numFiles).write.mode("append").format("delta").save(tmpDir)
+      ConvertToQbeastCommand(s"delta.`$tmpDir`", columnsToIndex, cubeSize).run(spark)
 
-        metrics.depth shouldBe 1
-        metrics.avgFanout shouldBe 0d
+      val metrics = QbeastTable.forPath(spark, tmpDir).getIndexMetrics(Some(0L))
+      metrics.revisionId shouldBe 0L
 
-        // There is no inner cube
-        val innerCsMetrics = metrics.innerCubeSizeMetrics
-        innerCsMetrics.count shouldBe 0
-        innerCsMetrics.min shouldBe -1
-        innerCsMetrics.levelStats shouldBe ""
+      metrics.elementCount shouldBe 0
 
-        val leafCsMetrics = metrics.leafCubeSizeMetrics
-        leafCsMetrics.count shouldBe 1
-      }
-    }
+      metrics.dimensionCount shouldBe 2
+      metrics.desiredCubeSize shouldBe 100
+      metrics.indexingColumns shouldBe "age:empty,val2:empty"
+      metrics.height shouldBe 1
+      metrics.avgFanout.isNaN shouldBe true
+
+      metrics.cubeElementCountStats.count shouldBe 1
+      metrics.blockElementCountStats.count shouldBe numFiles
+      metrics.fileBytesStats.count shouldBe numFiles
+      metrics.blockCountPerCubeStats.count shouldBe 1
+      metrics.blockCountPerFileStats.count shouldBe numFiles
+  }
+
+  "IndexMetrics" should "work correctly with empty cubeStatuses" in withQbeastContextSparkAndTmpDir {
+    (spark, tmpDir) =>
+      // Add 10 file to the staging revision
+      createDF(spark).repartition(10).write.mode("append").format("delta").save(tmpDir)
+      ConvertToQbeastCommand(s"delta.`$tmpDir`", Seq("age", "val2"), 100).run(spark)
+
+      import org.apache.spark.sql.delta.DeltaLog
+      val dl = DeltaLog.forTable(spark, tmpDir)
+      val qs = DeltaQbeastSnapshot(dl.update())
+
+      // Use an existing revision with empty cubeStatuses
+      val metrics = IndexMetrics(qs.loadLatestRevision, SortedMap.empty[CubeId, CubeStatus])
+
+      metrics.cubeStatuses.isEmpty shouldBe true
+      metrics.revisionId shouldBe 0L
+      metrics.height shouldBe -1
+      metrics.elementCount shouldBe 0
+      metrics.indexingColumns shouldBe "age:empty,val2:empty"
+
+      metrics.cubeElementCountStats.count shouldBe 0
+      metrics.blockElementCountStats.count shouldBe 0
+      metrics.fileBytesStats.count shouldBe 0
+      metrics.blockCountPerCubeStats.count shouldBe 0
+      metrics.blockCountPerFileStats.count shouldBe 0
+
+  }
 
 }

--- a/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastTableTest.scala
@@ -139,7 +139,6 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
 
         // If the tree has any inner node, avgFanout cannot be < 1.0
         metrics.avgFanout shouldBe >=(1d)
-        metrics.depthOnBalance shouldBe >(0d)
 
         val blocks = metrics.cubeStatuses.values.toSeq.flatMap(_.blocks)
 
@@ -210,7 +209,7 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       metrics.blockCountPerFileStats.count shouldBe numFiles
   }
 
-  "IndexMetrics" should "work correctly with empty cubeStatuses" in withQbeastContextSparkAndTmpDir {
+  "IndexMetrics" should "handle empty cubeStatuses correctly" in withQbeastContextSparkAndTmpDir {
     (spark, tmpDir) =>
       // Add 10 file to the staging revision
       createDF(spark).repartition(10).write.mode("append").format("delta").save(tmpDir)
@@ -235,6 +234,16 @@ class QbeastTableTest extends QbeastIntegrationTestSpec {
       metrics.blockCountPerCubeStats.count shouldBe 0
       metrics.blockCountPerFileStats.count shouldBe 0
 
+  }
+
+  "Tabulator" should "format data correctly" in {
+    val input = Seq(Seq("1", "2", "3", "4"), Seq("1", "22", "333", "4444"))
+    val expected = Seq(
+      Seq("1", "2 ", "3  ", "4   ").mkString(" "),
+      Seq("1", "22", "333", "4444").mkString(" ")).mkString("\n")
+
+    Tabulator.format(input) shouldBe expected
+    Tabulator.format(Seq.empty) shouldBe ""
   }
 
 }


### PR DESCRIPTION
## Description
Fixes #193 
This PR introduces new `IndexMetrics` statistics to account for the **multi-block files**.

Changes:
1. Add transformer type for the indexing columns
2. Add revision Id
3. Add revision bytes
4. Add block and file counts
5. Add quartiles for several metrics: element counts per cube and block, file bytes
6. Add quartile for level wise statistics
```
OTree Index Metrics:
revisionId: 1
elementCount: 309008
dimensionCount: 2
desiredCubeSize: 3000
indexingColumns: price:linear,user_id:linear
height: 8 (4)
avgFanout: 3.94 (4.0)
cubeCount: 230
blockCount: 848
fileCount: 61
bytes: 11605372

Multi-block files stats:
cubeElementCountStats: (count: 230, avg: 1343, std: 1186, quartiles: (1,292,858,2966,3215))
blockElementCountStats: (count: 848, avg: 364, std: 829, quartiles: (1,6,21,42,3120))
fileBytesStats: (count: 61, avg: 190252, std: 57583, quartiles: (113168,139261,182180,215136,332851))
blockCountPerCubeStats: (count: 230, avg: 3, std: 1, quartiles: (1,4,4,4,4))
blockCountPerFileStats: (count: 61, avg: 13, std: 43, quartiles: (1,3,5,5,207))

Inner cubes depth-wise stats:
cubeElementCountStats: (count: 58, avg: 3069, std: 58, quartiles: (2942,3026,3070,3109,3215))
blockElementCountStats: (count: 232, avg: 767, std: 1278, quartiles: (14,26,33,2859,3120))
depth avgCubeElementCount cubeCount blockCount cubeElementCountStd cubeElementCountQuartiles  avgWeight           
0     3026                1         4          0                   (3026,3026,3026,3026,3026) 0.009708486732493268
1     3120                2         8          72                  (3048,3048,3193,3193,3193) 0.1777036037942636  
2     3088                3         12         91                  (3003,3003,3048,3215,3215) 0.29339823296605566 
3     3078                7         28         45                  (3016,3046,3070,3110,3168) 0.3028351948969015  
4     3075                12        48         80                  (2942,3027,3084,3148,3214) 0.3853194593029685  
5     3056                21        84         45                  (2975,3016,3066,3090,3127) 0.557916611995329   
6     3071                12        48         37                  (2999,3055,3084,3111,3115) 0.71568557500894    

Leaf cubes depth-wise stats:
cubeElementCountStats: (count: 172, avg: 761, std: 733, quartiles: (1,163,584,1159,2966))
blockElementCountStats: (count: 616, avg: 212, std: 498, quartiles: (1,4,10,36,2877))
depth avgCubeElementCount cubeCount blockCount cubeElementCountStd cubeElementCountQuartiles avgWeight         
1     47                  2         4          46                  (1,1,94,94,94)            1515.9574468085107
2     358                 4         12         389                 (4,36,424,970,970)        210.8753971341503 
3     1010                5         20         994                 (314,330,677,767,2966)    5.5998339972396405
4     836                 14        45         951                 (4,38,315,1612,2552)      106.06026824809581
5     978                 27        103        827                 (63,299,616,1681,2666)    8.58027316980015  
6     811                 72        267        686                 (7,280,626,1253,2889)     21.17595889195726 
7     580                 48        165        590                 (3,143,515,779,2246)      76.10800345961682
```
## Checklist:

Here is the list of things you should do before submitting this pull request:

- [ ] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).
