### PR TITLE
Issue 331: Add Compute Histogram utility method

### DIFF
--- a/docs/AdvancedConfiguration.md
+++ b/docs/AdvancedConfiguration.md
@@ -178,7 +178,7 @@ This can be addressed by introducing a custom **String** histogram in the form o
 
 The following code snippet demonstrates the extraction of a **String** histogram from the source data:
 ```scala
- import io.qbeast.spark.utils.QbeastUtils
+import io.qbeast.spark.utils.QbeastUtils
 
 val brandStats = QbeastUtils.computeHistogramForColumn(df, "brand", 50)
 val statsStr = s"""{"brand_histogram":$brandStats}"""

--- a/docs/AdvancedConfiguration.md
+++ b/docs/AdvancedConfiguration.md
@@ -178,31 +178,9 @@ This can be addressed by introducing a custom **String** histogram in the form o
 
 The following code snippet demonstrates the extraction of a **String** histogram from the source data:
 ```scala
- import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions
- import org.apache.spark.sql.DataFrame
- import org.apache.spark.sql.functions.{col, min}
+ import io.qbeast.spark.utils.QbeastUtils
 
- def getStringHistogramStr(columnName: String, numBins: Int, df: DataFrame): String = {
-   val binStarts = "__bin_starts"
-   val stringPartitionColumn =
-     MultiDimClusteringFunctions.range_partition_id(col(columnName), numBins)
-   df
-     .select(columnName)
-     .distinct()
-     .na.drop()
-     .groupBy(stringPartitionColumn)
-     .agg(min(columnName).alias(binStarts))
-     .select(binStarts)
-     .orderBy(binStarts)
-     .collect()
-     .map { r =>
-       val s = r.getAs[String](0)
-       s"'$s'"
-     }
-     .mkString("[", ",", "]")
- }
-
-val brandStats = getStringHistogramStr("brand", 50, df)
+val brandStats = QbeastUtils.computeHistogramForColumn(df, "brand", 50)
 val statsStr = s"""{"brand_histogram":$brandStats}"""
 
 (df

--- a/src/main/scala/io/qbeast/spark/utils/QbeastUtils.scala
+++ b/src/main/scala/io/qbeast/spark/utils/QbeastUtils.scala
@@ -1,9 +1,23 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.qbeast.spark.utils
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.functions.log
 import org.apache.spark.sql.functions.min
 import org.apache.spark.sql.AnalysisExceptionFactory
 import org.apache.spark.sql.DataFrame

--- a/src/main/scala/io/qbeast/spark/utils/QbeastUtils.scala
+++ b/src/main/scala/io/qbeast/spark/utils/QbeastUtils.scala
@@ -1,0 +1,58 @@
+package io.qbeast.spark.utils
+
+import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.min
+import org.apache.spark.sql.DataFrame
+
+/**
+ * Utility object for indexing methods outside the box
+ */
+object QbeastUtils {
+
+  /**
+   * Compute the histogram for a given column
+   *
+   * Since computing the histogram can be expensive, this method is used outside the indexing
+   * process.
+   *
+   * It outputs the histogram of the column as format [bin1, bin2, bin3, ...] Number of bins by
+   * default is 50
+   *
+   * For example:
+   *
+   * val qbeastTable = QbeastTable.forPath(spark, "path")
+   *
+   * val histogram =qbeastTable.computeHistogramForColumn(df, "column")
+   *
+   * df.write.format("qbeast").option("columnsToIndex",
+   * "column:histogram").option("columnStats",histogram).save()
+   *
+   * @param df
+   * @param columnName
+   */
+  def computeHistogramForColumn(df: DataFrame, columnName: String, numBins: Int = 50): String = {
+
+    import df.sparkSession.implicits._
+    val binStarts = "__bin_starts"
+    val stringPartitionColumn =
+      MultiDimClusteringFunctions.range_partition_id(col(columnName), numBins)
+
+    val histogram = df
+      .select(columnName)
+      .distinct()
+      .na
+      .drop()
+      .groupBy(stringPartitionColumn)
+      .agg(min(columnName).alias(binStarts))
+      .select(binStarts)
+      .orderBy(binStarts)
+      .as[String]
+      .collect()
+
+    histogram
+      .map(string => s"'$string'")
+      .mkString("[", ",", "]")
+  }
+
+}

--- a/src/main/scala/io/qbeast/spark/utils/QbeastUtils.scala
+++ b/src/main/scala/io/qbeast/spark/utils/QbeastUtils.scala
@@ -1,14 +1,17 @@
 package io.qbeast.spark.utils
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.log
 import org.apache.spark.sql.functions.min
+import org.apache.spark.sql.AnalysisExceptionFactory
 import org.apache.spark.sql.DataFrame
 
 /**
  * Utility object for indexing methods outside the box
  */
-object QbeastUtils {
+object QbeastUtils extends Logging {
 
   /**
    * Compute the histogram for a given column
@@ -34,6 +37,11 @@ object QbeastUtils {
   def computeHistogramForColumn(df: DataFrame, columnName: String, numBins: Int = 50): String = {
 
     import df.sparkSession.implicits._
+    if (!df.columns.contains(columnName)) {
+      throw AnalysisExceptionFactory.create(s"Column $columnName does not exist in the dataframe")
+    }
+
+    log.info(s"Computing histogram for column $columnName with number of bins $numBins")
     val binStarts = "__bin_starts"
     val stringPartitionColumn =
       MultiDimClusteringFunctions.range_partition_id(col(columnName), numBins)
@@ -50,6 +58,7 @@ object QbeastUtils {
       .as[String]
       .collect()
 
+    log.info(s"Histogram for column $columnName: $histogram")
     histogram
       .map(string => s"'$string'")
       .mkString("[", ",", "]")

--- a/src/test/scala/io/qbeast/spark/utils/QbeastUtilsTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastUtilsTest.scala
@@ -1,0 +1,33 @@
+package io.qbeast.spark.utils
+
+import io.qbeast.spark.QbeastIntegrationTestSpec
+import org.apache.spark.sql.AnalysisException
+
+class QbeastUtilsTest extends QbeastIntegrationTestSpec {
+
+  "QbeastUtils" should "compute histogram for string columns" in withQbeastContextSparkAndTmpDir(
+    (spark, _) => {
+      import spark.implicits._
+      val df = Seq("a", "b", "c", "a", "b", "c", "a", "b", "c").toDF("name")
+      val hist = QbeastUtils.computeHistogramForColumn(df, "name")
+
+      hist shouldBe "['a','b','c']"
+    })
+
+  it should "compute histogram for Int" in withQbeastContextSparkAndTmpDir((spark, tmpDir) => {
+    import spark.implicits._
+    val df = Seq(1, 2, 3, 1, 2, 3, 1, 2, 3).toDF("age")
+    val hist = QbeastUtils.computeHistogramForColumn(df, "age")
+
+    hist shouldBe "['1','2','3']"
+  })
+
+  it should "throw error when the column does not exists" in withQbeastContextSparkAndTmpDir(
+    (spark, _) => {
+      import spark.implicits._
+      val df = Seq("a").toDF("name")
+      an[AnalysisException] shouldBe thrownBy(
+        QbeastUtils.computeHistogramForColumn(df, "non_existing_column"))
+    })
+
+}


### PR DESCRIPTION
## Description


Fixes #331 

## Type of change

New Feature, no breaking change. 

Easy API for computing the histogram for a column. Usage:
```scala
import io.qbeast.spark.utils.QbeastUtils

val brandStats = QbeastUtils.computeHistogramForColumn(df, "brand", 50)
val statsStr = s"""{"brand_histogram":$brandStats}"""

(df
  .write
  .mode("overwrite")
  .format("qbeast")
  .option("columnsToIndex", "brand:histogram")
  .option("columnStats", statsStr)
  .save(targetPath))
```



## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Test can be found in` io.qbeast.spark.utils.QbeastUtilsTest`

**Test Configuration**:
* Spark Version: 3.4.1
* Hadoop Version: 3.3.x
* Cluster or local? Local