### PR TITLE
Issue #388: Update build version to 0.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import xerial.sbt.Sonatype._
 import Dependencies._
 
-val mainVersion = "0.7.0-SNAPSHOT"
+val mainVersion = "0.8.0-SNAPSHOT"
 
 // Projects
 lazy val qbeastSpark = (project in file("."))


### PR DESCRIPTION
Adds #388. 
Update `build.sbt` with the next version 0.8.0.