### PR TITLE
Issue #517: Restore QbeastUtil.computeHistogramForColumn method

### DIFF
--- a/src/main/scala/io/qbeast/utils/QbeastUtils.scala
+++ b/src/main/scala/io/qbeast/utils/QbeastUtils.scala
@@ -217,4 +217,30 @@ object QbeastUtils extends Logging {
 
   }
 
+  /**
+   * Compute the histogram for a given column
+   *
+   * Since computing the histogram can be expensive, this method is used outside the indexing
+   * process.
+   *
+   * It outputs the histogram of the column as format [bin1, bin2, bin3, ...] Number of bins by
+   * default is 50
+   *
+   * For example:
+   *
+   * val qbeastTable = QbeastTable.forPath(spark, "path")
+   *
+   * val histogram =qbeastTable.computeHistogramForColumn(df, "column")
+   *
+   * df.write.format("qbeast").option("columnsToIndex",
+   * "column:histogram").option("columnStats",histogram).save()
+   *
+   * @param df
+   * @param columnName
+   */
+  @deprecated("Use computeQuantilesForColumn method instead", "0.8.0")
+  def computeHistogramForColumn(df: DataFrame, columnName: String, numBins: Int = 50): String = {
+    computeQuantilesForStringColumn(df, columnName, numBins).mkString("[", ", ", "]")
+  }
+
 }


### PR DESCRIPTION
## Description

Fixes #517. Restore API and mark it as deprecated.

## Type of change

API change.

## Checklist:

Here is the list of things you should do before submitting this pull request:

- [x] New feature / bug fix has been committed following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [x] Add logging to the code following the [Contribution guide](https://github.com/Qbeast-io/qbeast-spark/blob/main/CONTRIBUTING.md).
- [ ] Add comments to the code (make it easier for the community!).
- [ ] Change the documentation.
- [ ] Add tests.
- [x] Your branch is updated to the main branch (dependent changes have been merged).

## How Has This Been Tested? (Optional)

We should restore the same tests as the original API.