### PR TITLE
Issue #467: Separate index metada when creating a new Revision

### DIFF
--- a/src/test/scala/io/qbeast/spark/index/IndexTest.scala
+++ b/src/test/scala/io/qbeast/spark/index/IndexTest.scala
@@ -249,4 +249,25 @@ class IndexTest
     }
   }
 
+  it should "work with appends that are always out of range" in withSparkAndTmpDir(
+    (spark, tmpDir) => {
+      var offset = 10000
+      spark
+        .range(offset)
+        .toDF("id")
+        .write
+        .mode("append")
+        .format("qbeast")
+        .option("columnsToIndex", "id")
+        .option("cubeSize", "100")
+        .save(tmpDir)
+      val appendSize = 10
+      val numAppends = 10
+      (1 to numAppends).foreach { i =>
+        val df = spark.range(offset, offset + appendSize).toDF("id")
+        df.write.mode("append").format("qbeast").save(tmpDir)
+        offset += appendSize
+      }
+    })
+
 }


### PR DESCRIPTION
Fixes #467 

The estimation of cube weights when writing with qbeast consists of the following steps:
1. Compute cube domains only for the input/append data - `inputCubeDomains.` This consists of computing the `partitionCubeDomains` for each input partition and merging them by doing a group by sum to get `inputDataCubeDomains.`
2. Compute the updated cube domains of the index.
3. Compute `updatedCubeWeight` using the `updatedCubeDomains` with the following formula: `Wc = Wpc + dcs / Dc`

When there's no space change:
1. `partitionCubeDomains` should be built using the existing cube weights as a scaffold, pushing records further down the tree to maximize the precision of cube domain estimation.
2. `inputDataCubeDomains` should be merged with `existingCubeDomains` to get the `updatedCubeDomains.` Otherwise, `updatedCubeDomains = inputDataCubeDomains.`

## Checklist:
- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).