### PR TITLE
Issue 389: Documentation Updates should not trigger CI tests

### DIFF
--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -14,8 +14,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Show modified files in the latest commit
-      run: git show --name-only --oneline HEAD
+    - name: Show modified files in this PR
+      run: git diff --name-only origin/main...HEAD
 
     - name: Show initial value of run_tests
       run: |
@@ -23,16 +23,15 @@ jobs:
     - name: Check if only .md files were changed
       id: check_md_files
       run: |
-          if git show --name-only --oneline HEAD | grep -qv '\.md$'; then
+          if git diff --name-only origin/main...HEAD | grep -qv '\.md$'; then
             echo "run_tests=true" >> $GITHUB_ENV
           else
             echo "Only markdown files were changed. Skipping steps."
           fi
-    - name: Show value of run_tests after checking .md files
+    - name: Show value of run_tests after checking changed files
       run: |
           echo "Value of run_tests after check: ${{ env.run_tests }}"
     - name: Set up JDK 1.8
-      if: env.run_tests == 'true'
       uses: actions/setup-java@v1
       with:
         java-version: 1.8

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -14,8 +14,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Show modified files
-      run: git diff --name-only HEAD^ HEAD
+    - name: Show modified files in the latest commit
+      run: git diff-tree --no-commit-id --name-only -r HEAD
 
     - name: Show initial value of run_tests
       run: |
@@ -23,7 +23,7 @@ jobs:
     - name: Check if only .md files were changed
       id: check_md_files
       run: |
-          if git diff --name-only HEAD^ HEAD | grep -qv '\.md$'; then
+          if git diff-tree --no-commit-id --name-only -r HEAD | grep -qv '\.md$'; then
             echo "run_tests=true" >> $GITHUB_ENV
           else
             echo "Only markdown files were changed. Skipping steps."

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -13,18 +13,31 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Check if only .md files were changed
+      id: check_md_files
+      run: |
+          if git diff --name-only HEAD^ HEAD | grep -qv '\.md$'; then
+            echo "run_tests=true" >> $GITHUB_ENV
+          else
+            echo "Only markdown files were changed. Skipping steps."
+          fi
     - name: Set up JDK 1.8
+      if: env.run_tests == 'true'
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
     - name: Assembly
+      if: env.run_tests == 'true'
       run: sbt assembly
     - name: Lint
+      if: env.run_tests == 'true'
       run: sbt "scalafixAll --check"
     - name: Test
+      if: env.run_tests == 'true'
       run: |
         sbt coverage 'test' coverageReport
     - name: Upload to Codecov
+      if: env.run_tests == 'true'
       run: |
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
         curl -Os https://uploader.codecov.io/latest/linux/codecov
@@ -35,4 +48,5 @@ jobs:
         chmod +x codecov
         ./codecov -t ${{ secrets.CODECOV_TOKEN }}
     - name: Formatting of code and Scaladocs
+      if: env.run_tests == 'true'
       run: sbt scalafmtSbtCheck doc

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Show modified files in the latest commit
-      run: git diff-tree --no-commit-id --name-only -r HEAD
+      run: git show --name-only --oneline HEAD
 
     - name: Show initial value of run_tests
       run: |
@@ -23,7 +23,7 @@ jobs:
     - name: Check if only .md files were changed
       id: check_md_files
       run: |
-          if git diff-tree --no-commit-id --name-only -r HEAD | grep -qv '\.md$'; then
+          if git show --name-only --oneline HEAD | grep -qv '\.md$'; then
             echo "run_tests=true" >> $GITHUB_ENV
           else
             echo "Only markdown files were changed. Skipping steps."

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -13,6 +13,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Show modified files
+      run: git diff --name-only HEAD^ HEAD
+
+    - name: Show initial value of run_tests
+      run: |
+          echo "Initial value of run_tests: ${{ env.run_tests }}"
     - name: Check if only .md files were changed
       id: check_md_files
       run: |
@@ -21,6 +27,9 @@ jobs:
           else
             echo "Only markdown files were changed. Skipping steps."
           fi
+    - name: Show value of run_tests after checking .md files
+      run: |
+          echo "Value of run_tests after check: ${{ env.run_tests }}"
     - name: Set up JDK 1.8
       if: env.run_tests == 'true'
       uses: actions/setup-java@v1

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -9,12 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}
+      run_tests: 'false'
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Show modified files
-      run: git diff --name-only HEAD^ HEAD
+      run: git diff --name-only HEAD~1 HEAD
 
     - name: Show initial value of run_tests
       run: |
@@ -22,7 +23,7 @@ jobs:
     - name: Check if only .md files were changed
       id: check_md_files
       run: |
-          if git diff --name-only HEAD^ HEAD | grep -qv '\.md$'; then
+          if git diff --name-only HEAD~1 HEAD | grep -qv '\.md$'; then
             echo "run_tests=true" >> $GITHUB_ENV
           else
             echo "Only markdown files were changed. Skipping steps."

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -2,11 +2,15 @@ name: Test artifact
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - 'src/**'
+      - 'build.sbt'
+      - 'project/**'
   pull_request:
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - 'src/**'
+      - 'build.sbt'
+      - 'project/**'
 
 jobs:
   test-artifact:

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Show modified files
-      run: git diff --name-only HEAD~1 HEAD
+      run: git diff --name-only HEAD^ HEAD
 
     - name: Show initial value of run_tests
       run: |
@@ -23,7 +23,7 @@ jobs:
     - name: Check if only .md files were changed
       id: check_md_files
       run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qv '\.md$'; then
+          if git diff --name-only HEAD^ HEAD | grep -qv '\.md$'; then
             echo "run_tests=true" >> $GITHUB_ENV
           else
             echo "Only markdown files were changed. Skipping steps."

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -27,7 +27,6 @@ jobs:
       with:
         java-version: 1.8
     - name: Assembly
-      if: env.run_tests == 'true'
       run: sbt assembly
     - name: Lint
       if: env.run_tests == 'true'

--- a/.github/workflows/test-artifact.yml
+++ b/.github/workflows/test-artifact.yml
@@ -2,35 +2,21 @@ name: Test artifact
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test-artifact:
     runs-on: ubuntu-latest
     env:
       GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}
-      run_tests: 'false'
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Show modified files in this PR
-      run: git diff --name-only origin/main...HEAD
-
-    - name: Show initial value of run_tests
-      run: |
-          echo "Initial value of run_tests: ${{ env.run_tests }}"
-    - name: Check if only .md files were changed
-      id: check_md_files
-      run: |
-          if git diff --name-only origin/main...HEAD | grep -qv '\.md$'; then
-            echo "run_tests=true" >> $GITHUB_ENV
-          else
-            echo "Only markdown files were changed. Skipping steps."
-          fi
-    - name: Show value of run_tests after checking changed files
-      run: |
-          echo "Value of run_tests after check: ${{ env.run_tests }}"
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
@@ -38,14 +24,11 @@ jobs:
     - name: Assembly
       run: sbt assembly
     - name: Lint
-      if: env.run_tests == 'true'
       run: sbt "scalafixAll --check"
     - name: Test
-      if: env.run_tests == 'true'
       run: |
         sbt coverage 'test' coverageReport
     - name: Upload to Codecov
-      if: env.run_tests == 'true'
       run: |
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
         curl -Os https://uploader.codecov.io/latest/linux/codecov
@@ -56,5 +39,4 @@ jobs:
         chmod +x codecov
         ./codecov -t ${{ secrets.CODECOV_TOKEN }}
     - name: Formatting of code and Scaladocs
-      if: env.run_tests == 'true'
       run: sbt scalafmtSbtCheck doc

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # CODE OF CONDUCT
 
-## Our Pledge
+## Our Pledge!
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # CODE OF CONDUCT
 
-## Our Pledge!
+## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 


### PR DESCRIPTION
## Description


Fixes #389. In this PR I will try to edit the CI that is executed in github actions everytime someone pushes some changes to a Pull Request in the qbeast-spark repository. If only markdown files have been modified, we will try to skip most of the steps of the worfklow.

Please review whenever you can @cdelfosse @osopardo1 


## Type of change

I have created a new step on the workflow. This step will check if the modified files are markdown files, if that's not the case a variable called `run tests` will be set to true so that the remaining steps can be executed by using if statements. If only .md files are modified, the `run tests`variable will remain unchanged and the next steps will be skipped.


## Checklist:


- [X] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
