### PR TITLE
Issue 384: Update CODE_OF_CONDUCT.md header

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
+# CODE OF CONDUCT
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, religion, or sexual identity and orientation.


### PR DESCRIPTION
## Description

Fixes #384 . If we don't define a title / header of level 1 in the markdown files, the documentation website will use the name of the file as the title of the page.

<img width="1440" alt="Screenshot 2024-08-09 at 11 23 30" src="https://github.com/user-attachments/assets/fd46b44e-205c-4ee4-b91b-6a77a62b4bf6">


So, to fix that, I defined "CODE OF CONDUCT" as the title of the file. `# CODE OF CONDUCT`

Please, review whenever you can @cdelfosse @Jiaweihu08 

## Type of change

Documentation update.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [X] Change the documentation.
- [X] Add tests.
- [X] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

I ran locally the website in my PC and made sure the new title was correctly displayed.