### PR TITLE
Issue 352: Sampling Error when explicit type is set in columnsToIndex

### DIFF
--- a/src/main/scala/io/qbeast/core/model/ColumnToIndex.scala
+++ b/src/main/scala/io/qbeast/core/model/ColumnToIndex.scala
@@ -1,0 +1,45 @@
+package io.qbeast.core.model
+
+import io.qbeast.core.transform.Transformer
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Represents a column to be indexed.
+ * @param columnName
+ *   The name of the column.
+ * @param transformerType
+ *   The type of the transformer, if available.
+ */
+case class ColumnToIndex(columnName: String, transformerType: Option[String]) {
+
+  def toTransformer(schema: StructType): Transformer = {
+    val getColumnQType = ColumnToIndexUtils.getColumnQType(columnName, schema)
+    transformerType match {
+      case Some(tt) => Transformer(tt, columnName, getColumnQType)
+      case None => Transformer(columnName, getColumnQType)
+    }
+  }
+
+}
+
+/**
+ * Companion object for IndexedColumn. Allows creating an IndexedColumn from a string.
+ */
+
+object ColumnToIndex {
+
+  /**
+   * Creates an IndexedColumn from a string and schema.
+   * @param columnSpec
+   * @return
+   */
+  def apply(columnSpec: String): ColumnToIndex = {
+    columnSpec match {
+      case ColumnToIndexUtils.SpecExtractor(columnName, transformerType) =>
+        ColumnToIndex(columnName, Some(transformerType))
+      case columnName =>
+        ColumnToIndex(columnName, None)
+    }
+  }
+
+}

--- a/src/main/scala/io/qbeast/core/model/ColumnToIndex.scala
+++ b/src/main/scala/io/qbeast/core/model/ColumnToIndex.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.qbeast.core.model
 
 import io.qbeast.core.transform.Transformer

--- a/src/main/scala/io/qbeast/core/model/ColumnToIndexUtils.scala
+++ b/src/main/scala/io/qbeast/core/model/ColumnToIndexUtils.scala
@@ -1,0 +1,16 @@
+package io.qbeast.core.model
+
+import io.qbeast.spark.utils.SparkToQTypesUtils
+import org.apache.spark.sql.types.StructType
+
+import scala.util.matching.Regex
+
+object ColumnToIndexUtils {
+
+  val SpecExtractor: Regex = "([^:]+):([A-z]+)".r
+
+  def getColumnQType(columnName: String, schema: StructType): QDataType = {
+    SparkToQTypesUtils.convertDataTypes(schema(columnName).dataType)
+  }
+
+}

--- a/src/main/scala/io/qbeast/core/model/ColumnToIndexUtils.scala
+++ b/src/main/scala/io/qbeast/core/model/ColumnToIndexUtils.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.qbeast.core.model
 
 import io.qbeast.spark.utils.SparkToQTypesUtils

--- a/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
@@ -15,47 +15,28 @@
  */
 package io.qbeast.spark.index
 
-import io.qbeast.core.model.QDataType
 import io.qbeast.core.model.QTableID
 import io.qbeast.core.model.Revision
 import io.qbeast.core.model.RevisionFactory
 import io.qbeast.core.model.RevisionID
 import io.qbeast.core.transform.EmptyTransformation
 import io.qbeast.core.transform.Transformation
-import io.qbeast.core.transform.Transformer
 import io.qbeast.spark.internal.QbeastOptions
-import io.qbeast.spark.utils.SparkToQTypesUtils
 import org.apache.spark.sql.types.StructType
-
-import scala.util.matching.Regex
 
 /**
  * Spark implementation of RevisionBuilder
  */
 object SparkRevisionFactory extends RevisionFactory[StructType, QbeastOptions] {
 
-  val SpecExtractor: Regex = "([^:]+):([A-z]+)".r
-
-  def getColumnQType(columnName: String, schema: StructType): QDataType = {
-    SparkToQTypesUtils.convertDataTypes(schema(columnName).dataType)
-  }
-
   override def createNewRevision(
       qtableID: QTableID,
       schema: StructType,
       options: QbeastOptions): Revision = {
 
-    val columnSpecs = options.columnsToIndex
     val desiredCubeSize = options.cubeSize
-
-    val transformers = columnSpecs.map {
-      case SpecExtractor(columnName, transformerType) =>
-        Transformer(transformerType, columnName, getColumnQType(columnName, schema))
-
-      case columnName =>
-        Transformer(columnName, getColumnQType(columnName, schema))
-
-    }.toVector
+    val columnsToIndex = options.columnsToIndexDecoded
+    val transformers = columnsToIndex.map(_.toTransformer(schema)).toVector
 
     options.stats match {
       case None => Revision.firstRevision(qtableID, desiredCubeSize, transformers)

--- a/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
+++ b/src/main/scala/io/qbeast/spark/index/SparkRevisionFactory.scala
@@ -35,7 +35,7 @@ object SparkRevisionFactory extends RevisionFactory[StructType, QbeastOptions] {
       options: QbeastOptions): Revision = {
 
     val desiredCubeSize = options.cubeSize
-    val columnsToIndex = options.columnsToIndexDecoded
+    val columnsToIndex = options.columnsToIndexParsed
     val transformers = columnsToIndex.map(_.toTransformer(schema)).toVector
 
     options.stats match {

--- a/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
+++ b/src/main/scala/io/qbeast/spark/internal/QbeastOptions.scala
@@ -58,7 +58,6 @@ import scala.util.matching.Regex
  */
 case class QbeastOptions(
     columnsToIndex: Seq[String],
-    columnsToIndexDecoded: Seq[ColumnToIndex],
     cubeSize: Int,
     stats: Option[DataFrame],
     txnAppId: Option[String],
@@ -67,6 +66,12 @@ case class QbeastOptions(
     mergeSchema: Option[String],
     overwriteSchema: Option[String],
     hookInfo: Seq[HookInfo] = Nil) {
+
+  /**
+   * Returns a sequence of ColumnToIndex objects representing the columns to index already parsed
+   * @return
+   */
+  def columnsToIndexParsed: Seq[ColumnToIndex] = columnsToIndex.map(ColumnToIndex(_))
 
   def toMap: CaseInsensitiveMap[String] = {
     val options = Map.newBuilder[String, String]
@@ -216,7 +221,6 @@ object QbeastOptions {
    */
   def apply(options: CaseInsensitiveMap[String]): QbeastOptions = {
     val columnsToIndex = getColumnsToIndex(options)
-    val columnsToIndexDecoded = columnsToIndex.map(ColumnToIndex(_))
     val desiredCubeSize = getDesiredCubeSize(options)
     val stats = getStats(options)
     val txnAppId = getTxnAppId(options)
@@ -228,7 +232,6 @@ object QbeastOptions {
 
     QbeastOptions(
       columnsToIndex,
-      columnsToIndexDecoded,
       desiredCubeSize,
       stats,
       txnAppId,
@@ -258,14 +261,14 @@ object QbeastOptions {
     val caseInsensitiveMap = CaseInsensitiveMap(options)
     val userMetadata = getUserMetadata(caseInsensitiveMap)
     val hookInfo = getHookInfo(caseInsensitiveMap)
-    QbeastOptions(Seq.empty, Seq.empty, 0, None, None, None, userMetadata, None, None, hookInfo)
+    QbeastOptions(Seq.empty, 0, None, None, None, userMetadata, None, None, hookInfo)
   }
 
   /**
    * The empty options to be used as a placeholder.
    */
   lazy val empty: QbeastOptions =
-    QbeastOptions(Seq.empty, Seq.empty, DEFAULT_CUBE_SIZE, None, None, None, None, None, None)
+    QbeastOptions(Seq.empty, DEFAULT_CUBE_SIZE, None, None, None, None, None, None)
 
   def loadTableIDFromParameters(parameters: Map[String, String]): QTableID = {
     new QTableID(

--- a/src/main/scala/io/qbeast/spark/internal/rules/SampleRule.scala
+++ b/src/main/scala/io/qbeast/spark/internal/rules/SampleRule.scala
@@ -120,7 +120,8 @@ object QbeastRelation {
           _,
           _,
           _) =>
-      val columnsToIndex = QbeastOptions(parameters).columnsToIndex
+      val qbeastOptions = QbeastOptions(parameters)
+      val columnsToIndex = qbeastOptions.columnsToIndexDecoded.map(_.columnName)
       Some((l, columnsToIndex))
     case _ => None
   }

--- a/src/main/scala/io/qbeast/spark/internal/rules/SampleRule.scala
+++ b/src/main/scala/io/qbeast/spark/internal/rules/SampleRule.scala
@@ -121,7 +121,7 @@ object QbeastRelation {
           _,
           _) =>
       val qbeastOptions = QbeastOptions(parameters)
-      val columnsToIndex = qbeastOptions.columnsToIndexDecoded.map(_.columnName)
+      val columnsToIndex = qbeastOptions.columnsToIndexParsed.map(_.columnName)
       Some((l, columnsToIndex))
     case _ => None
   }

--- a/src/main/scala/io/qbeast/spark/internal/rules/SampleRule.scala
+++ b/src/main/scala/io/qbeast/spark/internal/rules/SampleRule.scala
@@ -19,6 +19,7 @@ import io.qbeast.core.model.Weight
 import io.qbeast.core.model.WeightRange
 import io.qbeast.spark.delta.DefaultFileIndex
 import io.qbeast.spark.internal.expressions.QbeastMurmur3Hash
+import io.qbeast.spark.internal.QbeastOptions
 import io.qbeast.IndexedColumns
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.And
@@ -119,8 +120,8 @@ object QbeastRelation {
           _,
           _,
           _) =>
-      val columnsToIndex = parameters("columnsToIndex")
-      Some((l, columnsToIndex.split(",")))
+      val columnsToIndex = QbeastOptions(parameters).columnsToIndex
+      Some((l, columnsToIndex))
     case _ => None
   }
 

--- a/src/test/scala/io/qbeast/core/model/ColumnToIndexTest.scala
+++ b/src/test/scala/io/qbeast/core/model/ColumnToIndexTest.scala
@@ -1,0 +1,70 @@
+package io.qbeast.core.model
+
+import io.qbeast.core.transform.HashTransformer
+import io.qbeast.core.transform.LinearTransformer
+import io.qbeast.core.transform.StringHistogramTransformer
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.FloatType
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ColumnToIndexTest extends AnyFlatSpec with Matchers {
+
+  behavior of "ColumnsToIndexTest"
+
+  it should "extract the correct column name" in {
+
+    val columnToIndex = ColumnToIndex("column:linear")
+    columnToIndex.columnName shouldBe "column"
+    columnToIndex.transformerType shouldBe Some("linear")
+
+  }
+
+  it should "return the transformer type as None" in {
+
+    val columnToIndex = ColumnToIndex("column")
+    columnToIndex.columnName shouldBe "column"
+    columnToIndex.transformerType shouldBe None
+
+  }
+
+  it should "return the correct Transformer" in {
+
+    val schema = StructType(
+      StructField("a", LongType) :: StructField("b", DoubleType) :: StructField(
+        "c",
+        StringType) :: StructField("d", FloatType) :: Nil)
+
+    val columnToIndex = ColumnToIndex("a")
+    val transformer = columnToIndex.toTransformer(schema)
+    transformer shouldBe a[LinearTransformer]
+
+  }
+
+  it should "return the correct Transformer with transformer type" in {
+
+    val schema = StructType(
+      StructField("a", LongType) :: StructField("b", DoubleType) :: StructField(
+        "c",
+        StringType) :: StructField("d", FloatType) :: Nil)
+
+    val columnToIndex = ColumnToIndex("a:linear")
+    val transformer = columnToIndex.toTransformer(schema)
+    transformer shouldBe a[LinearTransformer]
+
+    val columnToIndexHash = ColumnToIndex("a:hashing")
+    val transformerString = columnToIndexHash.toTransformer(schema)
+    transformerString shouldBe a[HashTransformer]
+
+    // Only StringHistogramTransformer is implemented
+    val columnToIndexHistogram = ColumnToIndex("c:histogram")
+    val transformerHistogram = columnToIndexHistogram.toTransformer(schema)
+    transformerHistogram shouldBe a[StringHistogramTransformer]
+
+  }
+
+}

--- a/src/test/scala/io/qbeast/core/model/ColumnToIndexUtilsTest.scala
+++ b/src/test/scala/io/qbeast/core/model/ColumnToIndexUtilsTest.scala
@@ -1,0 +1,49 @@
+package io.qbeast.core.model
+
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.FloatType
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ColumnToIndexUtilsTest extends AnyFlatSpec with Matchers {
+
+  behavior of "SparkRevisionFactory"
+
+  it should "detect the correct types in getColumnQType" in {
+
+    val schema = StructType(
+      StructField("a", LongType) :: StructField("b", DoubleType) :: StructField(
+        "c",
+        StringType) :: StructField("d", FloatType) :: Nil)
+
+    ColumnToIndexUtils.getColumnQType("a", schema) shouldBe LongDataType
+    ColumnToIndexUtils.getColumnQType("b", schema) shouldBe DoubleDataType
+    ColumnToIndexUtils.getColumnQType("c", schema) shouldBe StringDataType
+    ColumnToIndexUtils.getColumnQType("d", schema) shouldBe FloatDataType
+
+  }
+
+  it should "should extract correctly the type" in {
+
+    import ColumnToIndexUtils.SpecExtractor
+
+    "column:LinearTransformer" match {
+      case SpecExtractor(column, transformer) =>
+        column shouldBe "column"
+        transformer shouldBe "LinearTransformer"
+      case _ => fail("It did not recognize the type")
+    }
+
+    "column" match {
+      case SpecExtractor(column, transformer) =>
+        fail("It shouldn't be here")
+      case column =>
+        column shouldBe "column"
+    }
+  }
+
+}

--- a/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/SparkRevisionFactoryTest.scala
@@ -32,37 +32,6 @@ class SparkRevisionFactoryTest extends QbeastIntegrationTestSpec {
 
   behavior of "SparkRevisionFactory"
 
-  it should "detect the correct types in getColumnQType" in withSpark(spark => {
-
-    import spark.implicits._
-    val df = spark.range(10).map(i => T3(i, i * 2.0, s"$i", i * 1.2f)).schema
-
-    SparkRevisionFactory.getColumnQType("a", df) shouldBe LongDataType
-    SparkRevisionFactory.getColumnQType("b", df) shouldBe DoubleDataType
-    SparkRevisionFactory.getColumnQType("c", df) shouldBe StringDataType
-    SparkRevisionFactory.getColumnQType("d", df) shouldBe FloatDataType
-
-  })
-
-  it should "should extract correctly the type" in {
-
-    import SparkRevisionFactory.SpecExtractor
-
-    "column:LinearTransformer" match {
-      case SpecExtractor(column, transformer) =>
-        column shouldBe "column"
-        transformer shouldBe "LinearTransformer"
-      case _ => fail("It did not recognize the type")
-    }
-
-    "column" match {
-      case SpecExtractor(column, transformer) =>
-        fail("It shouldn't be here")
-      case column =>
-        column shouldBe "column"
-    }
-  }
-
   it should "createNewRevision with only one columns" in withSpark(spark => {
     import spark.implicits._
     val schema = spark.range(1).map(i => T3(i, i * 2.0, s"$i", i * 1.2f)).schema

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
@@ -156,10 +156,11 @@ class QbeastSamplingTest extends QbeastIntegrationTestSpec {
         val dataSize = data.count()
 
         val precision = 0.1
+        val precisionPercent = precision * 100
         val tolerance = 0.01
         // We allow a 1% of tolerance in the sampling
         spark
-          .sql(s"SELECT * FROM table TABLESAMPLE($precision PERCENT)")
+          .sql(s"SELECT * FROM table TABLESAMPLE($precisionPercent PERCENT)")
           .count()
           .toDouble shouldBe (dataSize * precision) +- dataSize * precision * tolerance
 

--- a/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastSamplingTest.scala
@@ -159,7 +159,7 @@ class QbeastSamplingTest extends QbeastIntegrationTestSpec {
         val tolerance = 0.01
         // We allow a 1% of tolerance in the sampling
         spark
-          .sql(s"SELECT * FROM qbeast TABLESAMPLE($precision PERCENT)")
+          .sql(s"SELECT * FROM table TABLESAMPLE($precision PERCENT)")
           .count()
           .toDouble shouldBe (dataSize * precision) +- dataSize * precision * tolerance
 


### PR DESCRIPTION
## Description

Fixes #352 

## Type of change

Bug Fix. 

This PR also centralizes the parsing of `ColumnToIndex` in the `QbeastOptions` case class, including a method to convert to the transformer. This is a way of using the same mechanism for parsing the string saved in the options in different places.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Tested on `QbeastSamplingTest`. It should fail with prior versions of the code.

**Test Configuration**:
* Spark Version: 3.5.0
* Hadoop Version: 3.3.4
* Cluster or local? Local