### PR TITLE
Issue 363: Update markdown file links

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ Check [here](https://docs.delta.io/latest/releases.html) for **Delta Lake** and 
 
 # Contribution Guide
 
-See [Contribution Guide](/CONTRIBUTING.md) for more information. 
+See [Contribution Guide](./CONTRIBUTING.md) for more information. 
 
 # License
-See [LICENSE](/LICENSE).
+See [LICENSE](./LICENSE).
 
 # Code of conduct
 
-See [Code of conduct](/CODE_OF_CONDUCT.md)
+See [Code of conduct](./CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## Description

Fixes [issue](https://github.com/Qbeast-io/qbeast-spark/issues/363) #363: Update some markdown files of Qbeast-spark repository.

This PR corrects the path used to link CONTRIBUTING.md, LICENSE.md and CODE_OF_CONDUCT.md in the README.md file so that the MDX compiler doesn't complain about any link.

For example:

```[Contribution Guide](/CONTRIBUTING.md)``` was changed into ```[Contribution Guide](./CONTRIBUTING.md)```

Please @cdelfosse @Jiaweihu08 review the changes.

## Type of change

Documentation update in the README.md file. 


## Checklist:

- [X] Change the documentation.
- [X] Your branch is updated to the main branch (dependent changes have been merged).
