### PR TITLE
Issue 340: ConvertToQbeast should work for table paths containing namespaces

### DIFF
--- a/src/main/scala/io/qbeast/spark/internal/commands/ConvertToQbeastCommand.scala
+++ b/src/main/scala/io/qbeast/spark/internal/commands/ConvertToQbeastCommand.scala
@@ -23,6 +23,7 @@ import io.qbeast.spark.utils.MetadataConfig.revision
 import io.qbeast.spark.utils.QbeastExceptionMessages.incorrectIdentifierFormat
 import io.qbeast.spark.utils.QbeastExceptionMessages.partitionedTableExceptionMsg
 import io.qbeast.spark.utils.QbeastExceptionMessages.unsupportedFormatExceptionMsg
+import org.apache.hadoop.fs.Path
 import org.apache.http.annotation.Experimental
 import org.apache.spark.internal.Logging
 import org.apache.spark.qbeast.config.DEFAULT_CUBE_SIZE
@@ -33,8 +34,6 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.AnalysisExceptionFactory
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
-
-import java.util.Locale
 
 /**
  * Command to convert a parquet or a delta table into a qbeast table. The command creates the an
@@ -56,13 +55,17 @@ case class ConvertToQbeastCommand(
     with Logging
     with StagingUtils {
 
-  private def resolveTableFormat(spark: SparkSession): (String, TableIdentifier) =
-    identifier.split("\\.") match {
-      case Array(f, p) if f.nonEmpty && p.nonEmpty =>
-        (f.toLowerCase(Locale.ROOT), spark.sessionState.sqlParser.parseTableIdentifier(p))
-      case _ =>
-        throw AnalysisExceptionFactory.create(incorrectIdentifierFormat(identifier))
+  private def resolveTableFormat(spark: SparkSession): (String, TableIdentifier) = {
+    val tableIdentifier = spark.sessionState.sqlParser.parseTableIdentifier(identifier)
+    val provider = tableIdentifier.database.getOrElse("")
+    // If the table is a path table, it is a parquet or delta table
+    val isPathTable = new Path(tableIdentifier.table).isAbsolute
+    val isCorrectFormat = provider == "parquet" || provider == "delta"
+    if (isPathTable && isCorrectFormat) (provider, tableIdentifier)
+    else {
+      throw AnalysisExceptionFactory.create(incorrectIdentifierFormat(identifier))
     }
+  }
 
   override def run(spark: SparkSession): Seq[Row] = {
     val (fileFormat, tableId) = resolveTableFormat(spark)

--- a/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
@@ -165,6 +165,18 @@ class ConvertToQbeastTest
       thrown.getMessage shouldBe incorrectIdentifierFormat(identifier)
     })
 
+  it should "convert if the path contains '.'" in withSparkAndTmpDir((spark, tmpDir) => {
+    val location = s"$tmpDir/test.db/table"
+    val identifier = s"parquet.`$location`"
+    loadTestData(spark)
+      .limit(dataSize)
+      .write
+      .format("delta")
+      .save(location)
+    ConvertToQbeastCommand(identifier, columnsToIndex, dcs).run(spark)
+    getQbeastSnapshot(spark, location).loadAllRevisions.size shouldBe 1
+  })
+
   it should "preserve sampling accuracy" in withSparkAndTmpDir((spark, tmpDir) => {
     convertFromFormat(spark, "parquet", tmpDir)
 

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSQLIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSQLIntegrationTest.scala
@@ -218,4 +218,23 @@ class QbeastSQLIntegrationTest extends QbeastIntegrationTestSpec {
       }
   }
 
+  it should "work with other namespaces" in withQbeastContextSparkAndTmpWarehouse {
+    (spark, tmpDir) =>
+      {
+        spark.sql("CREATE DATABASE IF NOT EXISTS test")
+        spark.sql(
+          "CREATE TABLE IF NOT EXISTS test.students(id INT, name STRING, age INT) " +
+            "USING qbeast OPTIONS ('columnsToIndex'='id')")
+
+        val data = createTestData(spark)
+        data.write.format("qbeast").mode("append").insertInto("test.students")
+
+        assertSmallDatasetEquality(
+          spark.sql("SELECT * FROM test.students"),
+          data,
+          ignoreNullable = true)
+
+      }
+  }
+
 }


### PR DESCRIPTION
## Description

Fixes #340 

## Type of change

Bug fix.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Locally on QbeastSQLIntegrationTest

**Test Configuration**:
* Spark Version: 3.5.0
* Hadoop Version: 3.3.4
* Cluster or local? Local