### PR TITLE
Issue #463: Support custom filename patterns in DataWriter

### DIFF
--- a/core/src/main/scala/io/qbeast/spark/index/QbeastColumns.scala
+++ b/core/src/main/scala/io/qbeast/spark/index/QbeastColumns.scala
@@ -52,7 +52,7 @@ object QbeastColumns {
   /**
    * Cube to rollup column name.
    */
-  val cubeToRollupColumnName = "_qbeastCubeToRollup"
+  val fileUUIDColumnName = "_qbeastFileUUID"
 
   /**
    * Cube to rollup file name column name.
@@ -65,7 +65,7 @@ object QbeastColumns {
     stateColumnName,
     revisionColumnName,
     cubeToReplicateColumnName,
-    cubeToRollupColumnName,
+    fileUUIDColumnName,
     filenameColumnName)
 
   /**
@@ -94,7 +94,7 @@ object QbeastColumns {
       stateColumnIndex = columnIndexes.getOrElse(stateColumnName, -1),
       revisionColumnIndex = columnIndexes.getOrElse(revisionColumnName, -1),
       cubeToReplicateColumnIndex = columnIndexes.getOrElse(cubeToReplicateColumnName, -1),
-      cubeToRollupColumnIndex = columnIndexes.getOrElse(cubeToRollupColumnName, -1),
+      fileUUIDColumnIndex = columnIndexes.getOrElse(fileUUIDColumnName, -1),
       filenameColumnIndex = columnIndexes.getOrElse(filenameColumnName, -1))
   }
 
@@ -134,8 +134,8 @@ object QbeastColumns {
  *   the revision column index or -1 if it is missing
  * @param cubeToReplicateColumnIndex
  *   the cube to replicate column index or -1 if it is missing
- * @param cubeToRollupColumnIndex
- *   the cube to rollup column index or -1 if it is missing
+ * @param fileUUIDColumnIndex
+ *   target file UUID column index or -1 if it is missing
  * @param filenameColumnIndex
  *   the cube to rollup file name column index or -1 if it is missing
  */
@@ -145,7 +145,7 @@ case class QbeastColumns(
     stateColumnIndex: Int,
     revisionColumnIndex: Int,
     cubeToReplicateColumnIndex: Int,
-    cubeToRollupColumnIndex: Int,
+    fileUUIDColumnIndex: Int,
     filenameColumnIndex: Int) {
 
   /**
@@ -162,7 +162,7 @@ case class QbeastColumns(
     columnIndex == stateColumnIndex ||
     columnIndex == revisionColumnIndex ||
     columnIndex == cubeToReplicateColumnIndex ||
-    columnIndex == cubeToRollupColumnIndex ||
+    columnIndex == fileUUIDColumnIndex ||
     columnIndex == filenameColumnIndex
   }
 
@@ -212,7 +212,7 @@ case class QbeastColumns(
    * @return
    *   the cube to rollup column exists
    */
-  def hasCubeToRollupColumn: Boolean = cubeToRollupColumnIndex >= 0
+  def hasFileUUIDColumn: Boolean = fileUUIDColumnIndex >= 0
 
   /**
    * Returns whether the filename column exists.

--- a/core/src/main/scala/io/qbeast/spark/index/QbeastColumns.scala
+++ b/core/src/main/scala/io/qbeast/spark/index/QbeastColumns.scala
@@ -54,13 +54,19 @@ object QbeastColumns {
    */
   val cubeToRollupColumnName = "_qbeastCubeToRollup"
 
+  /**
+   * Cube to rollup file name column name.
+   */
+  val filenameColumnName = "_qbeastFilename"
+
   val columnNames: Set[String] = Set(
     weightColumnName,
     cubeColumnName,
     stateColumnName,
     revisionColumnName,
     cubeToReplicateColumnName,
-    cubeToRollupColumnName)
+    cubeToRollupColumnName,
+    filenameColumnName)
 
   /**
    * Creates an instance for a given data frame.
@@ -88,7 +94,8 @@ object QbeastColumns {
       stateColumnIndex = columnIndexes.getOrElse(stateColumnName, -1),
       revisionColumnIndex = columnIndexes.getOrElse(revisionColumnName, -1),
       cubeToReplicateColumnIndex = columnIndexes.getOrElse(cubeToReplicateColumnName, -1),
-      cubeToRollupColumnIndex = columnIndexes.getOrElse(cubeToRollupColumnName, -1))
+      cubeToRollupColumnIndex = columnIndexes.getOrElse(cubeToRollupColumnName, -1),
+      filenameColumnIndex = columnIndexes.getOrElse(filenameColumnName, -1))
   }
 
   /**
@@ -129,6 +136,8 @@ object QbeastColumns {
  *   the cube to replicate column index or -1 if it is missing
  * @param cubeToRollupColumnIndex
  *   the cube to rollup column index or -1 if it is missing
+ * @param filenameColumnIndex
+ *   the cube to rollup file name column index or -1 if it is missing
  */
 case class QbeastColumns(
     weightColumnIndex: Int,
@@ -136,7 +145,8 @@ case class QbeastColumns(
     stateColumnIndex: Int,
     revisionColumnIndex: Int,
     cubeToReplicateColumnIndex: Int,
-    cubeToRollupColumnIndex: Int) {
+    cubeToRollupColumnIndex: Int,
+    filenameColumnIndex: Int) {
 
   /**
    * Returns whether a given column is one of the Qbeast columns.
@@ -152,7 +162,8 @@ case class QbeastColumns(
     columnIndex == stateColumnIndex ||
     columnIndex == revisionColumnIndex ||
     columnIndex == cubeToReplicateColumnIndex ||
-    columnIndex == cubeToRollupColumnIndex
+    columnIndex == cubeToRollupColumnIndex ||
+    columnIndex == filenameColumnIndex
   }
 
   /**
@@ -202,4 +213,12 @@ case class QbeastColumns(
    *   the cube to rollup column exists
    */
   def hasCubeToRollupColumn: Boolean = cubeToRollupColumnIndex >= 0
+
+  /**
+   * Returns whether the filename column exists.
+   *
+   * @return
+   *   the filename column exists
+   */
+  def hasFilenameColumn: Boolean = filenameColumnIndex >= 0
 }

--- a/core/src/main/scala/io/qbeast/spark/writer/IndexFileWriterFactory.scala
+++ b/core/src/main/scala/io/qbeast/spark/writer/IndexFileWriterFactory.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.execution.datasources.WriteJobStatsTracker
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
-import java.util.UUID
-
 /**
  * Factory for creating IndexFileWriter instances.
  *
@@ -60,8 +58,8 @@ private[writer] class IndexFileWriterFactory(
    * @return
    *   a new IndexFileWriter instance
    */
-  def createIndexFileWriter(): IndexFileWriter = {
-    val path = new Path(tableId.id, s"${UUID.randomUUID()}.parquet").toString
+  def createIndexFileWriter(fileName: String): IndexFileWriter = {
+    val path = new Path(tableId.id, fileName).toString
     val jobConfig = new JobConf(config.value)
     val taskId = new TaskAttemptID("", 0, TaskType.REDUCE, 0, 0)
     val context = new TaskAttemptContextImpl(jobConfig, taskId)

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
@@ -54,7 +54,7 @@ object DeltaRollupDataWriter extends RollupDataWriter with DeltaStatsCollectionU
     val fileStatsTracker = getFileStatsTracker(tableId, data)
     val trackers = statsTrackers ++ fileStatsTracker
 
-    val extendedData = extendDataWithCubeToRollup(data, tableChanges)
+    val extendedData = extendDataWithFileUUID(data, tableChanges)
     val filesAndStats = doWrite(tableId, schema, extendedData, tableChanges, trackers)
 
     val stats = filesAndStats.map(_._2)

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
@@ -22,7 +22,6 @@ import io.qbeast.spark.writer.StatsTracker
 import io.qbeast.spark.writer.TaskStats
 import io.qbeast.IISeq
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.stats.DeltaFileStatistics
 import org.apache.spark.sql.delta.stats.DeltaJobStatisticsTracker
@@ -40,15 +39,14 @@ import java.net.URI
  */
 object DeltaRollupDataWriter extends RollupDataWriter with DeltaStatsCollectionUtils {
 
-  override type GetCubeMaxWeight = CubeId => Weight
-  override type Extract = InternalRow => (InternalRow, Weight, CubeId, CubeId)
-  override type WriteRows = Iterator[InternalRow] => Iterator[(IndexFile, TaskStats)]
-
   override def write(
       tableId: QTableID,
       schema: StructType,
       data: DataFrame,
       tableChanges: TableChanges): IISeq[IndexFile] = {
+
+    if (data.isEmpty) return Seq.empty[IndexFile].toIndexedSeq
+
     val revision = tableChanges.updatedRevision
     val dimensionCount = revision.transformations.length
 
@@ -56,7 +54,9 @@ object DeltaRollupDataWriter extends RollupDataWriter with DeltaStatsCollectionU
     val fileStatsTracker = getFileStatsTracker(tableId, data)
     val trackers = statsTrackers ++ fileStatsTracker
 
-    val filesAndStats = internalWrite(tableId, schema, data, tableChanges, trackers)
+    val extendedData = extendDataWithCubeToRollup(data, tableChanges)
+    val filesAndStats = doWrite(tableId, schema, extendedData, tableChanges, trackers)
+
     val stats = filesAndStats.map(_._2)
     processStats(stats, statsTrackers, fileStatsTracker)
     filesAndStats

--- a/src/test/scala/io/qbeast/spark/index/QbeastColumnsTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/QbeastColumnsTest.scala
@@ -60,6 +60,8 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
     columns1.hasCubeToReplicateColumn shouldBe false
     columns1.cubeToRollupColumnIndex shouldBe -1
     columns1.hasCubeToRollupColumn shouldBe false
+    columns1.filenameColumnIndex shouldBe -1
+    columns1.hasFilenameColumn shouldBe false
 
     val schema2 = StructType(
       Seq(
@@ -68,7 +70,9 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
         StructField("B", StringType),
         StructField(QbeastColumns.cubeToReplicateColumnName, BinaryType),
         StructField("C", StringType),
-        StructField(QbeastColumns.cubeToRollupColumnName, BinaryType)))
+        StructField(QbeastColumns.cubeToRollupColumnName, BinaryType),
+        StructField("D", StringType),
+        StructField(QbeastColumns.filenameColumnName, StringType)))
     val columns2 = QbeastColumns(schema2)
     columns2.weightColumnIndex shouldBe -1
     columns2.hasWeightColumn shouldBe false
@@ -82,6 +86,8 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
     columns2.hasCubeToReplicateColumn shouldBe true
     columns2.cubeToRollupColumnIndex shouldBe 5
     columns2.hasCubeToRollupColumn shouldBe true
+    columns2.filenameColumnIndex shouldBe 7
+    columns2.hasFilenameColumn shouldBe true
   }
 
   it should "implement contains correctly" in {

--- a/src/test/scala/io/qbeast/spark/index/QbeastColumnsTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/QbeastColumnsTest.scala
@@ -35,7 +35,8 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
     QbeastColumns.stateColumnName should startWith("_qbeast")
     QbeastColumns.revisionColumnName should startWith("_qbeast")
     QbeastColumns.cubeToReplicateColumnName should startWith("_qbeast")
-    QbeastColumns.cubeToRollupColumnName should startWith("_qbeast")
+    QbeastColumns.fileUUIDColumnName should startWith("_qbeast")
+    QbeastColumns.filenameColumnName should startWith("_qbeast")
   }
 
   it should "create instance from schema correctly" in {
@@ -58,8 +59,8 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
     columns1.hasRevisionColumn shouldBe false
     columns1.cubeToReplicateColumnIndex shouldBe -1
     columns1.hasCubeToReplicateColumn shouldBe false
-    columns1.cubeToRollupColumnIndex shouldBe -1
-    columns1.hasCubeToRollupColumn shouldBe false
+    columns1.fileUUIDColumnIndex shouldBe -1
+    columns1.hasFileUUIDColumn shouldBe false
     columns1.filenameColumnIndex shouldBe -1
     columns1.hasFilenameColumn shouldBe false
 
@@ -70,7 +71,7 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
         StructField("B", StringType),
         StructField(QbeastColumns.cubeToReplicateColumnName, BinaryType),
         StructField("C", StringType),
-        StructField(QbeastColumns.cubeToRollupColumnName, BinaryType),
+        StructField(QbeastColumns.fileUUIDColumnName, BinaryType),
         StructField("D", StringType),
         StructField(QbeastColumns.filenameColumnName, StringType)))
     val columns2 = QbeastColumns(schema2)
@@ -84,8 +85,8 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
     columns2.hasRevisionColumn shouldBe true
     columns2.cubeToReplicateColumnIndex shouldBe 3
     columns2.hasCubeToReplicateColumn shouldBe true
-    columns2.cubeToRollupColumnIndex shouldBe 5
-    columns2.hasCubeToRollupColumn shouldBe true
+    columns2.fileUUIDColumnIndex shouldBe 5
+    columns2.hasFileUUIDColumn shouldBe true
     columns2.filenameColumnIndex shouldBe 7
     columns2.hasFilenameColumn shouldBe true
   }
@@ -114,7 +115,7 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
         StructField("B", StringType),
         StructField(QbeastColumns.cubeToReplicateColumnName, BinaryType),
         StructField("C", StringType),
-        StructField(QbeastColumns.cubeToRollupColumnName, BinaryType)))
+        StructField(QbeastColumns.fileUUIDColumnName, BinaryType)))
     val columns2 = QbeastColumns(schema2)
     columns2.contains(0) shouldBe false
     columns2.contains(1) shouldBe true
@@ -130,7 +131,7 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
     QbeastColumns.contains(QbeastColumns.stateColumnName) shouldBe true
     QbeastColumns.contains(QbeastColumns.revisionColumnName) shouldBe true
     QbeastColumns.contains(QbeastColumns.cubeToReplicateColumnName) shouldBe true
-    QbeastColumns.contains(QbeastColumns.cubeToRollupColumnName) shouldBe true
+    QbeastColumns.contains(QbeastColumns.fileUUIDColumnName) shouldBe true
     QbeastColumns.contains("weight") shouldBe false
     QbeastColumns.contains("cube") shouldBe false
     QbeastColumns.contains("state") shouldBe false
@@ -146,7 +147,7 @@ class QbeastColumnsTest extends AnyFlatSpec with Matchers {
     QbeastColumns.contains(
       StructField(QbeastColumns.cubeToReplicateColumnName, BinaryType)) shouldBe true
     QbeastColumns.contains(
-      StructField(QbeastColumns.cubeToRollupColumnName, BinaryType)) shouldBe true
+      StructField(QbeastColumns.fileUUIDColumnName, BinaryType)) shouldBe true
     QbeastColumns.contains(StructField("weight", IntegerType)) shouldBe false
     QbeastColumns.contains(StructField("cube", BinaryType)) shouldBe false
     QbeastColumns.contains(StructField("state", StringType)) shouldBe false


### PR DESCRIPTION
## Description

Fix for #463 

This PR allows table formats to specify custom filenames through a new configuration option in DataWriter. If a custom filename pattern is not provided, the default UUID.parquet format will be used, ensuring backward compatibility.

This PR updates the getRollupCubeIdUDF function to return a UUID instead of an Array[Byte]. It was found that the column added by this UDF is used solely to determine the file writer and filename. By using a UUID directly, we simplify the logic, as each unique RollupCubeID now maps to a unique UUID for filename generation.

## Type of change
- refactoring


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [X] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [X] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [X] Add comments to the code (make it easier for the community!).
- [X] Change the documentation.
- [X] Add tests.
- [X] Your branch is updated to the main branch (dependent changes have been merged).