### PR TITLE
Issue #294: Optimization of Unindexed Files [Staging Area]

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/QbeastSnapshot.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastSnapshot.scala
@@ -31,6 +31,16 @@ trait QbeastSnapshot {
   def isInitial: Boolean
 
   /**
+   * Returns true if a revision with a specific revision identifier exists
+   *
+   * @param revisionID
+   *   the identifier of the revision
+   * @return
+   *   boolean
+   */
+  def existsRevision(revisionID: RevisionID): Boolean
+
+  /**
    * Returns the total number of data files in the snapshot.
    */
   def allFilesCount: Long

--- a/core/src/main/scala/io/qbeast/core/model/QbeastSnapshot.scala
+++ b/core/src/main/scala/io/qbeast/core/model/QbeastSnapshot.scala
@@ -31,16 +31,6 @@ trait QbeastSnapshot {
   def isInitial: Boolean
 
   /**
-   * Returns true if a revision with a specific revision identifier exists
-   *
-   * @param revisionID
-   *   the identifier of the revision
-   * @return
-   *   boolean
-   */
-  def existsRevision(revisionID: RevisionID): Boolean
-
-  /**
    * Returns the total number of data files in the snapshot.
    */
   def allFilesCount: Long

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaQbeastSnapshot.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaQbeastSnapshot.scala
@@ -212,17 +212,17 @@ case class DeltaQbeastSnapshot(tableID: QTableID) extends QbeastSnapshot with De
    *   the Datasetframe
    */
 
-  override def loadDataframeFromIndexFiles(indexFile: Dataset[IndexFile]): DataFrame = {
+  override def loadDataframeFromIndexFiles(indexFiles: Dataset[IndexFile]): DataFrame = {
     if (snapshot.deletionVectorsSupported) {
 
       // TODO find a cleaner version to get a subset of data from the parquet considering the deleted parts.
       throw new UnsupportedOperationException("Deletion vectors are not supported yet")
     } else {
-      import indexFile.sparkSession.implicits._
+      import indexFiles.sparkSession.implicits._
       val rootPath = snapshot.path.getParent
-      val paths = indexFile.map(ifile => new Path(rootPath, ifile.path).toString).collect()
+      val paths = indexFiles.map(ifile => new Path(rootPath, ifile.path).toString).collect()
 
-      indexFile.sparkSession.read
+      indexFiles.sparkSession.read
         .schema(snapshot.schema)
         .parquet(paths: _*)
 

--- a/docs/QbeastTable.md
+++ b/docs/QbeastTable.md
@@ -31,11 +31,11 @@ qbeatsTable.lastRevisionID() // the last Revision identifier
 Through `QbeastTable` you can also execute the `Optimize` operation. This command is used to **rearrange the files in the table** according to the dictates of the index to render queries more efficient. 
 
 #### Paramaters of Manual Optimization
-| Parameter    | Description                                                                                               | Default            |
-|--------------|-----------------------------------------------------------------------------------------------------------|--------------------|
-| `revisionID` | The revision number you want to optimize.                                                                 | Latest revision    |
-| `fraction`   | The fraction of the data of the specified revision you want to optimize.                                  | None specified     |
-| `options`    | A map of options for optimization. You can specify `userMetadata` and configurations for `PreCommitHook`. | None specified     |
+| Parameter    | Description                                                                                               | Default         |
+|--------------|-----------------------------------------------------------------------------------------------------------|-----------------|
+| `revisionID` | The revision number you want to optimize.                                                                 | Latest revision |
+| `fraction`   | The fraction of the data of the specified revision you want to optimize.                                  | 1.0             |
+| `options`    | A map of options for optimization. You can specify `userMetadata` and configurations for `PreCommitHook`. | None specified  |
 
 
 #### Examples of Manual Optimization

--- a/docs/QbeastTable.md
+++ b/docs/QbeastTable.md
@@ -26,13 +26,19 @@ qbeatsTable.lastRevisionID() // the last Revision identifier
 ```
 
 ## Table Operations
+
+### Optimization
 Through `QbeastTable` you can also execute the `Optimize` operation. This command is used to **rearrange the files in the table** according to the dictates of the index to render queries more efficient. 
 
-These are a few different ways of executing the `optimize` operation, with the input parameters being:
-1. `revisionID`: The revision number you want to optimize, the default is the latest revision.
-2. `fraction`: The fraction of the data of the specified revision you want to optimize.
-3. `options`: A map of options of the optimization. You can specify the `userMetadata` as well as configurations for `io.qbeast.spark.delta.hook.PreCommitHook.`
+#### Paramaters of Manual Optimization
+| Parameter    | Description                                                                                               | Default            |
+|--------------|-----------------------------------------------------------------------------------------------------------|--------------------|
+| `revisionID` | The revision number you want to optimize.                                                                 | Latest revision    |
+| `fraction`   | The fraction of the data of the specified revision you want to optimize.                                  | None specified     |
+| `options`    | A map of options for optimization. You can specify `userMetadata` and configurations for `PreCommitHook`. | None specified     |
 
+
+#### Examples of Manual Optimization
 ```scala
 // Optimizing 10% of the data from Revision number 2, and stores some user metadata
 qbeastTable.optmize(2L, 0.1, Map["userMetadata" -> "user-metadata-for-optimization"])
@@ -45,6 +51,25 @@ qbeastTable.optimize()
 
 // Optimizes the specific files
 qbeastTable.optimize(Seq("file1", "file2"))
+```
+
+### Optimization of Unindexed Files
+
+There are some use cases in which a Table could have several **Unindexed Files**.
+- **Staging Data**: Enabling the Staging Area gives the possibility to **ingest data without indexing it**. Since very small appends could produce overhead during the write process, the new data would be commited to the table without reorganization. Every time the staging are size is reached, the data is indexed using the latest state of the Table. 
+- **Table Converted To Qbeast**: An existing `parquet` or `delta` Table can be converted to a `qbeast` Table through the `ConvertToQbeastCommand`. Since the table can be very big, the conversion only adds a metadata commit to the Log, indicating that from that point onwards the appends would be indexed with Qbeast.
+- **External Table Writers**: External writers can write data to the table in the underlying format (delta, hudi or iceberg)
+
+All the sets of Unindexed Files are mapped to a revision number 0. For manually indexing these files, you can use the `optimize` method with the `revisionId` parameter set to 0.
+
+#### Examples of Manual Optimization of Unindexed Files
+```scala
+qbeastTable.optimize(revisionId = 0L)
+
+// If the table is very large, 
+// we recommend to use the fraction configuration 
+// to decide the percentage of unindexed ddta to optimize
+qbeastTable.optimize(revisionId = 0L, fraction = 0.5)
 ```
 
 ## Index Metrics

--- a/docs/QbeastTable.md
+++ b/docs/QbeastTable.md
@@ -41,7 +41,7 @@ Through `QbeastTable` you can also execute the `Optimize` operation. This comman
 #### Examples of Manual Optimization
 ```scala
 // Optimizing 10% of the data from Revision number 2, and stores some user metadata
-qbeastTable.optmize(2L, 0.1, Map["userMetadata" -> "user-metadata-for-optimization"])
+qbeastTable.optimize(2L, 0.1, Map["userMetadata" -> "user-metadata-for-optimization"])
 
 // Optimizing all data from a given Revision
 qbeastTable.optimize(2L)
@@ -56,11 +56,11 @@ qbeastTable.optimize(Seq("file1", "file2"))
 ### Optimization of Unindexed Files
 
 There are some use cases in which a Table could have several **Unindexed Files**.
-- **Staging Data**: Enabling the Staging Area gives the possibility to **ingest data without indexing it**. Since very small appends could produce overhead during the write process, the new data would be commited to the table without reorganization. Every time the staging are size is reached, the data is indexed using the latest state of the Table. 
-- **Table Converted To Qbeast**: An existing `parquet` or `delta` Table can be converted to a `qbeast` Table through the `ConvertToQbeastCommand`. Since the table can be very big, the conversion only adds a metadata commit to the Log, indicating that from that point onwards the appends would be indexed with Qbeast.
+- **Staging Data**: Enabling the Staging Area gives the possibility to **ingest data without indexing it**. Since very small appends could produce overhead during the write process, the new data would be commited to the table without reorganization. Every time the staging area size is reached, the data could be indexed using the latest state of the Table. 
+- **Table Converted To Qbeast**: An existing `parquet` or `delta` Table can be converted to a `qbeast` Table through the `ConvertToQbeastCommand`. Since the table can be very big, the conversion only adds a metadata commit to the Log, indicating that from that point onwards the appends could be indexed with Qbeast.
 - **External Table Writers**: External writers can write data to the table in the underlying format (delta, hudi or iceberg)
 
-All the sets of Unindexed Files are mapped to a revision number 0. For manually indexing these files, you can use the `optimize` method with the `revisionId` parameter set to 0.
+All the Unindexed Files are mapped to a revision number 0. For manually indexing these files, you can use the `optimize` method with the `revisionId` parameter set to 0.
 
 #### Examples of Manual Optimization of Unindexed Files
 ```scala

--- a/src/main/scala/io/qbeast/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/table/IndexedTable.scala
@@ -140,7 +140,7 @@ trait IndexedTable {
    * @param options
    *   Optimization options where user metadata and pre-commit hooks are specified.
    */
-  def optimizeIndexFiles(indexFiles: Seq[String], options: Map[String, String]): Unit
+  def optimizeIndexedFiles(indexFiles: Seq[String], options: Map[String, String]): Unit
 
   /**
    * Optimizes the table by optimizing the data stored in the specified unindexed files.
@@ -556,7 +556,7 @@ private[table] class IndexedTableImpl(
     if (isStaging(revisionID)) { // If the revision is Staging, we should INDEX the staged data up to the fraction
       optimizeUnindexedFiles(selectUnindexedFilesToOptimize(fraction), options)
     } else { // If the revision is not Staging, we should optimize the index files up to the fraction
-      optimizeIndexFiles(selectIndexedFilesToOptimize(revisionID, fraction), options)
+      optimizeIndexedFiles(selectIndexedFilesToOptimize(revisionID, fraction), options)
     }
   }
 
@@ -605,7 +605,7 @@ private[table] class IndexedTableImpl(
     }
   }
 
-  override def optimizeIndexFiles(files: Seq[String], options: Map[String, String]): Unit = {
+  override def optimizeIndexedFiles(files: Seq[String], options: Map[String, String]): Unit = {
     if (files.isEmpty) return // Nothing to optimize
     val paths = files.toSet
     val schema = metadataManager.loadCurrentSchema(tableID)

--- a/src/main/scala/io/qbeast/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/table/IndexedTable.scala
@@ -575,6 +575,7 @@ private[table] class IndexedTableImpl(
   }
 
   override def optimizeIndexFiles(files: Seq[String], options: Map[String, String]): Unit = {
+    if (files.isEmpty) return // Nothing to optimize
     val paths = files.toSet
     val schema = metadataManager.loadCurrentSchema(tableID)
     // For each Revision, excluding the Staging,

--- a/src/main/scala/io/qbeast/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/table/IndexedTable.scala
@@ -565,7 +565,13 @@ private[table] class IndexedTableImpl(
       // Index the data with IndexManager
       val (data, tableChanges) = indexManager.index(filesDF, latestIndexStatus)
       // Write the data with DataWriter
-      val newFiles = dataWriter.write(tableID, schema, data, tableChanges)
+      val newFiles =
+        dataWriter
+          .write(tableID, schema, data, tableChanges)
+          .collect { case addFile: AddFile =>
+            addFile.copy(dataChange = false)
+          }
+          .toIndexedSeq
       // Remove the Unindexed Files from the Log
       val removeFiles =
         files.map(IndexFiles.toRemoveFile(dataChange = false)).collect().toIndexedSeq

--- a/src/main/scala/io/qbeast/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/table/IndexedTable.scala
@@ -572,10 +572,11 @@ private[table] class IndexedTableImpl(
   override def optimizeUnindexedFiles(
       unindexedFiles: Seq[String],
       options: Map[String, String]): Unit = {
-    if (unindexedFiles.isEmpty) return // Nothing to optimize
+    val unindexedFilesPaths = unindexedFiles.toSet
+    if (unindexedFilesPaths.isEmpty) return // Nothing to optimize
     // 1. Load the files from the Staging ID (Unindexed)
     val files =
-      snapshot.loadIndexFiles(stagingID).filter(f => unindexedFiles.contains(f.path))
+      snapshot.loadIndexFiles(stagingID).filter(f => unindexedFilesPaths.contains(f.path))
     import files.sparkSession.implicits._
     // 2. Load the Dataframe, the latest index status and the schema
     val filesDF = snapshot.loadDataframeFromIndexFiles(files)

--- a/src/main/scala/io/qbeast/table/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/table/QbeastTable.scala
@@ -167,7 +167,7 @@ class QbeastTable private (
    *   Optimization options where user metadata and pre-commit hooks are specified.
    */
   def optimize(files: Seq[String], options: Map[String, String]): Unit =
-    indexedTable.optimizeIndexFiles(files, options)
+    indexedTable.optimizeIndexedFiles(files, options)
 
   def optimize(files: Seq[String]): Unit =
     optimize(files, Map.empty[String, String])

--- a/src/main/scala/io/qbeast/table/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/table/QbeastTable.scala
@@ -56,7 +56,7 @@ class QbeastTable private (
    *   the revision to check
    */
   private def checkRevisionAvailable(revisionID: RevisionID): Unit = {
-    if (revisionID != stagingID && !qbeastSnapshot.existsRevision(revisionID)) {
+    if (!isStaging(revisionID) && !qbeastSnapshot.existsRevision(revisionID)) {
       throw AnalysisExceptionFactory.create(
         s"Revision $revisionID does not exists. " +
           s"The latest revision available is $latestRevisionID")

--- a/src/main/scala/io/qbeast/table/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/table/QbeastTable.scala
@@ -56,7 +56,7 @@ class QbeastTable private (
    *   the revision to check
    */
   private def checkRevisionAvailable(revisionID: RevisionID): Unit = {
-    if (!qbeastSnapshot.existsRevision(revisionID) && revisionID != stagingID) {
+    if (revisionID != stagingID && !qbeastSnapshot.existsRevision(revisionID)) {
       throw AnalysisExceptionFactory.create(
         s"Revision $revisionID does not exists. " +
           s"The latest revision available is $latestRevisionID")

--- a/src/main/scala/io/qbeast/table/QbeastTable.scala
+++ b/src/main/scala/io/qbeast/table/QbeastTable.scala
@@ -56,7 +56,7 @@ class QbeastTable private (
    *   the revision to check
    */
   private def checkRevisionAvailable(revisionID: RevisionID): Unit = {
-    if (!isStaging(revisionID) && !qbeastSnapshot.existsRevision(revisionID)) {
+    if (!qbeastSnapshot.existsRevision(revisionID)) {
       throw AnalysisExceptionFactory.create(
         s"Revision $revisionID does not exists. " +
           s"The latest revision available is $latestRevisionID")

--- a/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
@@ -20,7 +20,6 @@ import io.qbeast.internal.commands.ConvertToQbeastCommand
 import io.qbeast.spark.utils.QbeastExceptionMessages.incorrectIdentifierFormat
 import io.qbeast.spark.utils.QbeastExceptionMessages.partitionedTableExceptionMsg
 import io.qbeast.spark.utils.QbeastExceptionMessages.unsupportedFormatExceptionMsg
-import io.qbeast.table.QbeastTable
 import io.qbeast.QbeastIntegrationTestSpec
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.SparkSession

--- a/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/ConvertToQbeastTest.scala
@@ -206,17 +206,4 @@ class ConvertToQbeastTest
       isStaging(rev) shouldBe false
     })
 
-  "Optimizing the staging revision" should "not corrupt the data" in
-    withSparkAndTmpDir((spark, tmpDir) => {
-      val fileFormat = "parquet"
-      convertFromFormat(spark, fileFormat, tmpDir)
-
-      QbeastTable.forPath(spark, tmpDir).optimize()
-
-      // Compare DataFrames
-      val sourceDf = spark.read.format(fileFormat).load(tmpDir)
-      val qbeastDf = spark.read.format("qbeast").load(tmpDir)
-      assertLargeDatasetEquality(qbeastDf, sourceDf, orderedComparison = false)
-    })
-
 }

--- a/src/test/scala/io/qbeast/spark/utils/PreCommitHookIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/PreCommitHookIntegrationTest.scala
@@ -68,6 +68,7 @@ class PreCommitHookIntegrationTest extends QbeastIntegrationTestSpec {
       val indexedTable = QbeastContext.indexedTableFactory.getIndexedTable(QTableID(tmpDir))
       indexedTable.optimize(
         1L,
+        1.0,
         Map(
           s"$PRE_COMMIT_HOOKS_PREFIX.hook_1" -> classOf[SimpleHook].getCanonicalName,
           s"$PRE_COMMIT_HOOKS_PREFIX.hook_1.arg" -> "k1:v1",

--- a/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
@@ -278,7 +278,7 @@ class QbeastOptimizeIntegrationTest extends QbeastIntegrationTestSpec {
         ((1.0 - fractionToOptimize) * unindexedFilesSize).toLong)
 
       // Second optimization should index the rest of the Staging Area
-      qt.optimize(revisionID = 0L, fraction = 0.5)
+      qt.optimize(revisionID = 0L, fraction = 1.0)
       val snapshotAfter2 = deltaLog.update()
       val unindexedFiles2 = snapshotAfter2.allFiles.where("tags is null") // no tags
       unindexedFiles2 shouldBe empty

--- a/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
@@ -262,9 +262,8 @@ class QbeastOptimizeIntegrationTest extends QbeastIntegrationTestSpec {
       deltaTable.delete("id > 1 and id < 5")
 
       // Check that the number of unindexed files is not 0
-      val deltaLog = DeltaLog.forTable(spark, tmpDir)
-      val firstSnapshot = deltaLog.update()
-      val firstUnindexedFiles = firstSnapshot.allFiles.where("tags is null")
+      val qtableID = QTableID(tmpDir)
+      val firstUnindexedFiles = getUnindexedFilesFromDelta(qtableID)
       firstUnindexedFiles should not be empty
 
       // Optimize the Table
@@ -272,8 +271,7 @@ class QbeastOptimizeIntegrationTest extends QbeastIntegrationTestSpec {
       qt.optimize(0L)
 
       // After optimization, all files from the Delete Operation should be indexed
-      val snapshot = deltaLog.update()
-      val unindexedFiles = snapshot.allFiles.where("tags is null") // no tags
+      val unindexedFiles = getUnindexedFilesFromDelta(qtableID)
       unindexedFiles shouldBe empty
       // Check latest revision
       checkLatestRevisionAfterOptimize(spark, QTableID(tmpDir))

--- a/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
@@ -16,8 +16,11 @@
 package io.qbeast.spark.utils
 
 import io.qbeast.core.model.IndexFile
+import io.qbeast.core.model.QTableID
+import io.qbeast.spark.delta.DeltaMetadataManager
 import io.qbeast.table.QbeastTable
 import io.qbeast.QbeastIntegrationTestSpec
+import io.qbeast.internal.commands.ConvertToQbeastCommand
 import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.actions.CommitInfo
@@ -141,14 +144,13 @@ class QbeastOptimizeIntegrationTest extends QbeastIntegrationTestSpec {
 
     }
 
-  it should "optimize a table converted to Qbeast" in withQbeastContextSparkAndTmpDir {
   /**
    * Get the unindexed files from the last updated Snapshot
    * @param deltaLog
    * @return
    */
-  def getUnindexedFilesFromDelta(qtableID: QTableID): Dataset[AddFile] = {
-    SparkDeltaMetadataManager.loadSnapshot(qtableID).loadStagingFiles()
+  def getUnindexedFilesFromDelta(qtableID: QTableID): Dataset[IndexFile] = {
+    DeltaMetadataManager.loadSnapshot(qtableID).loadIndexFiles(0L) // Revision 0L
   }
 
   /**
@@ -157,7 +159,7 @@ class QbeastOptimizeIntegrationTest extends QbeastIntegrationTestSpec {
    * @return
    */
   def getIndexedFilesFromDelta(qtableID: QTableID): Dataset[IndexFile] = {
-    SparkDeltaMetadataManager.loadSnapshot(qtableID).loadLatestIndexFiles
+    DeltaMetadataManager.loadSnapshot(qtableID).loadLatestIndexFiles
   }
 
   def getAllFilesFromDelta(spark: SparkSession, d: QTableID): Dataset[AddFile] = {

--- a/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
@@ -230,7 +230,7 @@ class QbeastOptimizeIntegrationTest extends QbeastIntegrationTestSpec {
 
       // Check that the table size is correct
       val qbeastDF = spark.read.format("qbeast").load(tmpDir)
-      qbeastDF.count() shouldBe 4996
+      qbeastDF.count() shouldBe 4997
   }
 
   it should "Optimize a fraction of the Staging Area" in withQbeastContextSparkAndTmpDir {

--- a/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
+++ b/src/test/scala/io/qbeast/spark/utils/QbeastOptimizeIntegrationTest.scala
@@ -17,10 +17,10 @@ package io.qbeast.spark.utils
 
 import io.qbeast.core.model.IndexFile
 import io.qbeast.core.model.QTableID
+import io.qbeast.internal.commands.ConvertToQbeastCommand
 import io.qbeast.spark.delta.DeltaMetadataManager
 import io.qbeast.table.QbeastTable
 import io.qbeast.QbeastIntegrationTestSpec
-import io.qbeast.internal.commands.ConvertToQbeastCommand
 import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.actions.CommitInfo


### PR DESCRIPTION
## Description


Adds #294 

## Type of change


New Feature. The Unindexed Files of a Qbeast Table were only optimizable from the `StagingDataManager` component. After thinking about structure and use cases, we noticed that the Staging Area has lost its original purpose (check issue #438) and that we should treat Indexed and Unindexed File separately from the Append execution. 

For that reason, we extend the interface of optimization to enable the processing of the unindexed files too. 

#### API

```scala
import io.qbeast.spark.QbeastTable

val qbeastTable = QbeastTable.forPath(spark, "/path")
qbeastTable.optimize(revisionID = 0L, fraction = <fraction_to_optimize>)
```
- `revisionID = 0L` is the selected Revision ID for Unindexed Files.
- `fraction`: Any number from 0.0 to 1.0 that we want to optimize. By default is 1.0. If it's a recently converted table with Qbeast, and contains a lot of legacy data, we suggest reducing the fraction to optimize and doing the operation in batches. 

> WARNING: each time we execute optimize() for the Unindexed Files it would calculate the bytes to optimize from the current state. If some files had already been indexed, they would not be part of the second iteration. 

#### Implementation

1. Load the `QbeastSnapshot` of the Table.
2. Read the list of Unindexed Files from the `QbeastSnapshot`.
3. Select files til `fraction * totalBytes` threshold is reached.
4. Apply indexing and roll-up to the Data.
5. Write the data in files.
6. In the same transaction: (this step should be done internally as Qbeast Spark, since we have more control of Add Files, Delete Files, and transaction open/close. )
    1. mark the old files as Deleted.
    2. Add the new file entries.


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

This has been tested locally with: `QbeastOptimizationIntegrationTest`.

I've added four cases:
1. Optimization of a Converted Table. (All data is unindexed).
2. Optimization of a Hybrid Table after Append. (Some data is unindexed after an external append).
3. Optimization of a fraction of a Hybrid Table. (Do not optimize all the Unindexed Files at once). 

**Test Configuration**:
* Spark Version: 3.5.0
* Hadoop Version: 3.3.4
* Cluster or local? Local