### PR TITLE
Issue #468: Abstract Logic from MetadataWriter Operator for Reusability

### DIFF
--- a/core/src/main/scala/io/qbeast/spark/metadata/MetadataOperation.scala
+++ b/core/src/main/scala/io/qbeast/spark/metadata/MetadataOperation.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 Qbeast Analytics, S.L.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qbeast.spark.metadata
+
+import io.qbeast.core.model.mapper
+import io.qbeast.core.model.Revision
+import io.qbeast.core.model.StagingUtils
+import io.qbeast.core.model.TableChanges
+import io.qbeast.spark.internal.QbeastOptions
+import io.qbeast.spark.utils.MetadataConfig
+import io.qbeast.spark.utils.MetadataConfig.lastRevisionID
+import io.qbeast.spark.utils.MetadataConfig.revision
+import org.apache.spark.sql.types.ArrayType
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.MapType
+
+/**
+ * Qbeast metadata changes on a Delta Table.
+ */
+trait MetadataOperation extends StagingUtils {
+
+  type Configuration = Map[String, String]
+
+  /**
+   * Returns the same data type but set all nullability fields are true (ArrayType.containsNull,
+   * and MapType.valueContainsNull)
+   * @param dataType
+   *   the data type
+   * @return
+   *   same data type set to null
+   */
+  protected def asNullable(dataType: DataType): DataType = {
+    dataType match {
+      case array: ArrayType => array.copy(containsNull = true)
+      case map: MapType => map.copy(valueContainsNull = true)
+      case other => other
+    }
+  }
+
+  private def overwriteQbeastConfiguration(baseConfiguration: Configuration): Configuration = {
+    val revisionKeys = baseConfiguration.keys.filter(_.startsWith(MetadataConfig.revision))
+    val other = baseConfiguration.keys.filter(_ == MetadataConfig.lastRevisionID)
+    val qbeastKeys = revisionKeys ++ other
+    baseConfiguration -- qbeastKeys
+  }
+
+  /**
+   * Update metadata with new Qbeast Revision
+   * @param baseConfiguration
+   *   the base configuration
+   * @param newRevision
+   *   the new revision
+   */
+  private def updateQbeastRevision(
+      baseConfiguration: Configuration,
+      newRevision: Revision): Configuration = {
+    val newRevisionID = newRevision.revisionID
+
+    // Add staging revision, if necessary. The qbeast metadata configuration
+    // should always have a revision with RevisionID = stagingID.
+    val stagingRevisionKey = s"$revision.$stagingID"
+    val addStagingRevision =
+      newRevisionID == 1 && !baseConfiguration.contains(stagingRevisionKey)
+    val configuration =
+      if (!addStagingRevision) baseConfiguration
+      else {
+        // Create staging revision with EmptyTransformers (and EmptyTransformations).
+        // We modify its timestamp to secure loadRevisionAt
+        val stagingRev =
+          stagingRevision(
+            newRevision.tableID,
+            newRevision.desiredCubeSize,
+            newRevision.columnTransformers.map(_.columnName))
+            .copy(timestamp = newRevision.timestamp - 1)
+
+        // Add the staging revision to the revisionMap without overwriting
+        // the latestRevisionID
+        baseConfiguration
+          .updated(stagingRevisionKey, mapper.writeValueAsString(stagingRev))
+      }
+
+    // Update latest revision id and add new revision to metadata
+    configuration
+      .updated(lastRevisionID, newRevisionID.toString)
+      .updated(s"$revision.$newRevisionID", mapper.writeValueAsString(newRevision))
+  }
+
+  /**
+   * Update Qbeast Metadata
+   * @param currentConfiguration
+   *   Current table configuration
+   * @param isNewTable
+   *   whether the table is new or not
+   * @param isOverwriteMode
+   *   whether the write mode is overwritten
+   * @param tableChanges
+   *   the changes in the table
+   * @param qbeastOptions
+   *   the Qbeast options to update
+   */
+
+  def updateConfiguration(
+      currentConfiguration: Configuration,
+      isNewTable: Boolean,
+      isOverwriteMode: Boolean,
+      tableChanges: TableChanges,
+      qbeastOptions: QbeastOptions): (Configuration, Boolean) = {
+
+    // Either the data triggered a new revision or the user specified options to amplify the ranges
+    val containsQbeastMetadata: Boolean = currentConfiguration.contains(lastRevisionID)
+
+    // Append on an empty table
+    val isNewWriteAppend = !isOverwriteMode && isNewTable
+    // If the table exists, but the user added a new revision, we need to create a new revision
+    val isUserUpdatedMetadata =
+      containsQbeastMetadata &&
+        tableChanges.updatedRevision.revisionID == currentConfiguration(lastRevisionID).toInt + 1
+
+    // Whether:
+    // 1. Data Triggered a New Revision
+    // 2. User added a columnStats that triggered a new Revision
+    // 3. User made an APPEND on a NEW TABLE with columnStats that triggered a new Revision
+    val isNewRevision: Boolean =
+      tableChanges.isNewRevision || isUserUpdatedMetadata || isNewWriteAppend
+
+    val latestRevision = tableChanges.updatedRevision
+    val baseConfiguration: Configuration =
+      if (isNewTable) Map.empty
+      else if (isOverwriteMode) overwriteQbeastConfiguration(currentConfiguration)
+      else currentConfiguration
+
+    // Qbeast configuration metadata
+    val (qbeastConfiguration, hasRevisionUpdate) =
+      if (isNewRevision || isOverwriteMode || tableChanges.isOptimizeOperation)
+        (updateQbeastRevision(baseConfiguration, latestRevision), true)
+      else (baseConfiguration, false)
+    val qbeastExtraWriteOptions = qbeastOptions.extraOptions
+    val qbeastWriteProperties = qbeastOptions.writeProperties
+    // Merge the qbeast configuration with the extra configuration and the write properties
+    val configuration = qbeastConfiguration ++ qbeastWriteProperties ++ qbeastExtraWriteOptions
+
+    (configuration, hasRevisionUpdate)
+  }
+
+}

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataOperation.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataOperation.scala
@@ -15,95 +15,21 @@
  */
 package io.qbeast.spark.delta
 
-import io.qbeast.core.model.mapper
-import io.qbeast.core.model.Revision
-import io.qbeast.core.model.StagingUtils
-import io.qbeast.core.model.TableChanges
-import io.qbeast.spark.internal.QbeastOptions
-import io.qbeast.spark.utils.MetadataConfig
-import io.qbeast.spark.utils.MetadataConfig.lastRevisionID
-import io.qbeast.spark.utils.MetadataConfig.revision
+import io.qbeast.spark.metadata.MetadataOperation
 import org.apache.spark.sql.delta.schema.ImplicitMetadataOperation
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.MetadataMismatchErrorBuilder
 import org.apache.spark.sql.delta.OptimisticTransaction
-import org.apache.spark.sql.types.ArrayType
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.types.MapType
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.SparkSession
 
 /**
  * Qbeast metadata changes on a Delta Table.
  */
-private[delta] trait DeltaMetadataOperation extends ImplicitMetadataOperation with StagingUtils {
-
-  type Configuration = Map[String, String]
-
-  /**
-   * Returns the same data type but set all nullability fields are true (ArrayType.containsNull,
-   * and MapType.valueContainsNull)
-   * @param dataType
-   *   the data type
-   * @return
-   *   same data type set to null
-   */
-  private def asNullable(dataType: DataType): DataType = {
-    dataType match {
-      case array: ArrayType => array.copy(containsNull = true)
-      case map: MapType => map.copy(valueContainsNull = true)
-      case other => other
-    }
-  }
-
-  private def overwriteQbeastConfiguration(baseConfiguration: Configuration): Configuration = {
-    val revisionKeys = baseConfiguration.keys.filter(_.startsWith(MetadataConfig.revision))
-    val other = baseConfiguration.keys.filter(_ == MetadataConfig.lastRevisionID)
-    val qbeastKeys = revisionKeys ++ other
-    baseConfiguration -- qbeastKeys
-  }
-
-  /**
-   * Update metadata with new Qbeast Revision
-   * @param baseConfiguration
-   *   the base configuration
-   * @param newRevision
-   *   the new revision
-   */
-  private def updateQbeastRevision(
-      baseConfiguration: Configuration,
-      newRevision: Revision): Configuration = {
-    val newRevisionID = newRevision.revisionID
-
-    // Add staging revision, if necessary. The qbeast metadata configuration
-    // should always have a revision with RevisionID = stagingID.
-    val stagingRevisionKey = s"$revision.$stagingID"
-    val addStagingRevision =
-      newRevisionID == 1 && !baseConfiguration.contains(stagingRevisionKey)
-    val configuration =
-      if (!addStagingRevision) baseConfiguration
-      else {
-        // Create staging revision with EmptyTransformers (and EmptyTransformations).
-        // We modify its timestamp to secure loadRevisionAt
-        val stagingRev =
-          stagingRevision(
-            newRevision.tableID,
-            newRevision.desiredCubeSize,
-            newRevision.columnTransformers.map(_.columnName))
-            .copy(timestamp = newRevision.timestamp - 1)
-
-        // Add the staging revision to the revisionMap without overwriting
-        // the latestRevisionID
-        baseConfiguration
-          .updated(stagingRevisionKey, mapper.writeValueAsString(stagingRev))
-      }
-
-    // Update latest revision id and add new revision to metadata
-    configuration
-      .updated(lastRevisionID, newRevisionID.toString)
-      .updated(s"$revision.$newRevisionID", mapper.writeValueAsString(newRevision))
-  }
+private[delta] trait DeltaMetadataOperation
+    extends MetadataOperation
+    with ImplicitMetadataOperation {
 
   /**
    * Update Qbeast Metadata
@@ -115,71 +41,35 @@ private[delta] trait DeltaMetadataOperation extends ImplicitMetadataOperation wi
    *   whether the write mode is overwrite
    * @param rearrangeOnly
    *   whether the operation is only to rearrange the table
-   * @param tableChanges
+   * @param configuration
    *   the changes in the table
-   * @param qbeastOptions
+   * @param hasRevisionUpdate
    *   the Qbeast options to update
    */
-  def updateQbeastMetadata(
+  def updateTableMetadata(
       txn: OptimisticTransaction,
       schema: StructType,
       isOverwriteMode: Boolean,
       rearrangeOnly: Boolean,
-      tableChanges: TableChanges,
-      qbeastOptions: QbeastOptions): Unit = {
-
-    val spark = SparkSession.active
-
-    val dataSchema = StructType(schema.fields.map(field =>
-      field.copy(nullable = true, dataType = asNullable(field.dataType))))
-
-    val mergedSchema =
-      if (isOverwriteMode && canOverwriteSchema) dataSchema
-      else SchemaMergingUtils.mergeSchemas(txn.metadata.schema, dataSchema)
-
-    val normalizedPartitionCols = Seq.empty
-
-    // Merged schema will contain additional columns at the end
-    val isNewSchema: Boolean = txn.metadata.schema != mergedSchema
-    // Either the data triggered a new revision or the user specified options to amplify the ranges
-    val containsQbeastMetadata: Boolean = txn.metadata.configuration.contains(lastRevisionID)
+      configuration: Configuration,
+      hasRevisionUpdate: Boolean): Unit = {
 
     // TODO This whole class is starting to be messy, and contains a lot of IF then ELSE
     // TODO We should refactor QbeastMetadataOperation to make it more readable and usable
     // TODO Ideally, we should delegate this process to the underlying format
 
-    // Append on an empty table
-    val isNewWriteAppend = !isOverwriteMode && txn.readVersion == -1
-    // If the table exists, but the user added a new revision, we need to create a new revision
-    val isUserUpdatedMetadata =
-      containsQbeastMetadata &&
-        tableChanges.updatedRevision.revisionID == txn.metadata
-          .configuration(lastRevisionID)
-          .toInt + 1
+    val spark = SparkSession.active
 
-    // Whether:
-    // 1. Data Triggered a New Revision
-    // 2. User added a columnStats that triggered a new Revision
-    // 3. User made an APPEND on a NEW TABLE with columnStats that triggered a new Revision
-    val isNewRevision: Boolean =
-      tableChanges.isNewRevision || isUserUpdatedMetadata || isNewWriteAppend
+    // Update the schema
+    val dataSchema = StructType(schema.fields.map(field =>
+      field.copy(nullable = true, dataType = asNullable(field.dataType))))
+    val mergedSchema =
+      if (isOverwriteMode && canOverwriteSchema) dataSchema
+      else SchemaMergingUtils.mergeSchemas(txn.metadata.schema, dataSchema)
+    // Merged schema will contain additional columns at the end
+    val isNewSchema: Boolean = txn.metadata.schema != mergedSchema
 
-    val latestRevision = tableChanges.updatedRevision
-    val baseConfiguration: Configuration =
-      if (txn.readVersion == -1) Map.empty
-      else if (isOverwriteMode) overwriteQbeastConfiguration(txn.metadata.configuration)
-      else txn.metadata.configuration
-
-    // Qbeast configuration metadata
-    val (qbeastConfiguration, hasRevisionUpdate) =
-      if (isNewRevision || isOverwriteMode || tableChanges.isOptimizeOperation)
-        (updateQbeastRevision(baseConfiguration, latestRevision), true)
-      else (baseConfiguration, false)
-    val qbeastExtraWriteOptions = qbeastOptions.extraOptions
-    val qbeastWriteProperties = qbeastOptions.writeProperties
-    // Merge the qbeast configuration with the extra configuration and the write properties
-    val configuration = qbeastConfiguration ++ qbeastWriteProperties ++ qbeastExtraWriteOptions
-
+    // Update table metadata
     if (!txn.deltaLog.tableExists) {
       super.updateMetadata(
         spark,
@@ -193,7 +83,7 @@ private[delta] trait DeltaMetadataOperation extends ImplicitMetadataOperation wi
       // Can define new partitioning in overwrite mode
       val newMetadata = txn.metadata.copy(
         schemaString = dataSchema.json,
-        partitionColumns = normalizedPartitionCols,
+        partitionColumns = Seq.empty,
         configuration = configuration)
       recordDeltaEvent(txn.deltaLog, "delta.ddl.overwriteSchema")
       if (rearrangeOnly) {

--- a/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
+++ b/delta/src/main/scala/io/qbeast/spark/delta/DeltaMetadataWriter.scala
@@ -54,8 +54,8 @@ import scala.collection.mutable.ListBuffer
  *
  * @param tableID
  *   the table identifier
- * @param mode
- *   SaveMode of the writeMetadata
+ * @param writeMode
+ *   WriteMode of the writeMetadata
  * @param deltaLog
  *   deltaLog associated to the table
  * @param qbeastOptions
@@ -283,7 +283,9 @@ private[delta] case class DeltaMetadataWriter(
       removeFiles: Seq[RemoveFile],
       extraConfiguration: Configuration): Seq[Action] = {
 
-    if (txn.readVersion > -1) {
+    val isNewTable = txn.readVersion == -1
+
+    if (!isNewTable) {
       // This table already exists, check if the insert is valid.
       if (saveMode == SaveMode.ErrorIfExists) {
         throw AnalysisExceptionFactory.create(s"Path '${deltaLog.dataPath}' already exists.'")
@@ -297,29 +299,29 @@ private[delta] case class DeltaMetadataWriter(
 
     val isOptimizeOperation: Boolean = tableChanges.isOptimizeOperation
 
+    val (newConfiguration, hasRevisionUpdate) = updateConfiguration(
+      txn.metadata.configuration,
+      isNewTable,
+      isOverwriteOperation,
+      tableChanges,
+      qbeastOptions)
+
     // The Metadata can be updated only once in a single transaction
     // If a new space revision or a new replicated set is detected,
     // we update everything in the same operation
-    updateQbeastMetadata(
+    updateTableMetadata(
       txn,
       schema,
       isOverwriteOperation,
       rearrangeOnly,
-      tableChanges,
-      qbeastOptions)
+      newConfiguration,
+      hasRevisionUpdate)
 
-    if (txn.readVersion < 0) {
-      // Initialize the log path
-      val fs = deltaLog.logPath.getFileSystem(sparkSession.sessionState.newHadoopConf)
+    if (isNewTable) deltaLog.createLogDirectory()
 
-      fs.mkdirs(deltaLog.logPath)
-    }
-
-    val deletedFiles = saveMode match {
-      case SaveMode.Overwrite =>
-        txn.filterFiles().map(_.remove)
-      case _ => removeFiles
-    }
+    val deletedFiles = if (isOverwriteOperation && !isNewTable) {
+      txn.filterFiles().map(_.remove)
+    } else removeFiles
 
     val allFileActions = if (rearrangeOnly) {
       addFiles.map(_.copy(dataChange = !rearrangeOnly)) ++


### PR DESCRIPTION
## Description

- Abstract the Logic related to the configuration management from the Delta MetadataWriter Operator for Reusability #468 

## Type of change

Refactoring #398 


## Checklist:

Here is the list of things you should do before submitting this pull request:

- [X] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [X] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [X] Add comments to the code (make it easier for the community!).
- [X] Change the documentation.
- [X] Add tests.
- [X] Your branch is updated to the main branch (dependent changes have been merged).
