### PR TITLE
Issue 339: Persist property changes from SET TBLPROPERTIES operations in the _delta_log

### DIFF
--- a/src/main/scala/io/qbeast/spark/internal/commands/alterQbeastTableCommands.scala
+++ b/src/main/scala/io/qbeast/spark/internal/commands/alterQbeastTableCommands.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qbeast.spark.internal.commands
+
+import io.qbeast.spark.internal.sources.v2.QbeastTableImpl
+import org.apache.spark.sql.catalyst.plans.logical.IgnoreCachedData
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.AlterTableSetPropertiesDeltaCommand
+import org.apache.spark.sql.delta.commands.AlterTableUnsetPropertiesDeltaCommand
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+
+case class AlterTableSetPropertiesQbeastCommand(
+    qbeastTable: QbeastTableImpl,
+    configuration: Map[String, String])
+    extends LeafRunnableCommand {
+
+  override def run(spark: SparkSession): Seq[Row] = {
+    val deltaTable =
+      DeltaTableV2(
+        spark,
+        qbeastTable.path,
+        qbeastTable.catalogTable,
+        Some(qbeastTable.tableIdentifier.toString),
+        None,
+        qbeastTable.options)
+    AlterTableSetPropertiesDeltaCommand(
+      deltaTable,
+      DeltaConfigs.validateConfigurations(configuration))
+      .run(spark)
+  }
+
+}
+
+case class AlterTableUnsetPropertiesQbeastCommand(
+    qbeastTable: QbeastTableImpl,
+    propKeys: Seq[String],
+    ifExists: Boolean)
+    extends LeafRunnableCommand
+    with IgnoreCachedData {
+
+  override def run(spark: SparkSession): Seq[Row] = {
+    val deltaTable =
+      DeltaTableV2(
+        spark,
+        qbeastTable.path,
+        qbeastTable.catalogTable,
+        Some(qbeastTable.tableIdentifier.toString),
+        None,
+        qbeastTable.options)
+    AlterTableUnsetPropertiesDeltaCommand(
+      deltaTable,
+      propKeys,
+      // Data source V2 REMOVE PROPERTY is always IF EXISTS.
+      ifExists = true).run(spark)
+
+  }
+
+}

--- a/src/main/scala/io/qbeast/spark/internal/commands/alterQbeastTableCommands.scala
+++ b/src/main/scala/io/qbeast/spark/internal/commands/alterQbeastTableCommands.scala
@@ -16,6 +16,7 @@
 package io.qbeast.spark.internal.commands
 
 import io.qbeast.spark.internal.sources.v2.QbeastTableImpl
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.plans.logical.IgnoreCachedData
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.AlterTableSetPropertiesDeltaCommand
@@ -28,7 +29,8 @@ import org.apache.spark.sql.SparkSession
 case class AlterTableSetPropertiesQbeastCommand(
     qbeastTable: QbeastTableImpl,
     configuration: Map[String, String])
-    extends LeafRunnableCommand {
+    extends LeafRunnableCommand
+    with Logging {
 
   override def run(spark: SparkSession): Seq[Row] = {
     val deltaTable =
@@ -39,6 +41,7 @@ case class AlterTableSetPropertiesQbeastCommand(
         Some(qbeastTable.tableIdentifier.toString),
         None,
         qbeastTable.options)
+    log.info(s"Setting new properties $configuration for table ${qbeastTable.tableIdentifier}")
     AlterTableSetPropertiesDeltaCommand(
       deltaTable,
       DeltaConfigs.validateConfigurations(configuration))
@@ -52,7 +55,8 @@ case class AlterTableUnsetPropertiesQbeastCommand(
     propKeys: Seq[String],
     ifExists: Boolean)
     extends LeafRunnableCommand
-    with IgnoreCachedData {
+    with IgnoreCachedData
+    with Logging {
 
   override def run(spark: SparkSession): Seq[Row] = {
     val deltaTable =
@@ -63,6 +67,7 @@ case class AlterTableUnsetPropertiesQbeastCommand(
         Some(qbeastTable.tableIdentifier.toString),
         None,
         qbeastTable.options)
+    log.info(s"Unsetting properties $propKeys for table ${qbeastTable.tableIdentifier}")
     AlterTableUnsetPropertiesDeltaCommand(
       deltaTable,
       propKeys,

--- a/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalog.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalog.scala
@@ -31,10 +31,6 @@ import org.apache.spark.sql.connector.catalog.TableChange.RemoveProperty
 import org.apache.spark.sql.connector.catalog.TableChange.SetProperty
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
-import org.apache.spark.sql.delta.commands.AlterTableSetPropertiesDeltaCommand
-import org.apache.spark.sql.delta.commands.AlterTableUnsetPropertiesDeltaCommand
-import org.apache.spark.sql.delta.DeltaConfigs
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.SparkCatalogUtils

--- a/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalog.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalog.scala
@@ -16,6 +16,8 @@
 package io.qbeast.spark.internal.sources.catalog
 
 import io.qbeast.context.QbeastContext
+import io.qbeast.spark.internal.commands.AlterTableSetPropertiesQbeastCommand
+import io.qbeast.spark.internal.commands.AlterTableUnsetPropertiesQbeastCommand
 import io.qbeast.spark.internal.sources.v2.QbeastStagedTableImpl
 import io.qbeast.spark.internal.sources.v2.QbeastTableImpl
 import org.apache.hadoop.fs.Path
@@ -25,8 +27,14 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
+import org.apache.spark.sql.connector.catalog.TableChange.RemoveProperty
+import org.apache.spark.sql.connector.catalog.TableChange.SetProperty
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.AlterTableSetPropertiesDeltaCommand
+import org.apache.spark.sql.delta.commands.AlterTableUnsetPropertiesDeltaCommand
+import org.apache.spark.sql.delta.DeltaConfigs
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.SparkCatalogUtils
@@ -98,7 +106,7 @@ class QbeastCatalog[T <: TableCatalog with SupportsNamespaces with FunctionCatal
     } catch {
       case _: NoSuchDatabaseException | _: NoSuchNamespaceException | _: NoSuchTableException
           if QbeastCatalogUtils.isPathTable(ident) =>
-        new QbeastTableImpl(
+        QbeastTableImpl(
           TableIdentifier(ident.name(), ident.namespace().headOption),
           new Path(ident.name()),
           Map.empty,
@@ -247,8 +255,54 @@ class QbeastCatalog[T <: TableCatalog with SupportsNamespaces with FunctionCatal
   override def listTables(namespace: Array[String]): Array[Identifier] =
     getSessionCatalog().listTables(namespace)
 
-  override def alterTable(ident: Identifier, changes: TableChange*): Table =
-    getSessionCatalog().alterTable(ident, changes.head)
+  /**
+   * Code extracted from DeltaCatalog alterTable operation
+   * @param ident
+   * @param changes
+   * @return
+   */
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+
+    // Group the TableChanges by class
+    // The SetLocation class is used to group all the SetProperty changes that are related to the
+    // changing of location.
+    // We are still not handling them as part of the Qbeast Table Operations
+    class SetLocation {}
+    val grouped = changes.groupBy {
+      case s: SetProperty if s.property() == "location" => classOf[SetLocation]
+      case c => c.getClass
+    }
+    // Load qbeast table (if exists and is qbeast provider)
+    val qbeastTable = loadTable(ident) match {
+      case q: QbeastTableImpl => q
+      case _ => return getSessionCatalog().alterTable(ident, changes: _*)
+    }
+
+    grouped.foreach {
+      case (t, changes) if t == classOf[SetProperty] =>
+        AlterTableSetPropertiesQbeastCommand(
+          qbeastTable,
+          changes
+            .asInstanceOf[Seq[SetProperty]]
+            .map { prop =>
+              prop.property() -> prop.value()
+            }
+            .toMap).run(spark)
+
+      case (t, oldProperties) if t == classOf[RemoveProperty] =>
+        AlterTableUnsetPropertiesQbeastCommand(
+          qbeastTable,
+          oldProperties.asInstanceOf[Seq[RemoveProperty]].map(_.property()),
+          // Data source V2 REMOVE PROPERTY is always IF EXISTS.
+          ifExists = true).run(spark)
+
+      // Other cases not handled yet
+      case _ => return getSessionCatalog().alterTable(ident, changes: _*)
+    }
+
+    loadTable(ident)
+
+  }
 
   override def dropTable(ident: Identifier): Boolean = getSessionCatalog().dropTable(ident)
 

--- a/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogUtils.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogUtils.scala
@@ -369,7 +369,8 @@ object QbeastCatalogUtils {
           catalogTable.location.toString
         }
 
-        new QbeastTableImpl(
+        println("Returning qbeastTableImpl")
+        QbeastTableImpl(
           catalogTable.identifier,
           new Path(path),
           prop.asScala.toMap,

--- a/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastTableImpl.scala
+++ b/src/main/scala/io/qbeast/spark/internal/sources/v2/QbeastTableImpl.scala
@@ -41,18 +41,18 @@ import scala.collection.JavaConverters._
  *   the Path of the table
  * @param options
  *   the write options
- * @param schema
+ * @param optionSchema
  *   the schema of the table
  * @param catalogTable
  *   the underlying Catalog Table, if any
  * @param tableFactory
  *   the IndexedTable Factory
  */
-class QbeastTableImpl private[sources] (
+case class QbeastTableImpl(
     tableIdentifier: TableIdentifier,
     path: Path,
     options: Map[String, String] = Map.empty,
-    schema: Option[StructType] = None,
+    optionSchema: Option[StructType] = None,
     catalogTable: Option[CatalogTable] = None,
     private val tableFactory: IndexedTableFactory)
     extends Table
@@ -75,7 +75,8 @@ class QbeastTableImpl private[sources] (
 
   override def name(): String = tableIdentifier.identifier
 
-  override def schema(): StructType = if (schema.isDefined) schema.get else table.schema
+  override def schema(): StructType =
+    if (optionSchema.isDefined) optionSchema.get else table.schema
 
   override def capabilities(): util.Set[TableCapability] =
     Set(ACCEPT_ANY_SCHEMA, BATCH_READ, V1_BATCH_WRITE, OVERWRITE_BY_FILTER, TRUNCATE).asJava

--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogTest.scala
@@ -126,6 +126,28 @@ class QbeastCatalogTest extends QbeastIntegrationTestSpec with CatalogTestSuite 
       .columns() shouldBe modifiedColumns
   })
 
+  it should "alter table in the DeltaLog" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
+    val qbeastCatalog = createQbeastCatalog(spark)
+    val tableIdentifier = Identifier.of(defaultNamespace, "student")
+    qbeastCatalog.createTable(
+      tableIdentifier,
+      columns,
+      Array.empty[Transform],
+      Map.empty[String, String].asJava)
+
+
+    // Alter table with new information
+    qbeastCatalog.alterTable(
+      tableIdentifier,
+      TableChange.addColumn(Array("x"), IntegerType, false))
+
+    val modifiedSchema = StructType(schema.fields ++ Seq(StructField("x", IntegerType, false)))
+    val modifiedColumns = SparkCatalogV2Util.structTypeToV2Columns(modifiedSchema)
+    qbeastCatalog
+      .loadTable(Identifier.of(defaultNamespace, "student"))
+      .columns() shouldBe modifiedColumns
+  })
+
   it should "drop table" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
     val qbeastCatalog = createQbeastCatalog(spark)
     val tableIdentifier = Identifier.of(defaultNamespace, "student")

--- a/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogTest.scala
+++ b/src/test/scala/io/qbeast/spark/internal/sources/catalog/QbeastCatalogTest.scala
@@ -126,7 +126,7 @@ class QbeastCatalogTest extends QbeastIntegrationTestSpec with CatalogTestSuite 
       .columns() shouldBe modifiedColumns
   })
 
-  it should "alter table in the DeltaLog" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
+  it should "set properties" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {
     val qbeastCatalog = createQbeastCatalog(spark)
     val tableIdentifier = Identifier.of(defaultNamespace, "student")
     qbeastCatalog.createTable(
@@ -135,17 +135,14 @@ class QbeastCatalogTest extends QbeastIntegrationTestSpec with CatalogTestSuite 
       Array.empty[Transform],
       Map.empty[String, String].asJava)
 
-
+    val setPropertiesChange = TableChange.setProperty("newProperty", "newValue")
     // Alter table with new information
-    qbeastCatalog.alterTable(
-      tableIdentifier,
-      TableChange.addColumn(Array("x"), IntegerType, false))
+    qbeastCatalog.alterTable(tableIdentifier, setPropertiesChange)
 
-    val modifiedSchema = StructType(schema.fields ++ Seq(StructField("x", IntegerType, false)))
-    val modifiedColumns = SparkCatalogV2Util.structTypeToV2Columns(modifiedSchema)
     qbeastCatalog
       .loadTable(Identifier.of(defaultNamespace, "student"))
-      .columns() shouldBe modifiedColumns
+      .properties()
+      .asScala should contain("newProperty" -> "newValue")
   })
 
   it should "drop table" in withQbeastContextSparkAndTmpWarehouse((spark, _) => {


### PR DESCRIPTION
## Description

Fixes #339 

The command `ALTER TABLE t SET TBLPROPERTIES('k'='v')` was changing the properties at the Catalog level but not persisting them in the commit log of the table. 

## Type of change

It is a bug fix and it includes two more Qbeast commands: `AlterTableSetPropertiesQbeastCommand` and `AlterTableUnsetPropertiesQbeastCommand`.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

This is tested in QbeastCatalogTest and QbeastSQLIntegrationTest.

**Test Configuration**:
* Spark Version: 3.5.0
* Hadoop Version: 3.3.4
* Cluster or local? Local