### PR TITLE
Issue #465: Allow MetadataManager to pass the commit timestamp to DataWriter

### DIFF
--- a/core/src/main/scala/io/qbeast/core/model/DataWriter.scala
+++ b/core/src/main/scala/io/qbeast/core/model/DataWriter.scala
@@ -42,6 +42,6 @@ trait DataWriter {
       schema: StructType,
       data: DataFrame,
       tableChanges: TableChanges,
-      commitTime: String): IISeq[IndexFile]
+      commitStartTime: String): IISeq[IndexFile]
 
 }

--- a/core/src/main/scala/io/qbeast/core/model/DataWriter.scala
+++ b/core/src/main/scala/io/qbeast/core/model/DataWriter.scala
@@ -41,6 +41,7 @@ trait DataWriter {
       tableID: QTableID,
       schema: StructType,
       data: DataFrame,
-      tableChanges: TableChanges): IISeq[IndexFile]
+      tableChanges: TableChanges,
+      commitTime: String): IISeq[IndexFile]
 
 }

--- a/core/src/main/scala/io/qbeast/core/model/DataWriter.scala
+++ b/core/src/main/scala/io/qbeast/core/model/DataWriter.scala
@@ -42,6 +42,6 @@ trait DataWriter {
       schema: StructType,
       data: DataFrame,
       tableChanges: TableChanges,
-      commitStartTime: String): IISeq[IndexFile]
+      transactionStartTime: String): IISeq[IndexFile]
 
 }

--- a/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
+++ b/core/src/main/scala/io/qbeast/core/model/MetadataManager.scala
@@ -58,7 +58,8 @@ trait MetadataManager {
       tableID: QTableID,
       schema: StructType,
       options: QbeastOptions,
-      append: Boolean)(writer: => (TableChanges, IISeq[IndexFile], IISeq[DeleteFile])): Unit
+      append: Boolean)(
+      writer: String => (TableChanges, IISeq[IndexFile], IISeq[DeleteFile])): Unit
 
   /**
    * Updates the table metadata by overwriting the metadata configurations with the provided

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataManager.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataManager.scala
@@ -32,7 +32,8 @@ object DeltaMetadataManager extends MetadataManager {
       tableID: QTableID,
       schema: StructType,
       options: QbeastOptions,
-      append: Boolean)(writer: => (TableChanges, IISeq[IndexFile], IISeq[DeleteFile])): Unit = {
+      append: Boolean)(
+      writer: String => (TableChanges, IISeq[IndexFile], IISeq[DeleteFile])): Unit = {
 
     val deltaLog = loadDeltaLog(tableID)
     val mode = if (append) SaveMode.Append else SaveMode.Overwrite

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -177,8 +177,8 @@ private[delta] case class DeltaMetadataWriter(
       registerStatsTrackers(statsTrackers)
 
       // Execute write
-      val commitStartTime = txn.txnStartTimeNs.toString
-      val (tableChanges, indexFiles, deleteFiles) = writer(commitStartTime)
+      val transactionStartTime = txn.txnStartTimeNs.toString
+      val (tableChanges, indexFiles, deleteFiles) = writer(transactionStartTime)
       val addFiles = indexFiles.map(DeltaQbeastFileUtils.toAddFile)
       val removeFiles = deleteFiles.map(DeltaQbeastFileUtils.toRemoveFile)
 

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -177,7 +177,8 @@ private[delta] case class DeltaMetadataWriter(
       registerStatsTrackers(statsTrackers)
 
       // Execute write
-      val (tableChanges, indexFiles, deleteFiles) = writer(txn.txnStartTimeNs.toString)
+      val commitStartTime = txn.txnStartTimeNs.toString
+      val (tableChanges, indexFiles, deleteFiles) = writer(commitStartTime)
       val addFiles = indexFiles.map(DeltaQbeastFileUtils.toAddFile)
       val removeFiles = deleteFiles.map(DeltaQbeastFileUtils.toRemoveFile)
 

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -158,7 +158,8 @@ private[delta] case class DeltaMetadataWriter(
     }
   }
 
-  def writeWithTransaction(writer: => (TableChanges, Seq[IndexFile], Seq[DeleteFile])): Unit = {
+  def writeWithTransaction(
+      writer: String => (TableChanges, Seq[IndexFile], Seq[DeleteFile])): Unit = {
     val oldTransactions = deltaLog.unsafeVolatileSnapshot.setTransactions
     // If the transaction was completed before then no operation
     for (txn <- oldTransactions; version <- deltaOptions.txnVersion;
@@ -176,7 +177,7 @@ private[delta] case class DeltaMetadataWriter(
       registerStatsTrackers(statsTrackers)
 
       // Execute write
-      val (tableChanges, indexFiles, deleteFiles) = writer
+      val (tableChanges, indexFiles, deleteFiles) = writer(txn.txnStartTimeNs.toString)
       val addFiles = indexFiles.map(DeltaQbeastFileUtils.toAddFile)
       val removeFiles = deleteFiles.map(DeltaQbeastFileUtils.toRemoveFile)
 

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
@@ -43,7 +43,8 @@ object DeltaRollupDataWriter extends RollupDataWriter with DeltaStatsCollectionU
       tableId: QTableID,
       schema: StructType,
       data: DataFrame,
-      tableChanges: TableChanges): IISeq[IndexFile] = {
+      tableChanges: TableChanges,
+      commitTime: String): IISeq[IndexFile] = {
 
     if (data.isEmpty) return Seq.empty[IndexFile].toIndexedSeq
 

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
@@ -44,7 +44,7 @@ object DeltaRollupDataWriter extends RollupDataWriter with DeltaStatsCollectionU
       schema: StructType,
       data: DataFrame,
       tableChanges: TableChanges,
-      commitStartTime: String): IISeq[IndexFile] = {
+      transactionStartTime: String): IISeq[IndexFile] = {
 
     if (data.isEmpty) return Seq.empty[IndexFile].toIndexedSeq
 

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaRollupDataWriter.scala
@@ -44,7 +44,7 @@ object DeltaRollupDataWriter extends RollupDataWriter with DeltaStatsCollectionU
       schema: StructType,
       data: DataFrame,
       tableChanges: TableChanges,
-      commitTime: String): IISeq[IndexFile] = {
+      commitStartTime: String): IISeq[IndexFile] = {
 
     if (data.isEmpty) return Seq.empty[IndexFile].toIndexedSeq
 

--- a/src/main/scala/io/qbeast/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/table/IndexedTable.scala
@@ -486,9 +486,10 @@ private[table] class IndexedTableImpl(
         val schema = dataToWrite.schema
         val deleteFiles = removeFiles.toIndexedSeq
         metadataManager.updateWithTransaction(tableID, schema, options, append) {
-          commitTime: String =>
+          commitStartTime: String =>
             val (qbeastData, tableChanges) = indexManager.index(dataToWrite, indexStatus)
-            val addFiles = dataWriter.write(tableID, schema, qbeastData, tableChanges, commitTime)
+            val addFiles =
+              dataWriter.write(tableID, schema, qbeastData, tableChanges, commitStartTime)
             (tableChanges, addFiles, deleteFiles)
         }
     }
@@ -588,7 +589,7 @@ private[table] class IndexedTableImpl(
       tableID,
       schema,
       optimizationOptions(options),
-      append = true) { commitTime: String =>
+      append = true) { commitStartTime: String =>
       // Remove the Unindexed Files from the Log
       val deleteFiles: IISeq[DeleteFile] = files
         .map { indexFile =>
@@ -605,7 +606,7 @@ private[table] class IndexedTableImpl(
       // Write the data with DataWriter
       val newFiles: IISeq[IndexFile] =
         dataWriter
-          .write(tableID, schema, data, tableChanges, commitTime)
+          .write(tableID, schema, data, tableChanges, commitStartTime)
           .collect { case indexFile: IndexFile =>
             indexFile.copy(dataChange = false)
           }

--- a/src/main/scala/io/qbeast/table/IndexedTable.scala
+++ b/src/main/scala/io/qbeast/table/IndexedTable.scala
@@ -486,9 +486,10 @@ private[table] class IndexedTableImpl(
         val schema = dataToWrite.schema
         val deleteFiles = removeFiles.toIndexedSeq
         metadataManager.updateWithTransaction(tableID, schema, options, append) {
-          val (qbeastData, tableChanges) = indexManager.index(dataToWrite, indexStatus)
-          val addFiles = dataWriter.write(tableID, schema, qbeastData, tableChanges)
-          (tableChanges, addFiles, deleteFiles)
+          commitTime: String =>
+            val (qbeastData, tableChanges) = indexManager.index(dataToWrite, indexStatus)
+            val addFiles = dataWriter.write(tableID, schema, qbeastData, tableChanges, commitTime)
+            (tableChanges, addFiles, deleteFiles)
         }
     }
     logTrace(s"End: Writing data to table $tableID")
@@ -587,7 +588,7 @@ private[table] class IndexedTableImpl(
       tableID,
       schema,
       optimizationOptions(options),
-      append = true) {
+      append = true) { commitTime: String =>
       // Remove the Unindexed Files from the Log
       val deleteFiles: IISeq[DeleteFile] = files
         .map { indexFile =>
@@ -604,7 +605,7 @@ private[table] class IndexedTableImpl(
       // Write the data with DataWriter
       val newFiles: IISeq[IndexFile] =
         dataWriter
-          .write(tableID, schema, data, tableChanges)
+          .write(tableID, schema, data, tableChanges, commitTime)
           .collect { case indexFile: IndexFile =>
             indexFile.copy(dataChange = false)
           }
@@ -631,30 +632,31 @@ private[table] class IndexedTableImpl(
         // 3. In the same transaction
         metadataManager
           .updateWithTransaction(tableID, schema, optimizationOptions(options), append = true) {
-            import indexFiles.sparkSession.implicits._
-            val deleteFiles: IISeq[DeleteFile] = indexFiles
-              .map { indexFile =>
-                DeleteFile(
-                  path = indexFile.path,
-                  size = indexFile.size,
-                  dataChange = false,
-                  deletionTimestamp = currentTimeMillis())
-              }
-              .collect()
-              .toIndexedSeq
-            // 1. Load the data from the Index Files
-            val data = snapshot.loadDataframeFromIndexFiles(indexFiles)
-            // 2. Optimize the data with IndexManager
-            val (dataExtended, tableChanges) =
-              DoublePassOTreeDataAnalyzer.analyzeOptimize(data, indexStatus)
-            // 3. Write the data with DataWriter
-            val addFiles = dataWriter
-              .write(tableID, schema, dataExtended, tableChanges)
-              .collect { case indexFile: IndexFile =>
-                indexFile.copy(dataChange = false)
-              }
-            dataExtended.unpersist()
-            (tableChanges, addFiles, deleteFiles)
+            commitTime: String =>
+              import indexFiles.sparkSession.implicits._
+              val deleteFiles: IISeq[DeleteFile] = indexFiles
+                .map { indexFile =>
+                  DeleteFile(
+                    path = indexFile.path,
+                    size = indexFile.size,
+                    dataChange = false,
+                    deletionTimestamp = currentTimeMillis())
+                }
+                .collect()
+                .toIndexedSeq
+              // 1. Load the data from the Index Files
+              val data = snapshot.loadDataframeFromIndexFiles(indexFiles)
+              // 2. Optimize the data with IndexManager
+              val (dataExtended, tableChanges) =
+                DoublePassOTreeDataAnalyzer.analyzeOptimize(data, indexStatus)
+              // 3. Write the data with DataWriter
+              val addFiles = dataWriter
+                .write(tableID, schema, dataExtended, tableChanges, commitTime)
+                .collect { case indexFile: IndexFile =>
+                  indexFile.copy(dataChange = false)
+                }
+              dataExtended.unpersist()
+              (tableChanges, addFiles, deleteFiles)
           }
       }
     }

--- a/src/test/scala/io/qbeast/spark/delta/DeltaRollupDataWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/DeltaRollupDataWriterTest.scala
@@ -54,9 +54,14 @@ class DeltaRollupDataWriterTest extends QbeastIntegrationTestSpec {
       val indexStatus = IndexStatus(revision)
       val (qbeastData, tableChanges) = SparkOTreeManager.index(df, indexStatus)
 
-      val commitTime = System.currentTimeMillis().toString
+      val transactionStartTime = System.currentTimeMillis().toString
       val fileActions =
-        DeltaRollupDataWriter.write(tableID, df.schema, qbeastData, tableChanges, commitTime)
+        DeltaRollupDataWriter.write(
+          tableID,
+          df.schema,
+          qbeastData,
+          tableChanges,
+          transactionStartTime)
 
       for (fa <- fileActions) {
         Path(tmpDir + "/" + fa.path).exists shouldBe true

--- a/src/test/scala/io/qbeast/spark/delta/DeltaRollupDataWriterTest.scala
+++ b/src/test/scala/io/qbeast/spark/delta/DeltaRollupDataWriterTest.scala
@@ -54,7 +54,9 @@ class DeltaRollupDataWriterTest extends QbeastIntegrationTestSpec {
       val indexStatus = IndexStatus(revision)
       val (qbeastData, tableChanges) = SparkOTreeManager.index(df, indexStatus)
 
-      val fileActions = DeltaRollupDataWriter.write(tableID, df.schema, qbeastData, tableChanges)
+      val commitTime = System.currentTimeMillis().toString
+      val fileActions =
+        DeltaRollupDataWriter.write(tableID, df.schema, qbeastData, tableChanges, commitTime)
 
       for (fa <- fileActions) {
         Path(tmpDir + "/" + fa.path).exists shouldBe true


### PR DESCRIPTION
## Description
Allows to pass the timestamp generated in the MetadataManager to the DataWriter

Fixes #465 

## Type of change

feature addition

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add comments to the code (make it easier for the community!).
- [x] Change the documentation.
- [x] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).
