### PR TITLE
Issue #454: Next in line Rollup

### DIFF
--- a/src/test/scala/io/qbeast/spark/delta/DeltaRollupDataWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/DeltaRollupDataWriterTest.scala
@@ -62,7 +62,7 @@ class DeltaRollupDataWriterTest extends QbeastIntegrationTestSpec {
     }
 
   it should "compute rollup correctly when optimizing" in
-    withSparkAndTmpDir { (spark, tmpDir) =>
+    withSparkAndTmpDir { (_, tmpDir) =>
       val revision =
         Revision(1L, 0, QTableID(tmpDir), 20, Vector(EmptyTransformer("col_1")), Vector.empty)
 
@@ -77,7 +77,7 @@ class DeltaRollupDataWriterTest extends QbeastIntegrationTestSpec {
         Map(root -> 20L, c1 -> 1L, c2 -> 20L))
 
       val rollup = DeltaRollupDataWriter.computeRollup(tc)
-      rollup shouldBe Map(root -> root, c1 -> root, c2 -> c2)
+      rollup shouldBe Map(root -> root, c1 -> c2, c2 -> c2)
     }
 
 }

--- a/src/test/scala/io/qbeast/spark/writer/RollupTest.scala
+++ b/src/test/scala/io/qbeast/spark/writer/RollupTest.scala
@@ -1,30 +1,12 @@
-/*
- * Copyright 2021 Qbeast Analytics, S.L.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.qbeast.spark.writer
 
 import io.qbeast.core.model.CubeId
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-/**
- * Tests of Rollup.
- */
 class RollupTest extends AnyFlatSpec with Matchers {
 
-  "Rollup" should "work correctly" in {
+  "Rollup" should "work correctly with basic cube structure" in {
     val root = CubeId.root(1)
     val c0 = root.firstChild
     val c1 = c0.nextSibling.get
@@ -44,8 +26,38 @@ class RollupTest extends AnyFlatSpec with Matchers {
     result(root) shouldBe root
     result(c00) shouldBe c0
     result(c01) shouldBe c0
-    result(c10) shouldBe root
+    result(c10) shouldBe c11 // rolliing up into the next siblings.
     result(c11) shouldBe c11
   }
+
+  it should "handle empty rollup" in {
+    val result = new Rollup(3).compute()
+    result shouldBe empty
+  }
+
+  it should "handle single cube" in {
+    val root = CubeId.root(1)
+    val result = new Rollup(3)
+      .populate(root, 2)
+      .compute()
+
+    result(root) shouldBe root
+  }
+
+  it should "roll up to parent when size exceeds limit" in {
+    val root = CubeId.root(1)
+    val kids = root.children.toSeq
+    val child = kids(0)
+    val grandChild = kids(1)
+
+    val result = new Rollup(2)
+      .populate(root,1)
+      .populate(child,2)
+      .populate(grandChild, 3) // Exceeds limit
+      .compute()
+
+    result(grandChild) shouldBe grandChild
+  }
+
 
 }


### PR DESCRIPTION
## Description
As described in issue #454, I'm having some issues indexing high-dimensional spaces as the rollup puts all data in the father, which might result in very large files. This PR solves this problem by rolling up between siblings before rolling up to the father. This results in better file size, but as pointed out by @Jiaweihu08, it could make the algorithm more computation-intensive. 

## Type of change
This PR changes the Rollup algorithm, trying to pack siblings' cubes first and then packing them with the father. 

## Checklist:

- [x] Changed the code
- [x] Updated unit tests
- [x] Tested with high dimensional data
- [ ] Tested with existing use cases to check any possible regression. 
- [ ] Updated documentation
