### PR TITLE
Issue 350: Retrieve Revision information from QbeastTable

### DIFF
--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -18,6 +18,7 @@ package io.qbeast.spark
 import io.qbeast.context.QbeastContext
 import io.qbeast.core.model.DenormalizedBlock
 import io.qbeast.core.model.QTableID
+import io.qbeast.core.model.Revision
 import io.qbeast.core.model.RevisionID
 import io.qbeast.core.model.StagingUtils
 import io.qbeast.spark.delta.DeltaQbeastSnapshot
@@ -155,6 +156,10 @@ class QbeastTable private (
       .map(_.columnName)
   }
 
+  /**
+   * Outputs the indexed columns of the table
+   * @return
+   */
   def indexedColumns(): Seq[String] = {
     latestRevisionAvailable.columnTransformers.map(_.columnName)
   }
@@ -181,6 +186,32 @@ class QbeastTable private (
    */
   def revisionsIDs(): Seq[RevisionID] = {
     qbeastSnapshot.loadAllRevisions.map(_.revisionID)
+  }
+
+  /**
+   * Outputs all the revision information available for the table
+   * @return
+   */
+  def allRevisions(): Seq[Revision] = {
+    qbeastSnapshot.loadAllRevisions
+  }
+
+  /**
+   * Outputs the revision information for the latest revision available
+   * @return
+   */
+  def latestRevision: Revision = {
+    latestRevisionAvailable
+  }
+
+  /**
+   * Outputs the revision information for a given identifier
+   * @param revisionID the identifier of the revision
+   * @return
+   */
+  def revision(revisionID: RevisionID): Revision = {
+    checkRevisionAvailable(revisionID)
+    qbeastSnapshot.loadRevision(revisionID)
   }
 
   /**

--- a/src/main/scala/io/qbeast/spark/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/spark/QbeastTable.scala
@@ -206,7 +206,8 @@ class QbeastTable private (
 
   /**
    * Outputs the revision information for a given identifier
-   * @param revisionID the identifier of the revision
+   * @param revisionID
+   *   the identifier of the revision
    * @return
    */
   def revision(revisionID: RevisionID): Revision = {


### PR DESCRIPTION
## Description

Adds #350 

Three new methods are added to the QbeastTable interface:

```scala
import io.qbeast.spark.QbeastTable

// Init QbeastTable
val qbeastTable = QbeastTable.forPath(spark, "/tmp/dir")

qbeastTable.allRevisions() // List of Revision
qbeastTable.revision(1) // Information of Revision with ID=1
qbeastTable.latestRevision // Information of latest available revision

```
## Type of change

New feature.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

Test on `QbeastTableTest`.